### PR TITLE
feat: establish version-line release branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,10 @@ typecheck: ""
 
 ### Pull requests
 
-- **Direct commits to `main`** — no PR ceremony on this repo.
+- **Version-line integration** — long-lived branches (`main`, `v0.x-dev`,
+  `v0.x-release`, `v1.x-dev`, `v1.x-pre-release`) are PR-only. Tag releases
+  only on their designated release branch; merge the tagged branch into `main`
+  as published history. Do not use GitHub Actions or workflow files.
 - **"Ship it" means the full release ritual** end-to-end: build, test, commit, tag,
   push, GitHub release, deploy docs. Do not ask permission at each step.
 - **Phase 0 runs three steps before any version bump:** (1) `./scripts/maintain.sh release-check-state`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,8 +101,12 @@ Include `Cargo.lock` in version bump commits.
 ## Release
 
 See `context/notes/NOTE-20260411_0000-LoyalSpruce-aibox-release-process.md` for the full release process.
-Quick summary: `./scripts/maintain.sh release X.Y.Z` (in container) then
-`./scripts/maintain.sh release-host X.Y.Z` (on macOS host).
+Run a release only from its designated protected integration branch: stable
+v0 releases from `v0.x-release`, v1 prereleases from `v1.x-pre-release`, and
+v1 GA releases from `v1.x-release` once created. Quick summary:
+`./scripts/maintain.sh release X.Y.Z` (in container) then
+`./scripts/maintain.sh release-host X.Y.Z` (on macOS host). Merge the tagged
+release branch into `main` through a pull request afterward.
 
 Release validation and publication run locally. Do not introduce GitHub Actions
 or another hosted CI release path. The local release tooling runs independent

--- a/context/decisions/DEC-20260721_1910-FineSun-adopt-parallel-v0-maintenance-and-v1.md
+++ b/context/decisions/DEC-20260721_1910-FineSun-adopt-parallel-v0-maintenance-and-v1.md
@@ -1,0 +1,39 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: DecisionRecord
+metadata:
+  id: DEC-20260721_1910-FineSun-adopt-parallel-v0-maintenance-and-v1
+  created: '2026-07-21T19:10:09+00:00'
+spec:
+  title: Adopt parallel v0 maintenance and v1 prerelease release branches
+  state: accepted
+  decision: 'Adopt the version-line branching model from GitHub issue #83. Maintain
+    the active v0 release line in parallel with v1 development: use a v0.x development
+    branch and designated v0.x release branch for stable v0 releases and hotfixes;
+    use a v1.x development branch and v1.x prerelease integration branch for alpha/beta/RC
+    releases; create a v1.x stable release branch for GA. Merge tagged release branches
+    into main so main remains the complete published history, but tag only on the
+    appropriate release or prerelease integration branch.'
+  context: aibox will begin a new major evolutionary version soon while continuing
+    to support and release the established v0.x line. The existing main-only policy
+    cannot express independent development, prerelease, and stable-release authority
+    for those concurrent lines.
+  rationale: Separate version-line branches make release authority auditable, permit
+    v0 maintenance without mixing it with v1 work, and make prerelease promotion explicit.
+    This is now justified by actual parallel support needs rather than speculative
+    future branching.
+  alternatives:
+  - option: Continue main-only development and releases
+    reason_rejected: Would mix v0 maintenance with v1 prerelease work and make independent
+      release authority unclear.
+  - option: Freeze v0 while developing v1
+    reason_rejected: Conflicts with the requirement to continue supporting and releasing
+      v0 in parallel.
+  consequences: Release documentation, automation, and branch protection must be updated
+    before the first v1 prerelease. Existing v0 release behavior must be migrated
+    safely, and main remains a published-history integration branch rather than the
+    tagging authority.
+  related_workitems:
+  - BACK-20260721_1910-HardyClover-parallel-v0-v1-release-branches
+  decided_at: '2026-07-21T19:10:09+00:00'
+---

--- a/context/logs/2026/07/LOG-20260721_1904-FairArch-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260721_1904-FairArch-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260721_1904-FairArch-workitem-transitioned
+  created: '2026-07-21T19:04:10+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-21T19:04:10+00:00'
+  summary: Transitioned WorkItem 'BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags'
+    from 'review' to 'done'
+  subject: BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags
+  subject_kind: WorkItem
+  actor: BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags
+---

--- a/context/logs/2026/07/LOG-20260721_1904-KeenTrail-workitem-archive-moved.md
+++ b/context/logs/2026/07/LOG-20260721_1904-KeenTrail-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260721_1904-KeenTrail-workitem-archive-moved
+  created: '2026-07-21T19:04:10+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-07-21T19:04:10+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags'
+    to /workspace/context/workitems/done/2026/05/BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags.md
+  subject: BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags
+  subject_kind: WorkItem
+  actor: BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags
+  details:
+    path: /workspace/context/workitems/done/2026/05/BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags.md
+---

--- a/context/logs/2026/07/LOG-20260721_1904-ToughRiver-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260721_1904-ToughRiver-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260721_1904-ToughRiver-workitem-transitioned
+  created: '2026-07-21T19:04:10+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-21T19:04:10+00:00'
+  summary: Transitioned WorkItem 'BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags'
+    from 'in-progress' to 'review'
+  subject: BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags
+  subject_kind: WorkItem
+  actor: BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags
+---

--- a/context/logs/2026/07/LOG-20260721_1910-HonestQuartz-decision-created.md
+++ b/context/logs/2026/07/LOG-20260721_1910-HonestQuartz-decision-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260721_1910-HonestQuartz-decision-created
+  created: '2026-07-21T19:10:09+00:00'
+spec:
+  event_type: decision.created
+  timestamp: '2026-07-21T19:10:09+00:00'
+  summary: 'Created DecisionRecord ''DEC-20260721_1910-FineSun-adopt-parallel-v0-maintenance-and-v1'':
+    ''Adopt parallel v0 maintenance and v1 prerelease release branches'''
+  subject: DEC-20260721_1910-FineSun-adopt-parallel-v0-maintenance-and-v1
+  subject_kind: DecisionRecord
+  actor: DEC-20260721_1910-FineSun-adopt-parallel-v0-maintenance-and-v1
+---

--- a/context/logs/2026/07/LOG-20260721_1910-RoyalDawn-workitem-created.md
+++ b/context/logs/2026/07/LOG-20260721_1910-RoyalDawn-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260721_1910-RoyalDawn-workitem-created
+  created: '2026-07-21T19:10:09+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-07-21T19:10:09+00:00'
+  summary: 'Created WorkItem ''BACK-20260721_1910-HardyClover-parallel-v0-v1-release-branches'':
+    ''Implement parallel v0 maintenance and v1 prerelease branching strategy'''
+  subject: BACK-20260721_1910-HardyClover-parallel-v0-v1-release-branches
+  subject_kind: WorkItem
+  actor: BACK-20260721_1910-HardyClover-parallel-v0-v1-release-branches
+---

--- a/context/logs/2026/07/LOG-20260721_1912-QuickRaven-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260721_1912-QuickRaven-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260721_1912-QuickRaven-workitem-transitioned
+  created: '2026-07-21T19:12:39+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-21T19:12:39+00:00'
+  summary: Transitioned WorkItem 'BACK-20260721_1910-HardyClover-parallel-v0-v1-release-branches'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260721_1910-HardyClover-parallel-v0-v1-release-branches
+  subject_kind: WorkItem
+  actor: BACK-20260721_1910-HardyClover-parallel-v0-v1-release-branches
+---

--- a/context/workitems/2026/07/BACK-20260721_1910-HardyClover-parallel-v0-v1-release-branches.md
+++ b/context/workitems/2026/07/BACK-20260721_1910-HardyClover-parallel-v0-v1-release-branches.md
@@ -1,0 +1,31 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260721_1910-HardyClover-parallel-v0-v1-release-branches
+  created: '2026-07-21T19:10:09+00:00'
+  labels:
+    github_issue: 83
+    area: release-engineering
+    version-lines:
+    - v0
+    - v1
+  updated: '2026-07-21T19:12:39+00:00'
+spec:
+  title: Implement parallel v0 maintenance and v1 prerelease branching strategy
+  state: in-progress
+  type: epic
+  priority: high
+  description: 'Implement GitHub issue #83: establish protected version-line development
+    and release branches, make integration branches the tag authorities, adapt release
+    automation and documentation for v0 maintenance/hotfix releases and v1 prereleases,
+    and preserve main as the published-history integration branch. Sequence branch
+    creation/protection and release-script changes so existing v0.28.x releases remain
+    safe.'
+  scope: release-engineering
+  started_at: '2026-07-21T19:12:39+00:00'
+---
+
+## Transition note (2026-07-21T19:12:39+00:00)
+
+Branch topology implementation started. Creating v0.x and v1.x development/release authority branches from the agreed stable and main baselines.

--- a/context/workitems/done/2026/05/BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags.md
+++ b/context/workitems/done/2026/05/BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags.md
@@ -7,10 +7,10 @@ metadata:
   labels:
     decision: DEC-20260518_0631-ToughSwan-adopt-foundation-runtime-ghcr-image-tags
     defer_image_uploads: true
-  updated: '2026-05-18T06:38:32+00:00'
+  updated: '2026-07-21T19:04:10+00:00'
 spec:
   title: Implement GHCR foundation/runtime image tagging redesign
-  state: in-progress
+  state: done
   type: task
   priority: high
   description: Implement the approved next-minor aibox image publishing redesign.
@@ -21,8 +21,19 @@ spec:
     cleanup planning. Do not build or upload images while the owner is on slow/low-quota
     network.
   started_at: '2026-05-18T06:38:32+00:00'
+  completed_at: '2026-07-21T19:04:10+00:00'
 ---
 
 ## Transition note (2026-05-18T06:38:32+00:00)
 
 Implementation started after owner approval. Image builds/uploads are explicitly deferred due to low-quota network.
+
+
+## Transition note (2026-07-21T19:04:10+00:00)
+
+Implementation is complete and ready for closure review: foundation/runtime targets and tags, OCI source labels, label-based reuse, manifest verification, and guarded source-tag cleanup tooling shipped in v0.27.0.
+
+
+## Transition note (2026-07-21T19:04:10+00:00)
+
+Closure confirmed. The separate ToughSwan decision remains accepted and unchanged; no new ToughSwan implementation work was created.

--- a/docs-site/docs/contributing/maintenance.md
+++ b/docs-site/docs/contributing/maintenance.md
@@ -85,6 +85,26 @@ Release speed comes from bounded local concurrency, persistent caches, and
 reuse of evidence for the exact release commit rather than from moving gates to
 a hosted runner.
 
+## Version-line branches
+
+Long-lived branches are protected: direct pushes, force-pushes, and deletion
+are disabled; changes arrive through pull requests with resolved conversations.
+No GitHub Actions or required hosted checks are used.
+
+| Line | Development | Release authority | Purpose |
+| --- | --- | --- | --- |
+| v0 maintenance | `v0.x-dev` | `v0.x-release` | Stable v0 releases and hotfixes |
+| v1 prerelease | `v1.x-dev` | `v1.x-pre-release` | Alpha, beta, and release-candidate tags |
+| v1 GA | `v1.x-dev` | `v1.x-release` (created at GA) | Stable v1 releases |
+
+`main` is the published-history branch. After a tag is cut on its designated
+release branch, merge that branch into `main` through a pull request. Apply or
+verify the policy from an administrator checkout with:
+
+```bash
+./scripts/configure-branch-protection.sh
+```
+
 Do not create GitHub releases by hand with `gh release create`. The release
 script attaches binaries and writes the release notes expected by users.
 

--- a/scripts/configure-branch-protection.sh
+++ b/scripts/configure-branch-protection.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Configure long-lived aibox branches without GitHub Actions.
+set -euo pipefail
+
+repo="${AIBOX_GITHUB_REPO:-projectious-work/aibox}"
+branches=(main v0.x-dev v0.x-release v1.x-dev v1.x-pre-release)
+
+command -v gh >/dev/null 2>&1 || { echo "gh CLI is required" >&2; exit 1; }
+
+# PR-only with resolved conversations, but no hosted status checks or mandatory
+# second reviewer: releases are maintainer-run locally.
+payload='{"required_status_checks":null,"enforce_admins":true,"required_pull_request_reviews":{"dismissal_restrictions":{"users":[],"teams":[],"apps":[]},"dismiss_stale_reviews":true,"require_code_owner_reviews":false,"required_approving_review_count":0,"require_last_push_approval":false},"restrictions":null,"required_linear_history":false,"allow_force_pushes":false,"allow_deletions":false,"block_creations":false,"required_conversation_resolution":true,"lock_branch":false,"allow_fork_syncing":false}'
+
+for branch in "${branches[@]}"; do
+  printf 'Protecting %s\n' "${branch}"
+  gh api --method PUT "repos/${repo}/branches/${branch}/protection" --input - \
+    <<<"${payload}" >/dev/null
+done
+
+echo "Protected ${#branches[@]} branches; no GitHub Actions or status checks configured."

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -39,6 +39,30 @@ DIST_DIR="${PROJECT_ROOT}/dist"
 IMAGE_REGISTRY="ghcr.io/projectious-work/aibox"
 GITHUB_REPO="${AIBOX_GITHUB_REPO:-projectious-work/aibox}"
 
+# Releases are tagged only from their protected integration branches. This is a
+# local maintainer workflow; no GitHub Actions participate in it.
+release_branch_for_version() {
+  local version="$1"
+  case "${version}" in
+    0.*) printf '%s\n' 'v0.x-release' ;;
+    1.*-*) printf '%s\n' 'v1.x-pre-release' ;;
+    1.*) printf '%s\n' 'v1.x-release' ;;
+    *) die "Unsupported release line for ${version}; add a branch mapping first." ;;
+  esac
+}
+
+ensure_release_branch() {
+  local version="$1" expected actual remote
+  expected="$(release_branch_for_version "${version}")"
+  actual="$(git branch --show-current)"
+  [[ "${actual}" == "${expected}" ]] \
+    || die "Release ${version} must run on ${expected}, not ${actual}."
+  git fetch origin "${expected}" >/dev/null
+  remote="$(git rev-parse "origin/${expected}")"
+  [[ "$(git rev-parse HEAD)" == "${remote}" ]] \
+    || die "${expected} is behind origin; update it before tagging."
+}
+
 # ── Read container name from docker-compose.yml ─────────────────────────────
 _init_names() {
   local svc cn
@@ -704,8 +728,8 @@ cmd_push_images() {
   local version="${1:-}"
   [[ -z "${version}" ]] && die "Usage: ./scripts/maintain.sh push-images <version>  (e.g. 0.2.0)"
 
-  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${version})"
+  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})"
   fi
 
   ensure_ghcr_login
@@ -1582,11 +1606,11 @@ release_usage() {
 release_list_steps() {
   cat <<'STEPS'
 Release step aliases:
-  all       state,doctors,sync,version,test,e2e,visual,audit,build-linux,version-smoke,push-main,notes,tag,github-release,docs,prompt
+  all       state,doctors,sync,version,test,e2e,visual,audit,build-linux,version-smoke,notes,tag,github-release,docs,prompt
   phase0    state,doctors
   checks    sync,version,test,e2e,visual,audit
   build     build-linux,version-smoke
-  publish   push-main,notes,tag,github-release
+  publish   notes,tag,github-release
 
 Concrete release steps:
   state           Generate dist/RELEASE-STATE.md with dependency and harness network lookups
@@ -1599,7 +1623,6 @@ Concrete release steps:
   audit           Run cargo audit
   build-linux     Build Linux release archives and checksums
   version-smoke   Verify the native release binary reports the requested version
-  push-main       Push main to origin
   notes           Prepare or reuse dist/RELEASE-NOTES.md
   tag             Create and push the annotated release tag
   github-release  Create the GitHub release with Linux archives
@@ -1650,12 +1673,11 @@ release_expand_step_token() {
       release_add_step version-smoke
       ;;
     publish)
-      release_add_step push-main
       release_add_step notes
       release_add_step tag
       release_add_step github-release
       ;;
-    state|doctors|sync|version|test|e2e|visual|audit|build-linux|version-smoke|push-main|notes|tag|github-release|docs|prompt)
+    state|doctors|sync|version|test|e2e|visual|audit|build-linux|version-smoke|notes|tag|github-release|docs|prompt)
       release_add_step "${token}"
       ;;
     "")
@@ -1723,7 +1745,7 @@ release_requires_clean_tree() {
   local step
   for step in "${release_steps[@]}"; do
     case "${step}" in
-      sync|version|push-main|tag|github-release|docs)
+      sync|version|tag|github-release|docs)
         return 0
         ;;
     esac
@@ -2188,8 +2210,8 @@ cmd_release() {
   done
 
   # Validate semver (simple check)
-  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${version})"
+  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})"
   fi
 
   local tag="v${version}"
@@ -2199,6 +2221,7 @@ cmd_release() {
   release_parse_steps "${steps_spec}"
   release_apply_skip_steps "${skip_spec}"
   release_validate_license_guardrails
+  ensure_release_branch "${version}"
 
   info "Preparing release ${tag} with steps: $(release_steps_joined)"
 
@@ -2248,20 +2271,7 @@ cmd_release() {
     local current_cargo_version
     current_cargo_version=$(grep -m1 '^version = ' "${CLI_DIR}/Cargo.toml" | sed -E 's/version = "(.+)"/\1/')
     if [[ "${current_cargo_version}" != "${version}" ]]; then
-      info "Bumping cli/Cargo.toml ${current_cargo_version} → ${version}..."
-      # macOS/BSD sed and GNU sed differ on -i; write atomically via a tmp file.
-      local tmp_cargo
-      tmp_cargo=$(mktemp)
-      sed -E "s/^version = \"${current_cargo_version}\"$/version = \"${version}\"/" \
-        "${CLI_DIR}/Cargo.toml" > "${tmp_cargo}"
-      mv "${tmp_cargo}" "${CLI_DIR}/Cargo.toml"
-      # Refresh Cargo.lock so the new version is locked.
-      (cd "${CLI_DIR}" && cargo metadata --format-version 1 --quiet >/dev/null) \
-        || die "cargo metadata failed after version bump — review Cargo.toml"
-      git add "${CLI_DIR}/Cargo.toml" "${CLI_DIR}/Cargo.lock"
-      git commit -m "chore: bump CLI version to ${version}" \
-        || die "failed to commit Cargo.toml/Cargo.lock bump"
-      ok "Cargo.toml bumped and committed"
+      die "Cargo.toml is ${current_cargo_version}, not ${version}. Bump the version on the matching development branch and merge it into $(release_branch_for_version "${version}") through a pull request before running release."
     else
       ok "Cargo.toml already at ${version}"
     fi
@@ -2316,12 +2326,6 @@ cmd_release() {
     info "Verifying 'aibox --version' matches ${version}..."
     release_run_evidenced_step "version-smoke" "${version}" "CLI version smoke" \
       release_version_smoke_gate "${version}"
-  fi
-
-  if release_step_requested push-main; then
-    info "Pushing main to origin (version-bump commit)..."
-    git push origin main
-    ok "main pushed to origin"
   fi
 
   if release_step_requested notes; then
@@ -2391,13 +2395,13 @@ cmd_release() {
       echo "Run the following on the macOS host to sync the checkout and complete the release:"
       echo ""
       echo "\`\`\`bash"
-      echo "git fetch origin main"
-      echo "git reset --keep origin/main"
+      echo "git fetch origin $(release_branch_for_version "${version}")"
+      echo "git reset --keep origin/$(release_branch_for_version "${version}")"
       echo "./scripts/maintain.sh release-host ${version}"
       echo "\`\`\`"
       echo ""
       echo "This will:"
-      echo "- Verify the host checkout is at the just-pushed origin/main"
+      echo "- Verify the host checkout is at the just-pushed release branch"
       echo "- Build macOS binaries (aarch64-apple-darwin, x86_64-apple-darwin)"
       echo "- Upload them to the existing GitHub release ${tag}"
       echo "- Build and push container images to GHCR"
@@ -2433,13 +2437,14 @@ cmd_release_finalize_runtime() {
   local version="${1:-}"
   [[ -z "${version}" ]] && die "Usage: ./scripts/maintain.sh release-finalize-runtime <version>  (e.g. 0.10.2)"
 
-  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${version})"
+  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})"
   fi
 
   info "Refreshing repo-owned generated runtime surfaces..."
   (
     cd "${PROJECT_ROOT}"
+    ensure_release_branch "${version}"
     if ! git diff --cached --quiet; then
       die "Staged changes are already present; commit or unstage them before release runtime finalization."
     fi
@@ -2451,9 +2456,12 @@ cmd_release_finalize_runtime() {
     if git diff --cached --quiet -- .devcontainer aibox.lock context/migrations context/templates/aibox-home; then
       ok "Generated runtime surfaces already match v${version}; no commit needed."
     else
+      local topic_branch
+      topic_branch="release/v${version}-runtime-refresh"
+      git switch -c "${topic_branch}"
       git commit -m "chore: refresh generated runtime for v${version}"
-      git push origin main
-      ok "Generated runtime surfaces committed and pushed for v${version}."
+      git push -u origin "${topic_branch}"
+      warn "Generated runtime refresh is on ${topic_branch}; open and merge a PR into $(release_branch_for_version "${version}") before continuing."
     fi
   )
 }
@@ -2461,20 +2469,22 @@ cmd_release_finalize_runtime() {
 # ── Host-side release (run on macOS after container-side `release`) ──────────
 
 ensure_release_host_checkout_current() {
-  info "Verifying host checkout is current with origin/main..."
+  local version="$1" release_branch
+  release_branch="$(release_branch_for_version "${version}")"
+  info "Verifying host checkout is current with origin/${release_branch}..."
   (
     cd "${PROJECT_ROOT}"
-    git fetch origin main >/dev/null
+    git fetch origin "${release_branch}" >/dev/null
 
     local head remote_head
     head=$(git rev-parse HEAD)
-    remote_head=$(git rev-parse origin/main)
+    remote_head=$(git rev-parse "origin/${release_branch}")
 
     if [[ "${head}" != "${remote_head}" ]]; then
-      die "release-host must run from the current origin/main after container-side release. Run: git fetch origin main && git reset --keep origin/main"
+      die "release-host must run from origin/${release_branch}. Run: git fetch origin ${release_branch} && git reset --keep origin/${release_branch}"
     fi
   )
-  ok "Host checkout matches origin/main"
+  ok "Host checkout matches origin/${release_branch}"
 }
 
 cmd_release_host() {
@@ -2482,12 +2492,12 @@ cmd_release_host() {
   local release_started_epoch="$(date +%s)"
   [[ -z "${version}" ]] && die "Usage: ./scripts/maintain.sh release-host <version>  (e.g. 0.10.2)"
 
-  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${version})"
+  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})"
   fi
 
   local tag="v${version}"
-  ensure_release_host_checkout_current
+  ensure_release_host_checkout_current "${version}"
   release_evidence_init "${version}" host
   info "Host release source: ${RELEASE_CANDIDATE_SHA}"
 


### PR DESCRIPTION
Implements #83 for parallel v0 maintenance and v1 prereleases.\n\n- protects main, v0.x-dev, v0.x-release, v1.x-dev, and v1.x-pre-release without GitHub Actions or required hosted checks\n- adds reproducible local branch-protection configuration\n- routes local release tagging to v0.x-release, v1.x-pre-release, or v1.x-release\n- documents PR-only integration and local-only release operations\n\nValidation: bash -n scripts/maintain.sh; bash -n scripts/configure-branch-protection.sh; git diff --check.