### PR TITLE
fix: protect v1 stable branch at creation

### DIFF
--- a/scripts/configure-branch-protection.sh
+++ b/scripts/configure-branch-protection.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 repo="${AIBOX_GITHUB_REPO:-projectious-work/aibox}"
-branches=(main v0.x-dev v0.x-release v1.x-dev v1.x-pre-release)
+branches=(main v0.x-dev v0.x-release v1.x-dev v1.x-pre-release v1.x-release)
 
 command -v gh >/dev/null 2>&1 || { echo "gh CLI is required" >&2; exit 1; }
 
@@ -12,9 +12,13 @@ command -v gh >/dev/null 2>&1 || { echo "gh CLI is required" >&2; exit 1; }
 payload='{"required_status_checks":null,"enforce_admins":true,"required_pull_request_reviews":{"dismissal_restrictions":{"users":[],"teams":[],"apps":[]},"dismiss_stale_reviews":true,"require_code_owner_reviews":false,"required_approving_review_count":0,"require_last_push_approval":false},"restrictions":null,"required_linear_history":false,"allow_force_pushes":false,"allow_deletions":false,"block_creations":false,"required_conversation_resolution":true,"lock_branch":false,"allow_fork_syncing":false}'
 
 for branch in "${branches[@]}"; do
+  if ! gh api "repos/${repo}/branches/${branch}" >/dev/null 2>&1; then
+    printf 'Skipping absent future branch %s\n' "${branch}"
+    continue
+  fi
   printf 'Protecting %s\n' "${branch}"
   gh api --method PUT "repos/${repo}/branches/${branch}/protection" --input - \
     <<<"${payload}" >/dev/null
 done
 
-echo "Protected ${#branches[@]} branches; no GitHub Actions or status checks configured."
+echo "Protected all existing long-lived branches; no GitHub Actions or status checks configured."


### PR DESCRIPTION
Makes the local protection command recognize  once that GA branch exists, without failing before then. No GitHub Actions or workflows added.