### PR TITLE
chore: promote v0.x-dev into v0.x-release

### DIFF
--- a/cli/src/processkit_vocab.rs
+++ b/cli/src/processkit_vocab.rs
@@ -161,7 +161,7 @@ pub const TIER_SPECIFIC_MCP_SKILLS: &[&str] = &[
 /// constant serves as the canonical reference for tests and documentation.
 // Used in #[cfg(test)] blocks across multiple modules and in documentation.
 #[allow(dead_code)]
-pub const PROCESSKIT_DEFAULT_VERSION: &str = "v0.27.6";
+pub const PROCESSKIT_DEFAULT_VERSION: &str = "v0.28.1";
 
 // ---------------------------------------------------------------------------
 // v0.26.0 — RoleSlot MCP tools (team-manager skill)


### PR DESCRIPTION
Promote the processkit v0.28.1 integration into the v0.x release line before the patch release.

Refs: #88