### PR TITLE
chore: sync v0.x-dev with 0.28.4 release

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.28.3"
+version = "0.28.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.28.3"
+version = "0.28.4"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -558,6 +558,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.27.6",
         note: "Patch release: integrates processkit v0.27.6; makes GitHub CLI authoritative for github.com HTTPS credentials when enabled by resetting earlier credential helpers; exposes exact GitHub SSH aliases through the Forge tmux status configuration; and preserves the active page and zoom across LaTeX live-preview rebuilds.",
     },
+    CompatEntry {
+        aibox_version: "0.28.4",
+        processkit_version: "v0.28.1",
+        note: "Patch release: integrates processkit v0.28.1 and refreshes the maintained v0.x processkit compatibility baseline.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.


### PR DESCRIPTION
Merge the published v0.28.4 release back into the maintained v0.x development line so version, compatibility, and processkit baselines remain aligned.

Release: https://github.com/projectious-work/aibox/releases/tag/v0.28.4