### PR TITLE
fix: fetch only the requested host release tag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,7 +245,7 @@ typecheck: ""
 - **Phase 2 is always the user's job** — macOS host builds and GHCR image pushes
   run via `./scripts/maintain.sh release-host X.Y.Z` on the host, never from the container.
   Before Phase 2, sync the host checkout to the matching version-line release branch
-  (for example, `git fetch origin v0.x-release --tags && git switch v0.x-release && git reset --keep origin/v0.x-release`).
+  (for example, `git fetch origin v0.x-release && git switch v0.x-release && git reset --keep origin/v0.x-release`).
 - **Detailed release procedures:** See [`context/notes/NOTE-20260411_0000-LoyalSpruce-aibox-release-process.md`](./context/notes/NOTE-20260411_0000-LoyalSpruce-aibox-release-process.md) for step-by-step Phase 1 and Phase 2 instructions, including exact commands and prerequisites.
 - **One big change preferred over many small PRs** for breaking releases. The user
   explicitly said: "make one big change, I'll handle derived project dependencies."

--- a/docs-site/docs/contributing/maintenance.md
+++ b/docs-site/docs/contributing/maintenance.md
@@ -149,7 +149,7 @@ matching version-line release branch first; the container-side release may have
 pushed version-bump and tag-prep commits from another clone. For a v0 release:
 
 ```bash
-git fetch origin v0.x-release --tags
+git fetch origin v0.x-release
 git switch v0.x-release
 git reset --keep origin/v0.x-release
 ./scripts/maintain.sh release-host X.Y.Z

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -2393,7 +2393,7 @@ cmd_release() {
       echo "Run the following on the macOS host to sync the checkout and complete the release:"
       echo ""
       echo "\`\`\`bash"
-      echo "git fetch origin ${release_branch} --tags"
+      echo "git fetch origin ${release_branch}"
       echo "git switch ${release_branch}"
       echo "git reset --keep origin/${release_branch}"
       echo "./scripts/maintain.sh release-host ${version}"
@@ -2493,13 +2493,16 @@ cmd_release_finalize_runtime() {
 # ── Host-side release (run on macOS after container-side `release`) ──────────
 
 ensure_release_host_checkout_current() {
-  local version="$1" tag="v${version}" release_branch
+  local version="$1" tag release_branch
+  tag="v${version}"
   release_branch="$(release_branch_for_version "${version}")"
 
   info "Verifying host checkout is current with origin/${release_branch} and ${tag}..."
   (
     cd "${PROJECT_ROOT}"
-    git fetch origin "${release_branch}" --tags >/dev/null
+    git fetch origin \
+      "refs/heads/${release_branch}:refs/remotes/origin/${release_branch}" \
+      "refs/tags/${tag}:refs/tags/${tag}" >/dev/null
 
     local head remote_head tag_commit
     head=$(git rev-parse HEAD)
@@ -2512,7 +2515,7 @@ ensure_release_host_checkout_current() {
     fi
 
     if [[ "${head}" != "${remote_head}" ]]; then
-      die "release-host must run from current origin/${release_branch} containing ${tag}. Run: git fetch origin ${release_branch} --tags && git switch ${release_branch} && git reset --keep origin/${release_branch}"
+      die "release-host must run from current origin/${release_branch} containing ${tag}. Run: git fetch origin ${release_branch} && git switch ${release_branch} && git reset --keep origin/${release_branch}"
     fi
   )
   ok "Host checkout matches the ${release_branch} release line and contains ${tag}"


### PR DESCRIPTION
Avoid `git fetch --tags` during host release verification: historical local tag drift must not block a valid release-line checkout. Fetch only the requested release tag and branch.

Validated against the real `v0.28.4` tag and `origin/v0.x-release`.