### PR TITLE
fix: sync version-line host release workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,7 +245,7 @@ typecheck: ""
 - **Phase 2 is always the user's job** — macOS host builds and GHCR image pushes
   run via `./scripts/maintain.sh release-host X.Y.Z` on the host, never from the container.
   Before Phase 2, sync the host checkout to the matching version-line release branch
-  (for example, `git fetch origin v0.x-release --tags && git switch v0.x-release && git reset --keep origin/v0.x-release`).
+  (for example, `git fetch origin v0.x-release && git switch v0.x-release && git reset --keep origin/v0.x-release`).
 - **Detailed release procedures:** See [`context/notes/NOTE-20260411_0000-LoyalSpruce-aibox-release-process.md`](./context/notes/NOTE-20260411_0000-LoyalSpruce-aibox-release-process.md) for step-by-step Phase 1 and Phase 2 instructions, including exact commands and prerequisites.
 - **One big change preferred over many small PRs** for breaking releases. The user
   explicitly said: "make one big change, I'll handle derived project dependencies."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,8 +244,8 @@ typecheck: ""
   three automatically.
 - **Phase 2 is always the user's job** — macOS host builds and GHCR image pushes
   run via `./scripts/maintain.sh release-host X.Y.Z` on the host, never from the container.
-  Before Phase 2, sync the host checkout to the just-pushed container-side release
-  commits with `git fetch origin main && git reset --keep origin/main`.
+  Before Phase 2, sync the host checkout to the matching version-line release branch
+  (for example, `git fetch origin v0.x-release --tags && git switch v0.x-release && git reset --keep origin/v0.x-release`).
 - **Detailed release procedures:** See [`context/notes/NOTE-20260411_0000-LoyalSpruce-aibox-release-process.md`](./context/notes/NOTE-20260411_0000-LoyalSpruce-aibox-release-process.md) for step-by-step Phase 1 and Phase 2 instructions, including exact commands and prerequisites.
 - **One big change preferred over many small PRs** for breaking releases. The user
   explicitly said: "make one big change, I'll handle derived project dependencies."

--- a/docs-site/docs/contributing/maintenance.md
+++ b/docs-site/docs/contributing/maintenance.md
@@ -145,14 +145,19 @@ crate-update pass.
 ## Host-Side Release
 
 Run this on the macOS host after the container-side release succeeds. Sync the
-host checkout first; the container-side release may have pushed version-bump
-and tag-prep commits from another clone:
+matching version-line release branch first; the container-side release may have
+pushed version-bump and tag-prep commits from another clone. For a v0 release:
 
 ```bash
-git fetch origin main
-git reset --keep origin/main
+git fetch origin v0.x-release --tags
+git switch v0.x-release
+git reset --keep origin/v0.x-release
 ./scripts/maintain.sh release-host X.Y.Z
 ```
+
+`release-host` derives the expected branch from the major version (`v0.x-release`
+for `0.*`, `v1.x-release` for `1.*`) and verifies that the requested release tag
+is reachable from that branch. It does not build host artifacts from `main`.
 
 This phase builds Darwin binaries, uploads them to the existing GitHub release,
 pushes GHCR images, then runs a fresh downstream-style runtime smoke against
@@ -172,6 +177,11 @@ lanes before uploading binaries and starting the runtime smoke. Healthy tmux
 smoke probes advance on observed session, window, pane, and status readiness;
 their timeouts are failure ceilings rather than fixed delays. Host timings are
 written to `dist/RELEASE-HOST-TIMINGS.md`.
+
+If publishing the image changes repo-owned generated runtime surfaces, the host
+script creates and merges a short-lived PR back into the release branch rather
+than pushing directly to a protected long-lived branch. Promote that finalized
+release branch to `main` and the corresponding development branch afterwards.
 
 The Linux-side Tier 2 E2E companion is separate from this host phase. From the
 devcontainer, verify that companion over SSH/SCP; do not use local

--- a/docs-site/docs/contributing/maintenance.md
+++ b/docs-site/docs/contributing/maintenance.md
@@ -149,7 +149,7 @@ matching version-line release branch first; the container-side release may have
 pushed version-bump and tag-prep commits from another clone. For a v0 release:
 
 ```bash
-git fetch origin v0.x-release --tags
+git fetch origin v0.x-release
 git switch v0.x-release
 git reset --keep origin/v0.x-release
 ./scripts/maintain.sh release-host X.Y.Z

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -2193,6 +2193,8 @@ cmd_release() {
   fi
 
   local tag="v${version}"
+  local release_branch
+  release_branch="$(release_branch_for_version "${version}")"
   local release_steps=()
   local release_step_tokens=()
   local built_archives=()
@@ -2391,13 +2393,14 @@ cmd_release() {
       echo "Run the following on the macOS host to sync the checkout and complete the release:"
       echo ""
       echo "\`\`\`bash"
-      echo "git fetch origin main"
-      echo "git reset --keep origin/main"
+      echo "git fetch origin ${release_branch} --tags"
+      echo "git switch ${release_branch}"
+      echo "git reset --keep origin/${release_branch}"
       echo "./scripts/maintain.sh release-host ${version}"
       echo "\`\`\`"
       echo ""
       echo "This will:"
-      echo "- Verify the host checkout is at the just-pushed origin/main"
+      echo "- Verify the host checkout is current with the version-line release branch and contains ${tag}"
       echo "- Build macOS binaries (aarch64-apple-darwin, x86_64-apple-darwin)"
       echo "- Upload them to the existing GitHub release ${tag}"
       echo "- Build and push container images to GHCR"
@@ -2429,6 +2432,14 @@ cmd_release() {
   fi
 }
 
+release_branch_for_version() {
+  local version="$1" major
+  major="${version%%.*}"
+  [[ "${major}" =~ ^[0-9]+$ ]] \
+    || die "Cannot infer a release branch from version '${version}'."
+  printf 'v%s.x-release' "${major}"
+}
+
 cmd_release_finalize_runtime() {
   local version="${1:-}"
   [[ -z "${version}" ]] && die "Usage: ./scripts/maintain.sh release-finalize-runtime <version>  (e.g. 0.10.2)"
@@ -2436,6 +2447,10 @@ cmd_release_finalize_runtime() {
   if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     die "Version must be semver: X.Y.Z (got: ${version})"
   fi
+
+  local release_branch finalization_branch pr_url
+  release_branch="$(release_branch_for_version "${version}")"
+  finalization_branch="chore/refresh-generated-runtime-v${version}"
 
   info "Refreshing repo-owned generated runtime surfaces..."
   (
@@ -2451,9 +2466,26 @@ cmd_release_finalize_runtime() {
     if git diff --cached --quiet -- .devcontainer aibox.lock context/migrations context/templates/aibox-home; then
       ok "Generated runtime surfaces already match v${version}; no commit needed."
     else
+      [[ "$(git branch --show-current)" == "${release_branch}" ]] \
+        || die "Generated runtime finalization for v${version} must start on ${release_branch}."
+      if git ls-remote --exit-code --heads origin "${finalization_branch}" >/dev/null 2>&1; then
+        die "Remote branch ${finalization_branch} already exists; inspect or merge it before rerunning release finalization."
+      fi
+
+      git switch -c "${finalization_branch}"
       git commit -m "chore: refresh generated runtime for v${version}"
-      git push origin main
-      ok "Generated runtime surfaces committed and pushed for v${version}."
+      git push -u origin "${finalization_branch}"
+      pr_url="$(gh pr create \
+        --base "${release_branch}" \
+        --head "${finalization_branch}" \
+        --title "chore: refresh generated runtime for v${version}" \
+        --body "Post-image generated runtime refresh for v${version}.")" \
+        || die "Could not create generated-runtime finalization PR."
+      gh pr merge "${pr_url}" --merge --delete-branch \
+        || die "Could not merge generated-runtime finalization PR ${pr_url}."
+      git switch "${release_branch}"
+      git pull --ff-only origin "${release_branch}"
+      ok "Generated runtime surfaces merged into ${release_branch} for v${version}."
     fi
   )
 }
@@ -2461,20 +2493,29 @@ cmd_release_finalize_runtime() {
 # ── Host-side release (run on macOS after container-side `release`) ──────────
 
 ensure_release_host_checkout_current() {
-  info "Verifying host checkout is current with origin/main..."
+  local version="$1" tag="v${version}" release_branch
+  release_branch="$(release_branch_for_version "${version}")"
+
+  info "Verifying host checkout is current with origin/${release_branch} and ${tag}..."
   (
     cd "${PROJECT_ROOT}"
-    git fetch origin main >/dev/null
+    git fetch origin "${release_branch}" --tags >/dev/null
 
-    local head remote_head
+    local head remote_head tag_commit
     head=$(git rev-parse HEAD)
-    remote_head=$(git rev-parse origin/main)
+    remote_head=$(git rev-parse "origin/${release_branch}")
+    tag_commit=$(git rev-parse "${tag}^{commit}" 2>/dev/null) \
+      || die "Release tag ${tag} is missing locally. Fetch it from origin before running release-host."
+
+    if ! git merge-base --is-ancestor "${tag_commit}" "${remote_head}"; then
+      die "Release tag ${tag} is not reachable from origin/${release_branch}; refusing to build host artifacts from the wrong version line."
+    fi
 
     if [[ "${head}" != "${remote_head}" ]]; then
-      die "release-host must run from the current origin/main after container-side release. Run: git fetch origin main && git reset --keep origin/main"
+      die "release-host must run from current origin/${release_branch} containing ${tag}. Run: git fetch origin ${release_branch} --tags && git switch ${release_branch} && git reset --keep origin/${release_branch}"
     fi
   )
-  ok "Host checkout matches origin/main"
+  ok "Host checkout matches the ${release_branch} release line and contains ${tag}"
 }
 
 cmd_release_host() {
@@ -2487,7 +2528,7 @@ cmd_release_host() {
   fi
 
   local tag="v${version}"
-  ensure_release_host_checkout_current
+  ensure_release_host_checkout_current "${version}"
   release_evidence_init "${version}" host
   info "Host release source: ${RELEASE_CANDIDATE_SHA}"
 

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -2393,7 +2393,7 @@ cmd_release() {
       echo "Run the following on the macOS host to sync the checkout and complete the release:"
       echo ""
       echo "\`\`\`bash"
-      echo "git fetch origin ${release_branch} --tags"
+      echo "git fetch origin ${release_branch}"
       echo "git switch ${release_branch}"
       echo "git reset --keep origin/${release_branch}"
       echo "./scripts/maintain.sh release-host ${version}"
@@ -2493,13 +2493,16 @@ cmd_release_finalize_runtime() {
 # ── Host-side release (run on macOS after container-side `release`) ──────────
 
 ensure_release_host_checkout_current() {
-  local version="$1" tag="v${version}" release_branch
+  local version="$1" tag release_branch
+  tag="v${version}"
   release_branch="$(release_branch_for_version "${version}")"
 
   info "Verifying host checkout is current with origin/${release_branch} and ${tag}..."
   (
     cd "${PROJECT_ROOT}"
-    git fetch origin "${release_branch}" --tags >/dev/null
+    git fetch origin \
+      "refs/heads/${release_branch}:refs/remotes/origin/${release_branch}" \
+      "refs/tags/${tag}:refs/tags/${tag}" >/dev/null
 
     local head remote_head tag_commit
     head=$(git rev-parse HEAD)
@@ -2512,7 +2515,7 @@ ensure_release_host_checkout_current() {
     fi
 
     if [[ "${head}" != "${remote_head}" ]]; then
-      die "release-host must run from current origin/${release_branch} containing ${tag}. Run: git fetch origin ${release_branch} --tags && git switch ${release_branch} && git reset --keep origin/${release_branch}"
+      die "release-host must run from current origin/${release_branch} containing ${tag}. Run: git fetch origin ${release_branch} && git switch ${release_branch} && git reset --keep origin/${release_branch}"
     fi
   )
   ok "Host checkout matches the ${release_branch} release line and contains ${tag}"

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -6,6 +6,11 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 AIBOX_MAINTAIN_SOURCE_ONLY=1 source "${SCRIPT_DIR}/maintain.sh"
 
+[[ "$(release_branch_for_version 0.28.4)" == "v0.x-release" ]] \
+  || die "v0 release versions must resolve to v0.x-release"
+[[ "$(release_branch_for_version 1.0.0)" == "v1.x-release" ]] \
+  || die "v1 release versions must resolve to v1.x-release"
+
 test_root="$(mktemp -d)"
 trap 'rm -rf "${test_root}"' EXIT
 


### PR DESCRIPTION
Promote the version-line-aware host release workflow to published history.

This does not alter the v0.28.4 tag; it fixes the host-side tooling needed to complete that release and future v0 releases.