### PR TITLE
fix(release): promote candidates through protected line

### DIFF
--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -1599,7 +1599,7 @@ Concrete release steps:
   audit           Run cargo audit
   build-linux     Build Linux release archives and checksums
   version-smoke   Verify the native release binary reports the requested version
-  push-main       Push main to origin
+  push-main       Promote the candidate to its protected release branch
   notes           Prepare or reuse dist/RELEASE-NOTES.md
   tag             Create and push the annotated release tag
   github-release  Create the GitHub release with Linux archives
@@ -2322,9 +2322,7 @@ cmd_release() {
   fi
 
   if release_step_requested push-main; then
-    info "Pushing main to origin (version-bump commit)..."
-    git push origin main
-    ok "main pushed to origin"
+    publish_release_candidate "${version}" "${release_branch}"
   fi
 
   if release_step_requested notes; then
@@ -2439,6 +2437,42 @@ release_branch_for_version() {
   [[ "${major}" =~ ^[0-9]+$ ]] \
     || die "Cannot infer a release branch from version '${version}'."
   printf 'v%s.x-release' "${major}"
+}
+
+publish_release_candidate() {
+  local version="$1" release_branch="$2"
+  local candidate_branch="chore/release-v${version}" pr_url
+
+  [[ "$(git branch --show-current)" == "${release_branch}" ]] \
+    || die "Release ${version} must be published from ${release_branch}."
+
+  git fetch origin "${release_branch}"
+  git merge-base --is-ancestor "origin/${release_branch}" HEAD \
+    || die "Local ${release_branch} does not descend from origin/${release_branch}; reconcile it before publishing."
+
+  if [[ "$(git rev-parse HEAD)" == "$(git rev-parse "origin/${release_branch}")" ]]; then
+    ok "${release_branch} is already current on origin"
+    return
+  fi
+
+  if git ls-remote --exit-code --heads origin "${candidate_branch}" >/dev/null 2>&1; then
+    die "Remote branch ${candidate_branch} already exists; inspect or merge it before publishing."
+  fi
+
+  info "Promoting the release candidate to protected branch ${release_branch}..."
+  git switch -c "${candidate_branch}"
+  git push -u origin "${candidate_branch}"
+  pr_url="$(gh pr create \
+    --base "${release_branch}" \
+    --head "${candidate_branch}" \
+    --title "chore: release v${version}" \
+    --body "Promotes the validated v${version} release candidate to ${release_branch}.")" \
+    || die "Could not create release-candidate PR."
+  gh pr merge "${pr_url}" --merge --delete-branch \
+    || die "Could not merge release-candidate PR ${pr_url}."
+  git switch "${release_branch}"
+  git pull --ff-only origin "${release_branch}"
+  ok "Release candidate merged into ${release_branch}"
 }
 
 cmd_release_finalize_runtime() {

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -10,6 +10,8 @@ AIBOX_MAINTAIN_SOURCE_ONLY=1 source "${SCRIPT_DIR}/maintain.sh"
   || die "v0 release versions must resolve to v0.x-release"
 [[ "$(release_branch_for_version 1.0.0)" == "v1.x-release" ]] \
   || die "v1 release versions must resolve to v1.x-release"
+declare -F publish_release_candidate >/dev/null \
+  || die "release candidate protected-branch publisher is missing"
 
 test_root="$(mktemp -d)"
 trap 'rm -rf "${test_root}"' EXIT


### PR DESCRIPTION
Fixes release publication from maintained version lines. The validated version-bump candidate now goes through a pull request into the derived protected release branch instead of incorrectly pushing `main`.