### PR TITLE
chore: track deferred v0.28.5 dependency refresh

### DIFF
--- a/context/logs/2026/07/LOG-20260723_0906-GiftedDawn-workitem-created.md
+++ b/context/logs/2026/07/LOG-20260723_0906-GiftedDawn-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_0906-GiftedDawn-workitem-created
+  created: '2026-07-23T09:06:26+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-07-23T09:06:26+00:00'
+  summary: 'Created WorkItem ''BACK-20260723_0906-SnappyStone-refresh-deferred-dependencies-after-v0285'':
+    ''Refresh deferred dependencies and tool pins after v0.28.5'''
+  subject: BACK-20260723_0906-SnappyStone-refresh-deferred-dependencies-after-v0285
+  subject_kind: WorkItem
+  actor: BACK-20260723_0906-SnappyStone-refresh-deferred-dependencies-after-v0285
+---

--- a/context/workitems/2026/07/BACK-20260723_0906-SnappyStone-refresh-deferred-dependencies-after-v0285.md
+++ b/context/workitems/2026/07/BACK-20260723_0906-SnappyStone-refresh-deferred-dependencies-after-v0285.md
@@ -1,0 +1,23 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260723_0906-SnappyStone-refresh-deferred-dependencies-after-v0285
+  created: '2026-07-23T09:06:26+00:00'
+  labels:
+    source: v0.28.5-release-state
+    version_lines:
+    - v0.x
+    - v1.x
+spec:
+  title: Refresh deferred dependencies and tool pins after v0.28.5
+  state: backlog
+  type: task
+  priority: medium
+  description: Review and update the dependency and tool-version drift recorded in
+    dist/RELEASE-STATE.md for v0.28.5 as a dedicated maintenance pass. Cover Rust
+    lockfile updates, base image utilities, uv, harness/addon pins, documentation
+    toolchains, Go, infrastructure tools, and Kubernetes tools. Inspect upstream release
+    notes, apply compatible updates to both maintained version lines, rebuild affected
+    images, and rerun the appropriate release and runtime validation gates.
+---


### PR DESCRIPTION
Records the explicit Phase 0 disposition for dependency and tool-pin updates that are intentionally kept out of the focused v0.28.5 bugfix release.