### PR TITLE
chore: close v0.28.5 release workitem

### DIFF
--- a/context/logs/2026/07/LOG-20260723_0928-IdealComet-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_0928-IdealComet-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_0928-IdealComet-workitem-transitioned
+  created: '2026-07-23T09:28:28+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T09:28:28+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes'
+    from 'in-progress' to 'review'
+  subject: BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes
+  subject_kind: WorkItem
+  actor: BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes
+---

--- a/context/logs/2026/07/LOG-20260723_0928-PatientRose-workitem-archive-moved.md
+++ b/context/logs/2026/07/LOG-20260723_0928-PatientRose-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_0928-PatientRose-workitem-archive-moved
+  created: '2026-07-23T09:28:37+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-07-23T09:28:37+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes'
+    to /workspace/context/workitems/done/2026/07/BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes.md
+  subject: BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes
+  subject_kind: WorkItem
+  actor: BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes
+  details:
+    path: /workspace/context/workitems/done/2026/07/BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes.md
+---

--- a/context/logs/2026/07/LOG-20260723_0928-PromptWolf-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_0928-PromptWolf-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_0928-PromptWolf-workitem-transitioned
+  created: '2026-07-23T09:28:37+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T09:28:37+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes'
+    from 'review' to 'done'
+  subject: BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes
+  subject_kind: WorkItem
+  actor: BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes
+---

--- a/context/workitems/done/2026/07/BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes.md
+++ b/context/workitems/done/2026/07/BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes.md
@@ -4,18 +4,29 @@ kind: WorkItem
 metadata:
   id: BACK-20260723_0829-ValiantCliff-ship-v0285-port-cross-line-fixes
   created: '2026-07-23T08:29:51+00:00'
-  updated: '2026-07-23T08:30:01+00:00'
+  updated: '2026-07-23T09:28:37+00:00'
 spec:
   title: Ship v0.28.5 and port fixes across v0.x and v1.x
-  state: in-progress
+  state: done
   type: task
   priority: high
   description: Repair Hermes installation, integrate current v0.x changes, add enforceable
     bidirectional version-line port tracking, release v0.28.5, and port applicable
     changes to v1.x.
   started_at: '2026-07-23T08:30:01+00:00'
+  completed_at: '2026-07-23T09:28:37+00:00'
 ---
 
 ## Transition note (2026-07-23T08:30:01+00:00)
 
 Implementation started with three parallel read-only audits.
+
+
+## Transition note (2026-07-23T09:28:27+00:00)
+
+Implementation, cross-line promotion, validation, and v0.28.5 publication are complete and ready for closure.
+
+
+## Transition note (2026-07-23T09:28:37+00:00)
+
+Verified completion: v0.28.5 release is public with both Linux archives and checksums, documentation is deployed, v0.x and v1.x maintained branches carry the applicable fixes, and the v0 worktree is clean after closure promotion.


### PR DESCRIPTION
Records verified completion of the v0.28.5 release and cross-line remediation work.