### PR TITLE
fix(kubernetes): verify archives by upstream filename

### DIFF
--- a/addons/tools/kubernetes.yaml
+++ b/addons/tools/kubernetes.yaml
@@ -58,33 +58,36 @@ builder: |
   {% if tools.helm.enabled %}
       HELM_VERSION="{{ tools.helm.version }}" && \
       ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && \
-      curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz" -o /tmp/helm.tar.gz && \
-      curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz.sha256sum" -o /tmp/helm.tar.gz.sha256sum && \
-      sha256sum -c /tmp/helm.tar.gz.sha256sum && \
-      tar -xz --strip-components=1 -C /build/bin -f /tmp/helm.tar.gz "linux-${ARCH}/helm" && \
-      rm /tmp/helm.tar.gz /tmp/helm.tar.gz.sha256sum{% if tools.kustomize.enabled or tools.k9s.enabled %} && \
+      HELM_ARCHIVE="helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz" && \
+      curl -fsSL "https://get.helm.sh/${HELM_ARCHIVE}" -o "/tmp/${HELM_ARCHIVE}" && \
+      curl -fsSL "https://get.helm.sh/${HELM_ARCHIVE}.sha256sum" -o "/tmp/${HELM_ARCHIVE}.sha256sum" && \
+      (cd /tmp && sha256sum -c "${HELM_ARCHIVE}.sha256sum") && \
+      tar -xz --strip-components=1 -C /build/bin -f "/tmp/${HELM_ARCHIVE}" "linux-${ARCH}/helm" && \
+      rm "/tmp/${HELM_ARCHIVE}" "/tmp/${HELM_ARCHIVE}.sha256sum"{% if tools.kustomize.enabled or tools.k9s.enabled %} && \
   {% endif %}
   {% endif %}
   {% if tools.kustomize.enabled %}
       KUSTOMIZE_VERSION="{{ tools.kustomize.version }}" && \
       ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && \
-      curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz" -o /tmp/kustomize.tar.gz && \
+      KUSTOMIZE_ARCHIVE="kustomize_v${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz" && \
+      curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/${KUSTOMIZE_ARCHIVE}" -o "/tmp/${KUSTOMIZE_ARCHIVE}" && \
       curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/checksums.txt" -o /tmp/kustomize.checksums.txt && \
-      grep "kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz" /tmp/kustomize.checksums.txt | sha256sum -c && \
-      tar -xz -C /build/bin -f /tmp/kustomize.tar.gz kustomize && \
-      rm /tmp/kustomize.tar.gz /tmp/kustomize.checksums.txt{% if tools.k9s.enabled %} && \
+      (cd /tmp && grep "${KUSTOMIZE_ARCHIVE}$" kustomize.checksums.txt | sha256sum -c -) && \
+      tar -xz -C /build/bin -f "/tmp/${KUSTOMIZE_ARCHIVE}" kustomize && \
+      rm "/tmp/${KUSTOMIZE_ARCHIVE}" /tmp/kustomize.checksums.txt{% if tools.k9s.enabled %} && \
   {% endif %}
   {% endif %}
   {% if tools.k9s.enabled %}
       ARCH="$(dpkg --print-architecture)" && \
       K9S_VERSION="{{ tools.k9s.version }}" && \
-      curl -fsSL "https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_${ARCH}.tar.gz" \
-        -o /tmp/k9s.tar.gz && \
+      K9S_ARCHIVE="k9s_Linux_${ARCH}.tar.gz" && \
+      curl -fsSL "https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/${K9S_ARCHIVE}" \
+        -o "/tmp/${K9S_ARCHIVE}" && \
       curl -fsSL "https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/checksums.sha256" \
         -o /tmp/k9s_checksums.sha256 && \
-      grep "k9s_Linux_${ARCH}.tar.gz" /tmp/k9s_checksums.sha256 | sha256sum -c && \
-      tar xz -C /build/bin -f /tmp/k9s.tar.gz k9s && \
-      rm /tmp/k9s.tar.gz /tmp/k9s_checksums.sha256
+      (cd /tmp && grep "${K9S_ARCHIVE}$" k9s_checksums.sha256 | sha256sum -c -) && \
+      tar xz -C /build/bin -f "/tmp/${K9S_ARCHIVE}" k9s && \
+      rm "/tmp/${K9S_ARCHIVE}" /tmp/k9s_checksums.sha256
   {% endif %}
 
 runtime: |

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1282,6 +1282,38 @@ runtime: |
     }
 
     #[test]
+    fn kubernetes_builder_verifies_archives_using_upstream_filenames() {
+        let addon = load_repo_addon("kubernetes");
+        let tools = all_enabled_tools(&addon);
+        let rendered = render_builder(&addon, &tools).unwrap().unwrap();
+
+        for expected in [
+            r#"HELM_ARCHIVE="helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz""#,
+            r#"(cd /tmp && sha256sum -c "${HELM_ARCHIVE}.sha256sum")"#,
+            r#"KUSTOMIZE_ARCHIVE="kustomize_v${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz""#,
+            r#"(cd /tmp && grep "${KUSTOMIZE_ARCHIVE}$" kustomize.checksums.txt | sha256sum -c -)"#,
+            r#"K9S_ARCHIVE="k9s_Linux_${ARCH}.tar.gz""#,
+            r#"(cd /tmp && grep "${K9S_ARCHIVE}$" k9s_checksums.sha256 | sha256sum -c -)"#,
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "Kubernetes builder must verify the downloaded upstream filename ({expected}): {rendered}"
+            );
+        }
+
+        for stale in [
+            "sha256sum -c /tmp/helm.tar.gz.sha256sum",
+            "kustomize.checksums.txt | sha256sum -c &&",
+            "k9s_checksums.sha256 | sha256sum -c &&",
+        ] {
+            assert!(
+                !rendered.contains(stale),
+                "Kubernetes builder must not verify a renamed archive ({stale}): {rendered}"
+            );
+        }
+    }
+
+    #[test]
     fn purge_cloud_aws_uninstalls_when_disabled() {
         let addon = load_repo_addon("cloud-aws");
         let tools = all_disabled_tools(&addon);

--- a/context/logs/2026/07/LOG-20260723_1538-AgileMeadow-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_1538-AgileMeadow-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1538-AgileMeadow-workitem-transitioned
+  created: '2026-07-23T15:38:21+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T15:38:21+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_1538-MindfulAnchor-fix-kubernetes-addon-checksums-v0286'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260723_1538-MindfulAnchor-fix-kubernetes-addon-checksums-v0286
+  subject_kind: WorkItem
+  actor: BACK-20260723_1538-MindfulAnchor-fix-kubernetes-addon-checksums-v0286
+---

--- a/context/logs/2026/07/LOG-20260723_1538-PatientHearth-workitem-created.md
+++ b/context/logs/2026/07/LOG-20260723_1538-PatientHearth-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1538-PatientHearth-workitem-created
+  created: '2026-07-23T15:38:18+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-07-23T15:38:18+00:00'
+  summary: 'Created WorkItem ''BACK-20260723_1538-MindfulAnchor-fix-kubernetes-addon-checksums-v0286'':
+    ''Fix Kubernetes addon checksum verification and release v0.28.6'''
+  subject: BACK-20260723_1538-MindfulAnchor-fix-kubernetes-addon-checksums-v0286
+  subject_kind: WorkItem
+  actor: BACK-20260723_1538-MindfulAnchor-fix-kubernetes-addon-checksums-v0286
+---

--- a/context/workitems/2026/07/BACK-20260723_1538-MindfulAnchor-fix-kubernetes-addon-checksums-v0286.md
+++ b/context/workitems/2026/07/BACK-20260723_1538-MindfulAnchor-fix-kubernetes-addon-checksums-v0286.md
@@ -1,0 +1,22 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260723_1538-MindfulAnchor-fix-kubernetes-addon-checksums-v0286
+  created: '2026-07-23T15:38:18+00:00'
+  updated: '2026-07-23T15:38:21+00:00'
+spec:
+  title: Fix Kubernetes addon checksum verification and release v0.28.6
+  state: in-progress
+  type: bug
+  priority: high
+  description: Repair derived-project container builds where Helm checksum files name
+    the upstream archive but aibox downloads to /tmp/helm.tar.gz. Make checksum verification
+    path-safe for Helm, Kustomize, and k9s; add regression coverage; port applicable
+    changes across v0.x and v1.x; publish v0.28.6 and verify release artifacts.
+  started_at: '2026-07-23T15:38:21+00:00'
+---
+
+## Transition note (2026-07-23T15:38:21+00:00)
+
+Confirmed the upstream checksum filename mismatch and began generator/test remediation on v0.x before porting to v1.x.


### PR DESCRIPTION
## What changed
- preserve Helm archive basename for checksum verification
- use the actual Kustomize release asset basename, including its `v` prefix
- preserve k9s archive basename for checksum verification
- cover all three generated checksum commands with a regression test

## Validation
- `cargo test --manifest-path cli/Cargo.toml`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- live ARM64 downloads and checksum verification for Helm 4.2.2, Kustomize 5.8.1, and k9s 0.51.0

Release remains held pending processkit v0.28.3.