### PR TITLE
chore(processkit): port v0.28.3 default

### DIFF
--- a/cli/src/processkit_vocab.rs
+++ b/cli/src/processkit_vocab.rs
@@ -162,7 +162,7 @@ pub const TIER_SPECIFIC_MCP_SKILLS: &[&str] = &[
 /// constant serves as the canonical reference for tests and documentation.
 // Used in #[cfg(test)] blocks across multiple modules and in documentation.
 #[allow(dead_code)]
-pub const PROCESSKIT_DEFAULT_VERSION: &str = "v0.28.1";
+pub const PROCESSKIT_DEFAULT_VERSION: &str = "v0.28.3";
 
 // ---------------------------------------------------------------------------
 // v0.26.0 — RoleSlot MCP tools (team-manager skill)

--- a/context/archive/cli-migration-briefings/20260723_1311_0.28.4-to-0.28.5.md
+++ b/context/archive/cli-migration-briefings/20260723_1311_0.28.4-to-0.28.5.md
@@ -1,0 +1,111 @@
+# Migration: v0.28.4 → v0.28.5
+
+> **SAFETY: Do not execute any actions automatically.**
+> **Discuss each item with the project owner before proceeding.**
+> **Do not modify aibox.toml without explicit user confirmation.**
+> **`aibox` commands run on the HOST, outside the container — you cannot run them.**
+
+**Generated:** 2026-07-23
+**Status:** pending
+**aibox CLI:** v0.28.4 → v0.28.5
+**processkit:** v0.28.1
+
+## Summary
+
+aibox has been updated from v0.28.4 to v0.28.5. Review each section below
+and discuss action items with the project owner.
+
+## Breaking Changes
+
+Every release between v0.28.4 and v0.28.5 is listed below.                  Review each; treat entries tagged as breaking as action items.
+
+- **v0.28.5** (processkit v0.28.1): Patch release: fixes Hermes Agent installation under the non-root runtime model; restores the configured lazygit runtime surfaces; completes processkit reconciliation; and enforces traceable ports between maintained v0.x and v1.x lines.
+  <https://github.com/projectious-work/aibox/releases/tag/v0.28.5>
+
+## Action Items
+
+### Host actions (owner runs these outside the container)
+
+- [ ] Owner: verify `aibox apply` was run for v0.28.5 — check `aibox.lock` at
+      `/workspace/aibox.lock`: `[aibox].cli_version` should equal `0.28.5` and
+      `synced_at` should be a recent timestamp
+- [ ] Owner: if sync has NOT been run, run `aibox apply` on the host, then `aibox build`
+- [ ] Owner: if the container was not rebuilt after sync, run `aibox build` then `aibox up`
+
+### Agent verification (you can do these now)
+
+- [ ] Read `/workspace/aibox.lock` — confirm `[aibox].cli_version = "0.28.5"`
+- [ ] Read `/workspace/aibox.lock` — confirm `[processkit].version` matches
+      `/workspace/aibox.toml [processkit].version`
+- [ ] Verify `/workspace/AGENTS.md` exists and is non-empty
+- [ ] Verify `/workspace/context/skills/` directory exists
+- [ ] Verify `/workspace/context/skills/skill-finder/` exists (core skill)
+- [ ] Verify `/workspace/context/processes/` directory exists
+- [ ] Verify `/workspace/context/schemas/` directory exists
+- [ ] Verify `/workspace/context/templates/processkit/v0.28.1/` snapshot directory exists
+- [ ] Check `/workspace/context/migrations/` (this directory) for **other unreviewed CLI migration
+      documents** (files named `YYYYMMDD_HHMM_X.Y.Z-to-A.B.C.md`):
+      - Files with the **same** `from→to` range as this one (e.g. two `0.17.5-to-0.17.6.md`
+        files) are retries — the most recent is authoritative; mark older ones as cancelled
+      - Files with a **different** range (e.g. `0.17.5-to-0.17.6.md` alongside this
+        `0.17.6-to-0.17.7.md`) are **sequential migrations** — both must be reviewed in
+        chronological order; do NOT discard them
+- [ ] Check `/workspace/context/migrations/pending/` for processkit content migration files:
+      - Use `skill-finder` to locate the processkit migration skill, then work through each
+        file with the owner in chronological order — do NOT handle migrations manually
+      - **When reviewing template files like `AGENTS.md`:** do NOT diff the installed
+        (customized) file against the new template — that creates noise from project
+        customizations, hiding real upstream changes. Instead, diff the two template
+        snapshots to see only what changed in the upstream:
+        `diff context/templates/processkit/v0.28.1/AGENTS.md context/templates/processkit/v0.28.1/AGENTS.md`
+        Then apply only those delta changes on top of the customized installed file.
+- [ ] Mark this migration as completed (change Status to "completed")
+
+## processkit State
+
+processkit is tracking `version = "latest"` — installed: `v0.28.1` (upgraded from `v0.28.1` — aibox.toml now targets `vlatest`) (source: `https://github.com/projectious-work/processkit.git`).
+
+**Upgrade policy for `version = "latest"`:**
+`aibox apply` resolves `latest` at run time using a semver-aware policy:
+- **Patch / minor upgrades** (same major): applied automatically.
+- **Major upgrades**: blocked — a warning is shown and sync stays on the
+latest release within the current major. To cross a major boundary, pin
+an explicit version in `aibox.toml` (e.g. `version = "v2.0.0"`).
+
+**Check for pending processkit content migrations:**
+Look in `/workspace/context/migrations/pending/` — `aibox apply` deposits
+content migration documents there during the 3-way diff. Do NOT skip this step.
+
+If files exist, do NOT handle them manually. Instead:
+
+1. Use `skill-finder` to locate the processkit migration management skill
+(search for "migration" or "content update").
+2. Invoke that skill — it knows the correct workflow, state machine, and document
+format for reviewing and applying processkit content migrations.
+3. Work through each pending migration with the owner before marking it applied.
+
+processkit owns the migration format and workflow; defer entirely to its skill.
+
+## AGENTS.md Review
+
+After the upgrade, verify `AGENTS.md` is current:
+- [ ] processkit version reference matches `aibox.lock` (`v0.28.1`)
+- [ ] Configured AI harnesses/providers match the `[ai]` section in `aibox.toml`
+- [ ] Build / test / lint commands are still accurate
+- [ ] Project-specific notes and operational gotchas are up to date
+
+## Verification Summary
+
+After all host actions are confirmed and agent verifications pass, mark Status as "completed".
+
+## Rollback
+
+To revert this migration (owner runs on host):
+```
+git checkout HEAD~1 -- aibox.lock context/ .devcontainer/
+aibox apply
+```
+
+## Known Issues
+
+Check https://github.com/projectious-work/aibox/issues for known issues with v0.28.5.


### PR DESCRIPTION
## What changed
- port the processkit v0.28.3 default pin to v1.x
- preserve both line-specific archived CLI migration briefings

## Traceability
`Version-Line-Port: ported-from=7e298daca9390d6ec2739938900edaad469c45b8`

## Validation
- `./scripts/maintain.sh test`
- v1 version-line port gate