### PR TITLE
docs(v0.28.6): add compatibility metadata

### DIFF
--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -568,6 +568,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.1",
         note: "Patch release: fixes Hermes Agent installation under the non-root runtime model; restores the configured lazygit runtime surfaces; completes processkit reconciliation; and enforces traceable ports between maintained v0.x and v1.x lines.",
     },
+    CompatEntry {
+        aibox_version: "0.28.6",
+        processkit_version: "v0.28.3",
+        note: "Patch release: fixes Kubernetes addon checksum verification for Helm, Kustomize, and k9s archives on amd64 and arm64; and integrates processkit v0.28.3 authenticated GitHub repository reconciliation.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/docs-site/docs/reference/compatibility.md
+++ b/docs-site/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.28.6 | v0.28.3 | fixes Kubernetes addon checksum verification for Helm, Kustomize, and k9s archives on amd64 and arm64; and integrates processkit v0.28.3 authenticated GitHub repository reconciliation |
 | 0.28.5 | v0.28.1 | fixes Hermes Agent installation under the non-root runtime model; restores configured lazygit runtime surfaces; completes processkit reconciliation; and enforces traceable ports between maintained v0.x and v1.x lines |
 | 0.28.4 | v0.28.1 | integrates processkit v0.28.1 and refreshes the maintained v0.x processkit compatibility baseline |
 | 0.28.3 | v0.27.6 | integrates processkit v0.27.6; makes GitHub CLI authoritative for `github.com` HTTPS credentials; exposes exact GitHub SSH aliases through Forge; and preserves LaTeX preview state across rebuilds |


### PR DESCRIPTION
Adds the v0.28.6 compatibility entry for the Kubernetes checksum repair and processkit v0.28.3 integration.

This is v0 release metadata and is explicitly not applicable to the v1 development line.

Validation: `./scripts/maintain.sh test`.