### PR TITLE
fix: keep processkit latest on stable releases

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -177,6 +177,12 @@ pub enum Commands {
         #[arg(long)]
         processkit_version: Option<String>,
 
+        /// Include prerelease processkit tags in automatic and interactive
+        /// version selection. Explicit --processkit-version prerelease pins
+        /// always work without this flag.
+        #[arg(long)]
+        include_prerelease: bool,
+
         /// processkit branch override. Tracks the moving HEAD of a branch
         /// instead of a pinned tag — discouraged for production use, fine
         /// for testing pre-release work. Mutually informative with

--- a/cli/src/container.rs
+++ b/cli/src/container.rs
@@ -57,6 +57,9 @@ pub struct InitParams {
     /// configured source and pick interactively (or pick latest in
     /// non-interactive mode; fall back to "unset" if listing fails).
     pub processkit_version: Option<String>,
+    /// Include prerelease processkit tags in automatic and interactive
+    /// selection. Explicit prerelease pins do not require this opt-in.
+    pub include_prerelease: bool,
     /// Track a moving processkit branch. Wins over `processkit_version`
     /// at fetch time per the existing fetcher contract.
     pub processkit_branch: Option<String>,
@@ -184,9 +187,10 @@ fn run_install(cwd: &std::path::Path, config: &AiboxConfig) {
 /// 3. Version:
 ///    - `--processkit-version` if given → use as-is
 ///    - else: list available versions at the source.
-///      - Interactive: show a `dialoguer::Select` with a literal "latest"
-///        tracking entry as the default, followed by the 10 newest concrete
-///        tags. Includes an "unset (skip processkit install)" entry as the
+///      - Interactive: show a `dialoguer::Select` with a literal stable-only
+///        "latest" tracking entry as the default, followed by the 10 newest
+///        concrete tags (including prereleases only with explicit opt-in).
+///        Includes an "unset (skip processkit install)" entry as the
 ///        escape hatch when the user explicitly wants no install.
 ///      - Non-interactive: pick the first (latest) entry. If listing
 ///        fails or returns nothing, fall back to the `unset` sentinel
@@ -195,6 +199,7 @@ fn resolve_processkit_section(
     source_override: Option<&str>,
     version_override: Option<&str>,
     branch_override: Option<&str>,
+    include_prerelease: bool,
     interactive: bool,
 ) -> Result<crate::config::ProcessKitSection> {
     use crate::config::{PROCESSKIT_VERSION_UNSET, ProcessKitSection};
@@ -217,7 +222,11 @@ fn resolve_processkit_section(
         "Querying available processkit versions at {}...",
         section.source
     ));
-    let versions = match crate::content_source::list_versions(&section.source) {
+    let versions = match if include_prerelease {
+        crate::content_source::list_versions_including_prereleases(&section.source)
+    } else {
+        crate::content_source::list_versions(&section.source)
+    } {
         Ok(v) if !v.is_empty() => v,
         Ok(_) => {
             if interactive {
@@ -260,8 +269,13 @@ fn resolve_processkit_section(
         // Build the menu with a literal "latest" tracking entry at the top,
         // followed by a bounded set of concrete pin choices and an explicit
         // "skip" escape hatch at the bottom.
-        let mut items: Vec<String> = vec!["latest (always track newest)".to_string()];
-        items.extend(visible_versions.iter().cloned());
+        let mut items: Vec<String> =
+            vec!["latest (always track newest stable release)".to_string()];
+        items.extend(
+            visible_versions
+                .iter()
+                .map(|version| processkit_wizard_version_label(version)),
+        );
         items.push(format!(
             "{} — skip processkit install (configure later)",
             PROCESSKIT_VERSION_UNSET
@@ -293,6 +307,13 @@ fn processkit_wizard_visible_versions(versions: &[String]) -> Vec<String> {
         .take(MAX_CONCRETE_VERSIONS)
         .cloned()
         .collect()
+}
+
+fn processkit_wizard_version_label(version: &str) -> String {
+    match crate::content_source::parse_loose_semver(version) {
+        Some(parsed) if !parsed.pre.is_empty() => format!("{} (prerelease)", version),
+        _ => version.to_string(),
+    }
 }
 
 fn selected_processkit_wizard_version(idx: usize, visible_versions: &[String]) -> String {
@@ -2906,6 +2927,7 @@ pub fn cmd_init(config_path: &Option<String>, params: InitParams) -> Result<()> 
                 params.processkit_source.as_deref(),
                 params.processkit_version.as_deref(),
                 params.processkit_branch.as_deref(),
+                params.include_prerelease,
                 interactive,
             )?
         },
@@ -4137,6 +4159,23 @@ mod tests {
         let visible = processkit_wizard_visible_versions(&versions);
 
         assert_eq!(visible, vec!["v1.0.1", "v1.0.0", "v0.99.4"]);
+    }
+
+    #[test]
+    fn processkit_wizard_labels_prereleases() {
+        assert_eq!(
+            processkit_wizard_version_label("v1.0.0-alpha.1"),
+            "v1.0.0-alpha.1 (prerelease)"
+        );
+        assert_eq!(processkit_wizard_version_label("v0.28.3"), "v0.28.3");
+    }
+
+    #[test]
+    fn explicit_prerelease_processkit_pin_is_preserved() {
+        let section = resolve_processkit_section(None, Some("v1.0.0-alpha.1"), None, false, false)
+            .expect("explicit prerelease pins should not need version listing");
+
+        assert_eq!(section.version, "v1.0.0-alpha.1");
     }
 
     #[test]

--- a/cli/src/content_source.rs
+++ b/cli/src/content_source.rs
@@ -258,7 +258,7 @@ fn base_cache_dir() -> Result<PathBuf> {
 // Version listing
 // ---------------------------------------------------------------------------
 
-/// List the versions available at `source`, newest first.
+/// List the stable versions available at `source`, newest first.
 ///
 /// Strategy:
 ///
@@ -273,20 +273,37 @@ fn base_cache_dir() -> Result<PathBuf> {
 /// 2. **Anything else** (GitLab, Gitea, self-hosted, file://, SSH,
 ///    scp-like): `git ls-remote --tags --refs <source>` directly.
 ///
-/// Filtering: only tags that parse as semver (with an optional leading
-/// `v`) are returned. Sorted descending by semver. Duplicates after the
-/// `v` strip are deduplicated. Empty result is `Ok(vec![])`, not an error.
+/// Filtering: only stable tags that parse as semver (with an optional leading
+/// `v`) are returned. Sorted descending by semver. Duplicates after the `v`
+/// strip are deduplicated. Empty result is `Ok(vec![])`, not an error.
+///
+/// Use [`list_versions_including_prereleases`] only for an explicit
+/// prerelease-selection flow. Keeping the default stable-only protects every
+/// `processkit.version = "latest"` resolution path, including the git-tag
+/// fallback where GitHub Release prerelease metadata is unavailable.
 ///
 /// Used by `aibox init`'s interactive picker (and the
 /// `--processkit-version` flag's "default to latest" path).
 pub fn list_versions(source: &str) -> Result<Vec<String>> {
+    list_versions_with_prereleases(source, false)
+}
+
+/// List the versions available at `source`, optionally including prereleases.
+///
+/// This is for explicit opt-in selection flows. Callers resolving `latest`
+/// should use [`list_versions`] instead.
+pub fn list_versions_including_prereleases(source: &str) -> Result<Vec<String>> {
+    list_versions_with_prereleases(source, true)
+}
+
+fn list_versions_with_prereleases(source: &str, include_prereleases: bool) -> Result<Vec<String>> {
     // git ls-remote is always the authoritative source: it sees every pushed
     // tag, including those not yet published as a formal GitHub Release.
     // The GitHub Releases API is used only as a fallback (e.g. if git is
     // unavailable in the environment) because it can miss tags that have been
     // pushed but not formally released.
     match list_git_tags(source) {
-        Ok(v) if !v.is_empty() => return Ok(v),
+        Ok(v) if !v.is_empty() => return Ok(filter_and_sort_semver_tags(v, include_prereleases)),
         Ok(_) => {
             tracing::debug!(
                 "git ls-remote returned no semver tags for {}; \
@@ -305,13 +322,13 @@ pub fn list_versions(source: &str) -> Result<Vec<String>> {
 
     let parsed = parse_source(source)?;
     if parsed.host == "github.com" {
-        list_github_releases(&parsed.org, &parsed.name)
+        list_github_releases(&parsed.org, &parsed.name, include_prereleases)
     } else {
         bail!("Could not list any semver-tagged versions at {}", source)
     }
 }
 
-fn list_github_releases(org: &str, name: &str) -> Result<Vec<String>> {
+fn list_github_releases(org: &str, name: &str, include_prereleases: bool) -> Result<Vec<String>> {
     let url = format!(
         "https://api.github.com/repos/{}/{}/releases?per_page=100",
         org, name
@@ -338,7 +355,7 @@ fn list_github_releases(org: &str, name: &str) -> Result<Vec<String>> {
         .iter()
         .filter_map(|r| r.get("tag_name").and_then(|t| t.as_str()).map(String::from))
         .collect();
-    Ok(filter_and_sort_semver_tags(tags))
+    Ok(filter_and_sort_semver_tags(tags, include_prereleases))
 }
 
 fn list_git_tags(source: &str) -> Result<Vec<String>> {
@@ -360,16 +377,17 @@ fn list_git_tags(source: &str) -> Result<Vec<String>> {
         .filter_map(|ref_path| ref_path.strip_prefix("refs/tags/"))
         .map(String::from)
         .collect();
-    Ok(filter_and_sort_semver_tags(tags))
+    Ok(tags)
 }
 
 /// Keep only semver-looking tags, sort descending, and dedupe by the
 /// stripped semver form (so `v1.2.3` and `1.2.3` collapse to one entry,
 /// preferring the input that came first).
-fn filter_and_sort_semver_tags(tags: Vec<String>) -> Vec<String> {
+fn filter_and_sort_semver_tags(tags: Vec<String>, include_prereleases: bool) -> Vec<String> {
     let mut keep: Vec<(semver::Version, String)> = tags
         .into_iter()
         .filter_map(|t| parse_loose_semver(&t).map(|v| (v, t)))
+        .filter(|(version, _)| include_prereleases || version.pre.is_empty())
         .collect();
     keep.sort_by(|a, b| b.0.cmp(&a.0));
     let mut seen = std::collections::HashSet::new();
@@ -1120,7 +1138,7 @@ mod tests {
             "v0.4.0".to_string(),
             "release-candidate".to_string(),
         ];
-        let out = filter_and_sort_semver_tags(raw);
+        let out = filter_and_sort_semver_tags(raw, false);
         assert_eq!(out, vec!["v0.5.1", "v0.4.0"]);
     }
 
@@ -1132,7 +1150,7 @@ mod tests {
             "v0.5.0".to_string(),
             "v0.4.1".to_string(),
         ];
-        let out = filter_and_sort_semver_tags(raw);
+        let out = filter_and_sort_semver_tags(raw, false);
         assert_eq!(out, vec!["v0.5.1", "v0.5.0", "v0.4.1", "v0.4.0"]);
     }
 
@@ -1145,25 +1163,35 @@ mod tests {
             "0.5.1".to_string(),
             "v0.4.0".to_string(),
         ];
-        let out = filter_and_sort_semver_tags(raw);
+        let out = filter_and_sort_semver_tags(raw, false);
         assert_eq!(out, vec!["v0.5.1", "v0.4.0"]);
     }
 
     #[test]
-    fn filter_and_sort_handles_prerelease() {
+    fn filter_and_sort_excludes_prereleases_by_default() {
         let raw = vec![
-            "v1.0.0".to_string(),
-            "v1.0.0-rc1".to_string(),
-            "v0.9.0".to_string(),
+            "v0.28.3".to_string(),
+            "v1.0.0-alpha.1".to_string(),
+            "v1.0.0-rc.1".to_string(),
         ];
-        let out = filter_and_sort_semver_tags(raw);
-        // Per semver, 1.0.0 > 1.0.0-rc1, so the stable comes first.
-        assert_eq!(out, vec!["v1.0.0", "v1.0.0-rc1", "v0.9.0"]);
+        let out = filter_and_sort_semver_tags(raw, false);
+        assert_eq!(out, vec!["v0.28.3"]);
+    }
+
+    #[test]
+    fn filter_and_sort_includes_prereleases_when_requested() {
+        let raw = vec![
+            "v0.28.3".to_string(),
+            "v1.0.0-alpha.1".to_string(),
+            "v1.0.0-rc.1".to_string(),
+        ];
+        let out = filter_and_sort_semver_tags(raw, true);
+        assert_eq!(out, vec!["v1.0.0-rc.1", "v1.0.0-alpha.1", "v0.28.3"]);
     }
 
     #[test]
     fn filter_and_sort_empty_in_empty_out() {
-        assert!(filter_and_sort_semver_tags(vec![]).is_empty());
+        assert!(filter_and_sort_semver_tags(vec![], false).is_empty());
     }
 
     // -- URL parsing --------------------------------------------------------

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -114,6 +114,7 @@ fn dispatch(cli: cli::Cli) -> anyhow::Result<()> {
             addon_tool,
             processkit_source,
             processkit_version,
+            include_prerelease,
             processkit_branch,
             no_container,
         } => {
@@ -135,6 +136,7 @@ fn dispatch(cli: cli::Cli) -> anyhow::Result<()> {
                     addon_tool,
                     processkit_source,
                     processkit_version,
+                    include_prerelease,
                     processkit_branch,
                     no_container,
                 },

--- a/docs-site/docs/getting-started/new-project.md
+++ b/docs-site/docs/getting-started/new-project.md
@@ -27,7 +27,7 @@ The `init` command accepts these options:
 | `--addon` | — | Addon names (can be repeated): `python`, `rust`, `node`, `go`, `latex`, etc. |
 | `--theme` | `gruvbox` | Theme family |
 | `--context-mode` | `processkit` | Context layer: `processkit` or `harness-only` |
-| `--processkit-version` | latest available tag | processkit content release to pin |
+| `--processkit-version` | latest stable tag | processkit content release to pin; explicit prerelease pins are supported |
 
 If you omit options, `aibox init` runs interactively and prompts for each value.
 
@@ -95,13 +95,21 @@ Use narrowly scoped PATs by default. For the alternative persistent
 :::tip processkit version
 
 By default, the interactive `aibox init` picker offers `latest` first, then the
-10 newest concrete processkit tags. Choosing `latest` writes
+10 newest stable processkit tags. Choosing `latest` writes
 `version = "latest"` to `aibox.toml` so `aibox apply` tracks the newest
 compatible content. Use `--processkit-version` to pin a specific tag
 non-interactively:
 
 ```bash
 aibox init my-app --processkit-version v0.27.4
+```
+
+To evaluate prerelease processkit content without changing the stable default,
+pin the prerelease explicitly or opt into prerelease selection:
+
+```sh
+aibox init my-app --processkit-version v1.0.0-alpha.1
+aibox init my-app --include-prerelease
 ```
 
 This picker is skipped when `--context-mode harness-only` is selected.

--- a/docs-site/docs/reference/cli-commands.md
+++ b/docs-site/docs/reference/cli-commands.md
@@ -66,6 +66,7 @@ aibox init my-app --theme catppuccin-mocha
 | `--addon <NAME>` | -- | Addon name, repeatable |
 | `--theme <THEME>` | `gruvbox` | Runtime UI theme family |
 | `--processkit-version <TAG>` | latest prompt/default | Pin processkit |
+| `--include-prerelease` | off | Include processkit prereleases when init selects a version; explicit prerelease pins always work |
 
 The hidden legacy `--context <PKG>` option is still accepted as a processkit
 package selector for compatibility. New configs use `[context].mode` and,

--- a/docs-site/docs/reference/configuration.md
+++ b/docs-site/docs/reference/configuration.md
@@ -55,7 +55,7 @@ packages = ["product"]                # processkit package selection
 
 [processkit]
 source   = "https://github.com/projectious-work/processkit.git"
-version  = "latest"                   # "latest", "unset", or a real tag
+version  = "latest"                   # newest stable release, "unset", or a real tag (including an explicit prerelease)
 src_path = "src"
 # branch = "main"                     # Optional; tarball-first, branch as fallback
 # release_asset_url_template = "..."  # Optional, for non-GitHub hosts
@@ -421,8 +421,6 @@ allow_public = false
 | `documents[].name` | String | Yes | -- | Unique command-safe document name. |
 | `documents[].source` | Relative path | Yes | -- | Main TeX source. |
 | `documents[].output_dir` | Relative path | No | `.latex-cache/output` | PDF, log, and auxiliary output directory. |
-| `documents[].options` | Array | No | `[]` | Additional arguments for this document only; appended after the global `latex.options`. |
-| `documents[].extra_dirs` | Array | No | `[]` | Relative directories created below `output_dir` before building or watching, useful for TikZ externalization output. |
 | `preview.enabled` | Boolean | No | `false` | Generates one shared read-only Compose preview sidecar; host-side `aibox up` starts it and it serves every configured document. |
 | `preview.engine` | String | No | `embedpdf` | Viewer implementation; currently only `embedpdf` is supported. |
 | `preview.bind` | IP address | No | `127.0.0.1` | Compose host-publish address. Loopback is accessible only from that host; use `0.0.0.0` only for other machines. |


### PR DESCRIPTION
Forward-port of #134 for the v1.x line.\n\nProvenance: `Version-Line-Port: ported-from=3c6fd414ab84f4bf24ecae603f7492d528577751`.\n\nValidation: cargo test; cargo clippy --all-targets -- -D warnings; cargo fmt -- --check.