### PR TITLE
fix: verify infrastructure archives by upstream name

### DIFF
--- a/addons/tools/infrastructure.yaml
+++ b/addons/tools/infrastructure.yaml
@@ -43,23 +43,25 @@ builder: |
   {% if tools.opentofu.enabled %}
       TOFU_VERSION="{{ tools.opentofu.version }}" && \
       ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && \
-      curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" -o /tmp/tofu.tar.gz && \
+      TOFU_ARCHIVE="tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" && \
+      curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/${TOFU_ARCHIVE}" -o "/tmp/${TOFU_ARCHIVE}" && \
       curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS" -o /tmp/tofu_SHA256SUMS && \
-      grep "tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" /tmp/tofu_SHA256SUMS | sha256sum -c && \
-      tar -xz -C /build/bin -f /tmp/tofu.tar.gz tofu && \
-      rm /tmp/tofu.tar.gz /tmp/tofu_SHA256SUMS{% if tools.packer.enabled %} && \
+      (cd /tmp && grep "${TOFU_ARCHIVE}$" tofu_SHA256SUMS | sha256sum -c -) && \
+      tar -xz -C /build/bin -f "/tmp/${TOFU_ARCHIVE}" tofu && \
+      rm "/tmp/${TOFU_ARCHIVE}" /tmp/tofu_SHA256SUMS{% if tools.packer.enabled %} && \
   {% endif %}
   {% endif %}
   {% if tools.packer.enabled %}
       ARCH="$(dpkg --print-architecture)" && \
       PACKER_VERSION="{{ tools.packer.version }}" && \
-      curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${ARCH}.zip" \
-        -o /tmp/packer.zip && \
+      PACKER_ARCHIVE="packer_${PACKER_VERSION}_linux_${ARCH}.zip" && \
+      curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_ARCHIVE}" \
+        -o "/tmp/${PACKER_ARCHIVE}" && \
       curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS" \
         -o /tmp/packer_SHA256SUMS && \
-      grep "packer_${PACKER_VERSION}_linux_${ARCH}.zip" /tmp/packer_SHA256SUMS | sha256sum -c && \
-      unzip -q /tmp/packer.zip -d /build/bin && \
-      rm /tmp/packer.zip /tmp/packer_SHA256SUMS
+      (cd /tmp && grep "${PACKER_ARCHIVE}$" packer_SHA256SUMS | sha256sum -c -) && \
+      unzip -q "/tmp/${PACKER_ARCHIVE}" -d /build/bin && \
+      rm "/tmp/${PACKER_ARCHIVE}" /tmp/packer_SHA256SUMS
   {% endif %}
 
 runtime: |

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1314,6 +1314,35 @@ runtime: |
     }
 
     #[test]
+    fn infrastructure_builder_verifies_archives_using_upstream_filenames() {
+        let addon = load_repo_addon("infrastructure");
+        let tools = all_enabled_tools(&addon);
+        let rendered = render_builder(&addon, &tools).unwrap().unwrap();
+
+        for expected in [
+            r#"TOFU_ARCHIVE="tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz""#,
+            r#"(cd /tmp && grep "${TOFU_ARCHIVE}$" tofu_SHA256SUMS | sha256sum -c -)"#,
+            r#"PACKER_ARCHIVE="packer_${PACKER_VERSION}_linux_${ARCH}.zip""#,
+            r#"(cd /tmp && grep "${PACKER_ARCHIVE}$" packer_SHA256SUMS | sha256sum -c -)"#,
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "Infrastructure builder must verify the downloaded upstream filename ({expected}): {rendered}"
+            );
+        }
+
+        for stale in [
+            "grep \"tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz\" /tmp/tofu_SHA256SUMS | sha256sum -c",
+            "grep \"packer_${PACKER_VERSION}_linux_${ARCH}.zip\" /tmp/packer_SHA256SUMS | sha256sum -c",
+        ] {
+            assert!(
+                !rendered.contains(stale),
+                "Infrastructure builder must not verify a renamed archive ({stale}): {rendered}"
+            );
+        }
+    }
+
+    #[test]
     fn purge_cloud_aws_uninstalls_when_disabled() {
         let addon = load_repo_addon("cloud-aws");
         let tools = all_disabled_tools(&addon);


### PR DESCRIPTION
Forward-port of #140 for v1.x.\n\nValidation: cargo test; cargo clippy --all-targets -- -D warnings; cargo fmt -- --check.