### PR TITLE
chore: close infrastructure checksum fix work item

### DIFF
--- a/context/logs/2026/07/LOG-20260723_1852-CapableFalcon-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_1852-CapableFalcon-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1852-CapableFalcon-workitem-transitioned
+  created: '2026-07-23T18:52:56+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T18:52:56+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on'
+    from 'in-progress' to 'review'
+  subject: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  subject_kind: WorkItem
+  actor: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+---

--- a/context/logs/2026/07/LOG-20260723_1853-FitOasis-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_1853-FitOasis-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1853-FitOasis-workitem-transitioned
+  created: '2026-07-23T18:53:00+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T18:53:00+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on'
+    from 'review' to 'done'
+  subject: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  subject_kind: WorkItem
+  actor: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+---

--- a/context/logs/2026/07/LOG-20260723_1853-TrueLily-workitem-archive-moved.md
+++ b/context/logs/2026/07/LOG-20260723_1853-TrueLily-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1853-TrueLily-workitem-archive-moved
+  created: '2026-07-23T18:53:00+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-07-23T18:53:00+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on'
+    to /workspace/context/workitems/done/2026/07/BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on.md
+  subject: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  subject_kind: WorkItem
+  actor: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  details:
+    path: /workspace/context/workitems/done/2026/07/BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on.md
+---

--- a/context/workitems/done/2026/07/BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on.md
+++ b/context/workitems/done/2026/07/BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on.md
@@ -4,10 +4,10 @@ kind: WorkItem
 metadata:
   id: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
   created: '2026-07-23T18:49:25+00:00'
-  updated: '2026-07-23T18:49:33+00:00'
+  updated: '2026-07-23T18:53:00+00:00'
 spec:
   title: Fix infrastructure addon checksum verification on ARM64
-  state: in-progress
+  state: done
   type: bug
   priority: high
   description: Repair generated infrastructure builder verification for OpenTofu and
@@ -15,8 +15,19 @@ spec:
     a temporary path. Download by upstream filename under /tmp, verify from /tmp,
     add renderer regression coverage, and port the applicable fix from v0.x to v1.x.
   started_at: '2026-07-23T18:49:33+00:00'
+  completed_at: '2026-07-23T18:53:00+00:00'
 ---
 
 ## Transition note (2026-07-23T18:49:33+00:00)
 
 Confirmed failing ARM64 OpenTofu checksum entry and matching latent Packer failure; implementing path-safe verification and regression coverage.
+
+
+## Transition note (2026-07-23T18:52:56+00:00)
+
+OpenTofu and Packer checksum verification now uses upstream archive filenames; validated against current ARM64 checksum manifests and merged across v0.x/v1.x.
+
+
+## Transition note (2026-07-23T18:53:00+00:00)
+
+Completed: v0.x release merge, v1.x development/pre-release port, full test gates, and cross-line port gates all pass.


### PR DESCRIPTION
Records completion of the OpenTofu and Packer checksum verification fix after v0 and v1 merges.