### PR TITLE
fix: promote infrastructure checksum verification to main

### DIFF
--- a/addons/tools/infrastructure.yaml
+++ b/addons/tools/infrastructure.yaml
@@ -43,23 +43,25 @@ builder: |
   {% if tools.opentofu.enabled %}
       TOFU_VERSION="{{ tools.opentofu.version }}" && \
       ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && \
-      curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" -o /tmp/tofu.tar.gz && \
+      TOFU_ARCHIVE="tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" && \
+      curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/${TOFU_ARCHIVE}" -o "/tmp/${TOFU_ARCHIVE}" && \
       curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS" -o /tmp/tofu_SHA256SUMS && \
-      grep "tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" /tmp/tofu_SHA256SUMS | sha256sum -c && \
-      tar -xz -C /build/bin -f /tmp/tofu.tar.gz tofu && \
-      rm /tmp/tofu.tar.gz /tmp/tofu_SHA256SUMS{% if tools.packer.enabled %} && \
+      (cd /tmp && grep "${TOFU_ARCHIVE}$" tofu_SHA256SUMS | sha256sum -c -) && \
+      tar -xz -C /build/bin -f "/tmp/${TOFU_ARCHIVE}" tofu && \
+      rm "/tmp/${TOFU_ARCHIVE}" /tmp/tofu_SHA256SUMS{% if tools.packer.enabled %} && \
   {% endif %}
   {% endif %}
   {% if tools.packer.enabled %}
       ARCH="$(dpkg --print-architecture)" && \
       PACKER_VERSION="{{ tools.packer.version }}" && \
-      curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${ARCH}.zip" \
-        -o /tmp/packer.zip && \
+      PACKER_ARCHIVE="packer_${PACKER_VERSION}_linux_${ARCH}.zip" && \
+      curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_ARCHIVE}" \
+        -o "/tmp/${PACKER_ARCHIVE}" && \
       curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS" \
         -o /tmp/packer_SHA256SUMS && \
-      grep "packer_${PACKER_VERSION}_linux_${ARCH}.zip" /tmp/packer_SHA256SUMS | sha256sum -c && \
-      unzip -q /tmp/packer.zip -d /build/bin && \
-      rm /tmp/packer.zip /tmp/packer_SHA256SUMS
+      (cd /tmp && grep "${PACKER_ARCHIVE}$" packer_SHA256SUMS | sha256sum -c -) && \
+      unzip -q "/tmp/${PACKER_ARCHIVE}" -d /build/bin && \
+      rm "/tmp/${PACKER_ARCHIVE}" /tmp/packer_SHA256SUMS
   {% endif %}
 
 runtime: |

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1314,6 +1314,35 @@ runtime: |
     }
 
     #[test]
+    fn infrastructure_builder_verifies_archives_using_upstream_filenames() {
+        let addon = load_repo_addon("infrastructure");
+        let tools = all_enabled_tools(&addon);
+        let rendered = render_builder(&addon, &tools).unwrap().unwrap();
+
+        for expected in [
+            r#"TOFU_ARCHIVE="tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz""#,
+            r#"(cd /tmp && grep "${TOFU_ARCHIVE}$" tofu_SHA256SUMS | sha256sum -c -)"#,
+            r#"PACKER_ARCHIVE="packer_${PACKER_VERSION}_linux_${ARCH}.zip""#,
+            r#"(cd /tmp && grep "${PACKER_ARCHIVE}$" packer_SHA256SUMS | sha256sum -c -)"#,
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "Infrastructure builder must verify the downloaded upstream filename ({expected}): {rendered}"
+            );
+        }
+
+        for stale in [
+            "grep \"tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz\" /tmp/tofu_SHA256SUMS | sha256sum -c",
+            "grep \"packer_${PACKER_VERSION}_linux_${ARCH}.zip\" /tmp/packer_SHA256SUMS | sha256sum -c",
+        ] {
+            assert!(
+                !rendered.contains(stale),
+                "Infrastructure builder must not verify a renamed archive ({stale}): {rendered}"
+            );
+        }
+    }
+
+    #[test]
     fn purge_cloud_aws_uninstalls_when_disabled() {
         let addon = load_repo_addon("cloud-aws");
         let tools = all_disabled_tools(&addon);

--- a/context/logs/2026/07/LOG-20260723_1849-CleverSage-workitem-created.md
+++ b/context/logs/2026/07/LOG-20260723_1849-CleverSage-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1849-CleverSage-workitem-created
+  created: '2026-07-23T18:49:26+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-07-23T18:49:26+00:00'
+  summary: 'Created WorkItem ''BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on'':
+    ''Fix infrastructure addon checksum verification on ARM64'''
+  subject: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  subject_kind: WorkItem
+  actor: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+---

--- a/context/logs/2026/07/LOG-20260723_1849-MightyLeaf-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_1849-MightyLeaf-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1849-MightyLeaf-workitem-transitioned
+  created: '2026-07-23T18:49:33+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T18:49:33+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  subject_kind: WorkItem
+  actor: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+---

--- a/context/logs/2026/07/LOG-20260723_1852-CapableFalcon-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_1852-CapableFalcon-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1852-CapableFalcon-workitem-transitioned
+  created: '2026-07-23T18:52:56+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T18:52:56+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on'
+    from 'in-progress' to 'review'
+  subject: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  subject_kind: WorkItem
+  actor: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+---

--- a/context/logs/2026/07/LOG-20260723_1853-FitOasis-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_1853-FitOasis-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1853-FitOasis-workitem-transitioned
+  created: '2026-07-23T18:53:00+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T18:53:00+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on'
+    from 'review' to 'done'
+  subject: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  subject_kind: WorkItem
+  actor: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+---

--- a/context/logs/2026/07/LOG-20260723_1853-TrueLily-workitem-archive-moved.md
+++ b/context/logs/2026/07/LOG-20260723_1853-TrueLily-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1853-TrueLily-workitem-archive-moved
+  created: '2026-07-23T18:53:00+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-07-23T18:53:00+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on'
+    to /workspace/context/workitems/done/2026/07/BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on.md
+  subject: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  subject_kind: WorkItem
+  actor: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  details:
+    path: /workspace/context/workitems/done/2026/07/BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on.md
+---

--- a/context/workitems/2026/07/BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on.md
+++ b/context/workitems/2026/07/BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on.md
@@ -1,0 +1,22 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
+  created: '2026-07-23T18:49:25+00:00'
+  updated: '2026-07-23T18:49:33+00:00'
+spec:
+  title: Fix infrastructure addon checksum verification on ARM64
+  state: in-progress
+  type: bug
+  priority: high
+  description: Repair generated infrastructure builder verification for OpenTofu and
+    Packer when upstream SHA256SUMS entries name the archive but aibox downloads to
+    a temporary path. Download by upstream filename under /tmp, verify from /tmp,
+    add renderer regression coverage, and port the applicable fix from v0.x to v1.x.
+  started_at: '2026-07-23T18:49:33+00:00'
+---
+
+## Transition note (2026-07-23T18:49:33+00:00)
+
+Confirmed failing ARM64 OpenTofu checksum entry and matching latent Packer failure; implementing path-safe verification and regression coverage.

--- a/context/workitems/done/2026/07/BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on.md
+++ b/context/workitems/done/2026/07/BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on.md
@@ -4,10 +4,10 @@ kind: WorkItem
 metadata:
   id: BACK-20260723_1849-WildHare-fix-infrastructure-addon-checksum-verification-on
   created: '2026-07-23T18:49:25+00:00'
-  updated: '2026-07-23T18:49:33+00:00'
+  updated: '2026-07-23T18:53:00+00:00'
 spec:
   title: Fix infrastructure addon checksum verification on ARM64
-  state: in-progress
+  state: done
   type: bug
   priority: high
   description: Repair generated infrastructure builder verification for OpenTofu and
@@ -15,8 +15,19 @@ spec:
     a temporary path. Download by upstream filename under /tmp, verify from /tmp,
     add renderer regression coverage, and port the applicable fix from v0.x to v1.x.
   started_at: '2026-07-23T18:49:33+00:00'
+  completed_at: '2026-07-23T18:53:00+00:00'
 ---
 
 ## Transition note (2026-07-23T18:49:33+00:00)
 
 Confirmed failing ARM64 OpenTofu checksum entry and matching latent Packer failure; implementing path-safe verification and regression coverage.
+
+
+## Transition note (2026-07-23T18:52:56+00:00)
+
+OpenTofu and Packer checksum verification now uses upstream archive filenames; validated against current ARM64 checksum manifests and merged across v0.x/v1.x.
+
+
+## Transition note (2026-07-23T18:53:00+00:00)
+
+Completed: v0.x release merge, v1.x development/pre-release port, full test gates, and cross-line port gates all pass.


### PR DESCRIPTION
Promotes the completed OpenTofu and Packer checksum verification fix from v0.x-release.