### PR TITLE
chore: release v0.28.7

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.28.6"
+version = "0.28.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.28.6"
+version = "0.28.7"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -573,6 +573,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.3",
         note: "Patch release: fixes Kubernetes addon checksum verification for Helm, Kustomize, and k9s archives on amd64 and arm64; and integrates processkit v0.28.3 authenticated GitHub repository reconciliation.",
     },
+    CompatEntry {
+        aibox_version: "0.28.7",
+        processkit_version: "v0.28.3",
+        note: "Patch release: fixes OpenTofu and Packer addon checksum verification on amd64 and arm64 by preserving upstream archive filenames during checksum validation.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/context/logs/2026/07/LOG-20260723_1856-HardyIvy-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_1856-HardyIvy-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1856-HardyIvy-workitem-transitioned
+  created: '2026-07-23T18:56:37+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T18:56:37+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix
+  subject_kind: WorkItem
+  actor: BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix
+---

--- a/context/logs/2026/07/LOG-20260723_1856-SoftPath-workitem-created.md
+++ b/context/logs/2026/07/LOG-20260723_1856-SoftPath-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1856-SoftPath-workitem-created
+  created: '2026-07-23T18:56:34+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-07-23T18:56:34+00:00'
+  summary: 'Created WorkItem ''BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix'':
+    ''Release aibox v0.28.7 infrastructure checksum verification fix'''
+  subject: BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix
+  subject_kind: WorkItem
+  actor: BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix
+---

--- a/context/workitems/2026/07/BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix.md
+++ b/context/workitems/2026/07/BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix.md
@@ -1,0 +1,22 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix
+  created: '2026-07-23T18:56:34+00:00'
+  updated: '2026-07-23T18:56:36+00:00'
+spec:
+  title: Release aibox v0.28.7 infrastructure checksum verification fix
+  state: in-progress
+  type: bug
+  priority: high
+  description: Prepare and publish the v0.28.7 patch release containing the OpenTofu
+    and Packer archive checksum verification fix. Validate the release line, publish
+    repository-side Linux assets and docs, then hand off macOS/GHCR Phase 2 to the
+    owner.
+  started_at: '2026-07-23T18:56:36+00:00'
+---
+
+## Transition note (2026-07-23T18:56:36+00:00)
+
+Release preparation started on v0.x-release.


### PR DESCRIPTION
Promotes the validated v0.28.7 release candidate to v0.x-release.