### PR TITLE
chore: track v0.28.7 host release phase

### DIFF
--- a/context/logs/2026/07/LOG-20260723_1910-BuoyantPond-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_1910-BuoyantPond-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1910-BuoyantPond-workitem-transitioned
+  created: '2026-07-23T19:10:56+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T19:10:56+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix'
+    from 'in-progress' to 'review'
+  subject: BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix
+  subject_kind: WorkItem
+  actor: BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix
+---

--- a/context/workitems/2026/07/BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix.md
+++ b/context/workitems/2026/07/BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix.md
@@ -4,10 +4,10 @@ kind: WorkItem
 metadata:
   id: BACK-20260723_1856-CuriousDeer-release-v0287-infrastructure-checksum-fix
   created: '2026-07-23T18:56:34+00:00'
-  updated: '2026-07-23T18:56:36+00:00'
+  updated: '2026-07-23T19:10:56+00:00'
 spec:
   title: Release aibox v0.28.7 infrastructure checksum verification fix
-  state: in-progress
+  state: review
   type: bug
   priority: high
   description: Prepare and publish the v0.28.7 patch release containing the OpenTofu
@@ -20,3 +20,8 @@ spec:
 ## Transition note (2026-07-23T18:56:36+00:00)
 
 Release preparation started on v0.x-release.
+
+
+## Transition note (2026-07-23T19:10:56+00:00)
+
+Repository-side v0.28.7 release published and verified: GitHub release has Linux archives/checksums and LICENSE; docs deployed. Awaiting owner-run macOS/GHCR Phase 2.


### PR DESCRIPTION
Tracks the owner-run macOS/GHCR Phase 2 for v0.28.7.