### PR TITLE
fix: install pip before Ansible

### DIFF
--- a/addons/tools/infrastructure.yaml
+++ b/addons/tools/infrastructure.yaml
@@ -73,6 +73,9 @@ runtime: |
   COPY --from=infra-builder /build/bin/packer /usr/local/bin/packer
   {% endif %}
   {% if tools.ansible.enabled %}
+  RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3-pip \
+      && rm -rf /var/lib/apt/lists/*
   RUN pip3 install --no-cache-dir 'ansible=={{ tools.ansible.version }}'
   {% endif %}
   # ── Variant 1 disable-then-purge guards ───────────────────────────────

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1343,6 +1343,24 @@ runtime: |
     }
 
     #[test]
+    fn infrastructure_runtime_installs_pip_before_ansible() {
+        let addon = load_repo_addon("infrastructure");
+        let tools = all_enabled_tools(&addon);
+        let rendered = render_runtime(&addon, &tools).unwrap();
+
+        let pip_install = rendered
+            .find("python3-pip")
+            .expect("enabled Ansible must install python3-pip: {rendered}");
+        let ansible_install = rendered
+            .find("pip3 install --no-cache-dir 'ansible==")
+            .expect("enabled Ansible must be installed with pip3: {rendered}");
+        assert!(
+            pip_install < ansible_install,
+            "python3-pip must be installed before pip3 installs Ansible: {rendered}"
+        );
+    }
+
+    #[test]
     fn purge_cloud_aws_uninstalls_when_disabled() {
         let addon = load_repo_addon("cloud-aws");
         let tools = all_disabled_tools(&addon);

--- a/context/logs/2026/07/LOG-20260723_1923-RapidRose-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260723_1923-RapidRose-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1923-RapidRose-workitem-transitioned
+  created: '2026-07-23T19:23:20+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-23T19:23:20+00:00'
+  summary: Transitioned WorkItem 'BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon
+  subject_kind: WorkItem
+  actor: BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon
+---

--- a/context/logs/2026/07/LOG-20260723_1923-StrongFern-workitem-created.md
+++ b/context/logs/2026/07/LOG-20260723_1923-StrongFern-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260723_1923-StrongFern-workitem-created
+  created: '2026-07-23T19:23:13+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-07-23T19:23:13+00:00'
+  summary: 'Created WorkItem ''BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon'':
+    ''Fix Ansible installer dependency in infrastructure addon'''
+  subject: BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon
+  subject_kind: WorkItem
+  actor: BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon
+---

--- a/context/workitems/2026/07/BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon.md
+++ b/context/workitems/2026/07/BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon.md
@@ -1,0 +1,22 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon
+  created: '2026-07-23T19:23:13+00:00'
+  updated: '2026-07-23T19:23:20+00:00'
+spec:
+  title: Fix Ansible installer dependency in infrastructure addon
+  state: in-progress
+  type: bug
+  priority: high
+  description: Derived projects enable the infrastructure addon by default, which
+    renders `pip3 install ansible` although the base runtime image has no pip3. Install
+    the required Python pip package before Ansible and port the source change to v0.x
+    and v1.x.
+  started_at: '2026-07-23T19:23:20+00:00'
+---
+
+## Transition note (2026-07-23T19:23:20+00:00)
+
+Investigating derived Dockerfile failure caused by missing pip3 before Ansible installation.


### PR DESCRIPTION
Ensures the infrastructure addon installs python3-pip before rendering its Ansible pip installation. Fixes derived Dockerfile builds without the Python addon.