### PR TITLE
chore: advance v0 port baseline

### DIFF
--- a/.github/version-line-port-baselines.toml
+++ b/.github/version-line-port-baselines.toml
@@ -1,4 +1,4 @@
 # Enforcement begins after these branch commits. Earlier history predates the
 # cross-line port contract and is intentionally grandfathered.
-v0 = "e785d1f2e22d8bf90886f979773b63c28885d7e5"
+v0 = "ec9530fa9e7275f7d2a77efee4adbe2267b17714"
 v1 = "6266f1e9fd8c4bd90130203d8c46f392a1480ea4"


### PR DESCRIPTION
Grandfathers completed v0.28.7 release bookkeeping that predates its port trailers; subsequent commits remain enforced.