### PR TITLE
chore: release v0.28.8

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.28.7"
+version = "0.28.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.28.7"
+version = "0.28.8"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -578,6 +578,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.3",
         note: "Patch release: fixes OpenTofu and Packer addon checksum verification on amd64 and arm64 by preserving upstream archive filenames during checksum validation.",
     },
+    CompatEntry {
+        aibox_version: "0.28.8",
+        processkit_version: "v0.28.3",
+        note: "Patch release: makes the infrastructure addon self-sufficient by installing python3-pip before installing Ansible, so generated Dockerfiles build without the Python addon.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.


### PR DESCRIPTION
Promotes the validated v0.28.8 release candidate to v0.x-release.