### PR TITLE
fix: install Python addon CLIs in virtual environments

### DIFF
--- a/addons/languages/python.yaml
+++ b/addons/languages/python.yaml
@@ -74,14 +74,18 @@ runtime: |
 
   {% if tools.poetry.enabled %}
   RUN apt-get update && apt-get install -y --no-install-recommends \
-      python3-pip \
+      python3-venv \
       && rm -rf /var/lib/apt/lists/*
-  RUN pip3 install --no-cache-dir 'poetry=={{ tools.poetry.version }}'
+  RUN python3 -m venv /opt/aibox/poetry && \
+      /opt/aibox/poetry/bin/pip install --no-cache-dir 'poetry=={{ tools.poetry.version }}' && \
+      ln -sf /opt/aibox/poetry/bin/poetry /usr/local/bin/poetry
   {% endif %}
 
   {% if tools.pdm.enabled %}
   RUN apt-get update && apt-get install -y --no-install-recommends \
-      python3-pip \
+      python3-venv \
       && rm -rf /var/lib/apt/lists/*
-  RUN pip3 install --no-cache-dir 'pdm=={{ tools.pdm.version }}'
+  RUN python3 -m venv /opt/aibox/pdm && \
+      /opt/aibox/pdm/bin/pip install --no-cache-dir 'pdm=={{ tools.pdm.version }}' && \
+      ln -sf /opt/aibox/pdm/bin/pdm /usr/local/bin/pdm
   {% endif %}

--- a/addons/tools/cloud-azure.yaml
+++ b/addons/tools/cloud-azure.yaml
@@ -19,10 +19,15 @@ builder: null
 runtime: |
   # Addon: cloud-azure
   {% if tools["azure-cli"].enabled %}
-  RUN pip3 install --no-cache-dir azure-cli
+  RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3-venv \
+      && rm -rf /var/lib/apt/lists/*
+  RUN python3 -m venv /opt/aibox/azure-cli && \
+      /opt/aibox/azure-cli/bin/pip install --no-cache-dir azure-cli && \
+      ln -sf /opt/aibox/azure-cli/bin/az /usr/local/bin/az
   {% endif %}
   {% if not tools["azure-cli"].enabled %}
   # Variant 1 disable-then-purge: azure-cli installs as a pip package.
   USER root
-  RUN pip3 uninstall -y azure-cli azure-cli-core 2>/dev/null || true
+  RUN rm -rf /opt/aibox/azure-cli && rm -f /usr/local/bin/az
   {% endif %}

--- a/addons/tools/infrastructure.yaml
+++ b/addons/tools/infrastructure.yaml
@@ -74,9 +74,13 @@ runtime: |
   {% endif %}
   {% if tools.ansible.enabled %}
   RUN apt-get update && apt-get install -y --no-install-recommends \
-      python3-pip \
+      python3-venv \
       && rm -rf /var/lib/apt/lists/*
-  RUN pip3 install --no-cache-dir 'ansible=={{ tools.ansible.version }}'
+  RUN python3 -m venv /opt/aibox/ansible && \
+      /opt/aibox/ansible/bin/pip install --no-cache-dir 'ansible=={{ tools.ansible.version }}' && \
+      for bin in /opt/aibox/ansible/bin/ansible*; do \
+        ln -sf "$bin" "/usr/local/bin/$(basename "$bin")"; \
+      done
   {% endif %}
   # ── Variant 1 disable-then-purge guards ───────────────────────────────
   {% if not tools.opentofu.enabled %}
@@ -89,5 +93,5 @@ runtime: |
   {% endif %}
   {% if not tools.ansible.enabled %}
   USER root
-  RUN pip3 uninstall -y ansible ansible-core 2>/dev/null || true
+  RUN rm -rf /opt/aibox/ansible && rm -f /usr/local/bin/ansible*
   {% endif %}

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1343,21 +1343,50 @@ runtime: |
     }
 
     #[test]
-    fn infrastructure_runtime_installs_pip_before_ansible() {
+    fn infrastructure_runtime_installs_ansible_in_isolated_venv() {
         let addon = load_repo_addon("infrastructure");
         let tools = all_enabled_tools(&addon);
         let rendered = render_runtime(&addon, &tools).unwrap();
 
-        let pip_install = rendered
-            .find("python3-pip")
-            .expect("enabled Ansible must install python3-pip: {rendered}");
+        let venv_install = rendered
+            .find("python3-venv")
+            .expect("enabled Ansible must install python3-venv: {rendered}");
         let ansible_install = rendered
-            .find("pip3 install --no-cache-dir 'ansible==")
-            .expect("enabled Ansible must be installed with pip3: {rendered}");
+            .find("/opt/aibox/ansible/bin/pip install --no-cache-dir 'ansible==")
+            .expect("enabled Ansible must be installed in its virtual environment: {rendered}");
         assert!(
-            pip_install < ansible_install,
-            "python3-pip must be installed before pip3 installs Ansible: {rendered}"
+            venv_install < ansible_install,
+            "python3-venv must be installed before the Ansible virtual environment: {rendered}"
         );
+        assert!(
+            rendered.contains("ln -sf \"$bin\" \"/usr/local/bin/$(basename \"$bin\")\""),
+            "Ansible commands must be exposed on PATH: {rendered}"
+        );
+    }
+
+    #[test]
+    fn pip_packaged_runtime_tools_use_isolated_venvs() {
+        for (addon_name, venv, command) in [
+            ("cloud-azure", "azure-cli", "az"),
+            ("python", "poetry", "poetry"),
+            ("python", "pdm", "pdm"),
+        ] {
+            let addon = load_repo_addon(addon_name);
+            let tools = all_enabled_tools(&addon);
+            let rendered = render_runtime(&addon, &tools).unwrap();
+            let venv_path = format!("/opt/aibox/{venv}/bin/pip install");
+            let command_path = format!("/opt/aibox/{venv}/bin/{command}");
+            assert!(
+                rendered.contains("python3-venv")
+                    && rendered.contains(&venv_path)
+                    && rendered.contains(&command_path),
+                "{addon_name} must install {command} through the {venv} virtual environment: {rendered}"
+            );
+            assert!(
+                !rendered.contains("RUN pip3 install"),
+                "{addon_name} must not install Python packages into Debian's externally managed Python: {rendered}"
+            );
+        }
     }
 
     #[test]
@@ -1372,13 +1401,13 @@ runtime: |
     }
 
     #[test]
-    fn purge_cloud_azure_pip_uninstalls_when_disabled() {
+    fn purge_cloud_azure_removes_venv_when_disabled() {
         let addon = load_repo_addon("cloud-azure");
         let tools = all_disabled_tools(&addon);
         let rendered = render_runtime(&addon, &tools).unwrap();
         assert!(
-            rendered.contains("pip3 uninstall -y azure-cli"),
-            "disabled azure-cli must pip uninstall: {rendered}"
+            rendered.contains("rm -rf /opt/aibox/azure-cli"),
+            "disabled azure-cli must remove its virtual environment: {rendered}"
         );
     }
 


### PR DESCRIPTION
Fixes the downstream Debian PEP 668 build failure.\n\n- install pip-distributed addon CLIs in isolated venvs\n- expose CLIs through /usr/local/bin\n- cover all affected recipes with renderer tests\n\nRefs: BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon