### PR TITLE
chore: release v0.28.9

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.28.8"
+version = "0.28.9"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1429,7 +1429,8 @@ runtime: |
         let rendered = render_runtime(&addon, &tools).unwrap();
         assert!(rendered.contains("rm -f /usr/local/bin/tofu"));
         assert!(rendered.contains("rm -f /usr/local/bin/packer"));
-        assert!(rendered.contains("pip3 uninstall -y ansible"));
+        assert!(rendered.contains("rm -rf /opt/aibox/ansible"));
+        assert!(rendered.contains("rm -f /usr/local/bin/ansible*"));
     }
 
     #[test]

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -583,6 +583,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.3",
         note: "Patch release: makes the infrastructure addon self-sufficient by installing python3-pip before installing Ansible, so generated Dockerfiles build without the Python addon.",
     },
+    CompatEntry {
+        aibox_version: "0.28.9",
+        processkit_version: "v0.28.3",
+        note: "Patch release: installs Ansible, Poetry, PDM, and Azure CLI in isolated virtual environments so generated Debian trixie Dockerfiles comply with PEP 668 while keeping their commands available on PATH.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.


### PR DESCRIPTION
Promotes the validated v0.28.9 release candidate to v0.x-release.