### PR TITLE
test: align v1 Ansible purge assertion

### DIFF
--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1429,7 +1429,8 @@ runtime: |
         let rendered = render_runtime(&addon, &tools).unwrap();
         assert!(rendered.contains("rm -f /usr/local/bin/tofu"));
         assert!(rendered.contains("rm -f /usr/local/bin/packer"));
-        assert!(rendered.contains("pip3 uninstall -y ansible"));
+        assert!(rendered.contains("rm -rf /opt/aibox/ansible"));
+        assert!(rendered.contains("rm -f /usr/local/bin/ansible*"));
     }
 
     #[test]


### PR DESCRIPTION
Updates the v1 test to match the isolated Ansible virtual-environment cleanup shipped in v0.28.9.\n\nVersion-Line-Port: ported-from=76f4c586fe560ee94b91429b72f058d6a05dc61f