### PR TITLE
fix: install cloudflared from Cloudflare repository

### DIFF
--- a/addons/tools/cloudflare.yaml
+++ b/addons/tools/cloudflare.yaml
@@ -1,0 +1,38 @@
+name: cloudflare
+version: "1.0.0"
+description: "Cloudflare Tunnel connector (cloudflared)"
+profile_intent: runtime
+usage_class: automated
+profiles: ["human-dev", "headless-runner"]
+exported_surfaces: ["cli-binary", "config-files"]
+builder_weight: null
+
+tools:
+  - name: cloudflared
+    description: "Cloudflare Tunnel connector and command-line client"
+    default_enabled: true
+    default_version: ""
+    supported_versions: []
+
+builder: null
+
+runtime: |
+  # Addon: cloudflare
+  {% if tools.cloudflared.enabled %}
+  # cloudflared is not in Debian's archive. Install it from Cloudflare's
+  # signed package repository, which supports both amd64 and arm64.
+  USER root
+  RUN mkdir -p --mode=0755 /usr/share/keyrings && \
+      curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
+        -o /usr/share/keyrings/cloudflare-main.gpg && \
+      echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main" > /etc/apt/sources.list.d/cloudflared.list && \
+      apt-get update && apt-get install -y --no-install-recommends cloudflared && \
+      rm -rf /var/lib/apt/lists/*
+  {% endif %}
+  {% if not tools.cloudflared.enabled %}
+  USER root
+  RUN if dpkg-query -W -f='${Status}' cloudflared 2>/dev/null | grep -q 'install ok installed'; then \
+        apt-get purge -y --auto-remove cloudflared && rm -rf /var/lib/apt/lists/*; \
+      fi && \
+      rm -f /etc/apt/sources.list.d/cloudflared.list /usr/share/keyrings/cloudflare-main.gpg
+  {% endif %}

--- a/cli/src/addon_registry.rs
+++ b/cli/src/addon_registry.rs
@@ -169,6 +169,7 @@ mod tests {
         assert!(get_addon("latex").is_some());
         assert!(get_addon("kubernetes").is_some());
         assert!(get_addon("cloud-aws").is_some());
+        assert!(get_addon("cloudflare").is_some());
         assert!(get_addon("docs-zensical").is_some());
     }
 

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -593,6 +593,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.3",
         note: "Patch release: reconciles the standard processkit skills, recommends tooling-linked skills interactively, upgrades prerelease processkit surfaces, and serializes release Tier 2 E2E validation for the shared companion.",
     },
+    CompatEntry {
+        aibox_version: "0.28.11",
+        processkit_version: "v0.28.3",
+        note: "Patch release: adds the Cloudflare addon, installing cloudflared from Cloudflare's signed repository instead of Debian's archive so generated trixie images build on amd64 and arm64.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/cli/tests/e2e/addon_disablement.rs
+++ b/cli/tests/e2e/addon_disablement.rs
@@ -262,6 +262,62 @@ gcloud-cli = { enabled = false }
     );
 }
 
+// ─── H1-e2: cloudflare — cloudflared disabled ──────────────────────────────
+
+#[test]
+fn cloudflare_default_uses_signed_vendor_repository() {
+    let toml = r#"[aibox]
+version = "0.28.10"
+base = "debian"
+
+[container]
+name = "h1-cloudflare"
+
+[processkit]
+version = "unset"
+
+[addons.cloudflare.tools]
+cloudflared = {}
+"#;
+
+    let dockerfile = render_dockerfile(toml);
+
+    assert!(
+        dockerfile.contains("https://pkg.cloudflare.com/cloudflare-main.gpg")
+            && dockerfile.contains("https://pkg.cloudflare.com/cloudflared any main")
+            && dockerfile.contains("apt-get install -y --no-install-recommends cloudflared"),
+        "Dockerfile must install cloudflared from Cloudflare's signed repository:\n{dockerfile}"
+    );
+}
+
+#[test]
+fn cloudflare_disabled_omits_repo_install_and_adds_purge() {
+    let toml = r#"[aibox]
+version = "0.28.10"
+base = "debian"
+
+[container]
+name = "h1-cloudflare"
+
+[processkit]
+version = "unset"
+
+[addons.cloudflare.tools]
+cloudflared = { enabled = false }
+"#;
+
+    let dockerfile = render_dockerfile(toml);
+
+    assert!(
+        !dockerfile.contains("https://pkg.cloudflare.com/cloudflared"),
+        "Dockerfile must not add the Cloudflare repository when cloudflared is disabled:\n{dockerfile}"
+    );
+    assert!(
+        dockerfile.contains("apt-get purge -y --auto-remove cloudflared"),
+        "Dockerfile must purge cloudflared when disabled:\n{dockerfile}"
+    );
+}
+
 // ─── H1-f: infrastructure — opentofu and packer disabled ─────────────────────
 
 #[test]

--- a/docs-site/docs/addons/overview.md
+++ b/docs-site/docs/addons/overview.md
@@ -130,6 +130,7 @@ agents pick them up via skill descriptions, not via addon membership:
 | `latex` / `typst` | `documentation` |
 | `git-ui` | `git-workflow` |
 | `kubernetes` | `container-orchestration` |
+| `cloudflare` | Cloudflare Tunnel workflows |
 | `infrastructure` | terraform-flavoured patterns shipped upstream |
 
 See [Skills (via processkit)](../skills/index.md) for the full split.

--- a/docs-site/docs/reference/compatibility.md
+++ b/docs-site/docs/reference/compatibility.md
@@ -12,6 +12,8 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.28.11 | v0.28.3 | adds the `cloudflare` addon, which installs cloudflared from Cloudflare's signed package repository rather than Debian's archive |
+| 0.28.10 | v0.28.3 | reconciles standard processkit skills, recommends tooling-linked skills interactively, upgrades prerelease processkit surfaces, and serializes release Tier 2 E2E validation |
 | 0.28.6 | v0.28.3 | fixes Kubernetes addon checksum verification for Helm, Kustomize, and k9s archives on amd64 and arm64; and integrates processkit v0.28.3 authenticated GitHub repository reconciliation |
 | 0.28.5 | v0.28.1 | fixes Hermes Agent installation under the non-root runtime model; restores configured lazygit runtime surfaces; completes processkit reconciliation; and enforces traceable ports between maintained v0.x and v1.x lines |
 | 0.28.4 | v0.28.1 | integrates processkit v0.28.1 and refreshes the maintained v0.x processkit compatibility baseline |


### PR DESCRIPTION
Adds a cloudflare addon that installs cloudflared through Cloudflare signed repository instead of Debian trixie apt, with enable and disable rendering coverage.