### PR TITLE
chore: release v0.28.11

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.28.10"
+version = "0.28.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.28.10"
+version = "0.28.11"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -230,6 +230,7 @@ main() {
     tools/cloud-aws.yaml
     tools/cloud-gcp.yaml
     tools/cloud-azure.yaml
+    tools/cloudflare.yaml
     tools/audio-voice.yaml
     tools/data-preview.yaml
     tools/git-ui.yaml


### PR DESCRIPTION
Promotes the validated v0.28.11 release candidate to v0.x-release.