### PR TITLE
chore: integrate processkit v0.28.4

### DIFF
--- a/cli/src/processkit_vocab.rs
+++ b/cli/src/processkit_vocab.rs
@@ -173,7 +173,7 @@ pub const TIER_SPECIFIC_MCP_SKILLS: &[&str] = &[
 /// constant serves as the canonical reference for tests and documentation.
 // Used in #[cfg(test)] blocks across multiple modules and in documentation.
 #[allow(dead_code)]
-pub const PROCESSKIT_DEFAULT_VERSION: &str = "v0.28.3";
+pub const PROCESSKIT_DEFAULT_VERSION: &str = "v0.28.4";
 
 // ---------------------------------------------------------------------------
 // v0.26.0 — RoleSlot MCP tools (team-manager skill)


### PR DESCRIPTION
Integrates the latest stable processkit v0.x release. FORMAT.md is unchanged; targeted vocabulary, full tests, and release doctors pass. Deferred non-security dependency refresh: BACK-20260724_1938-SoundMoss.