### PR TITLE
feat(tmux): show open forge discussions

### DIFF
--- a/cli/src/container.rs
+++ b/cli/src/container.rs
@@ -1855,7 +1855,9 @@ pub(crate) fn serialize_config_with_comments(config: &AiboxConfig) -> String {
     );
     out.push_str("#   not poll live clusters and does not need second-level freshness.\n");
     out.push_str("# cloud-cache-ttl-seconds: local cloud CLI/context cache TTL; this avoids auth/network probes.\n");
-    out.push_str("# github-cache-ttl-seconds: local repo + GitHub issue/PR count cache TTL.\n");
+    out.push_str(
+        "# github-cache-ttl-seconds: local repo + GitHub issue/PR/discussion count cache TTL.\n",
+    );
     let refresh = &config.customization.tmux.status.refresh;
     out.push_str(&format!(
         "interval-seconds = {}\n",

--- a/context/logs/2026/07/LOG-20260725_2052-QuickLark-workitem-created.md
+++ b/context/logs/2026/07/LOG-20260725_2052-QuickLark-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260725_2052-QuickLark-workitem-created
+  created: '2026-07-25T20:52:03+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-07-25T20:52:03+00:00'
+  summary: 'Created WorkItem ''BACK-20260725_2052-ResoluteMoss-tmux-forge-open-discussions'':
+    ''Show open GitHub Discussions in tmux forge status'''
+  subject: BACK-20260725_2052-ResoluteMoss-tmux-forge-open-discussions
+  subject_kind: WorkItem
+  actor: BACK-20260725_2052-ResoluteMoss-tmux-forge-open-discussions
+---

--- a/context/logs/2026/07/LOG-20260725_2057-CheerfulTide-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260725_2057-CheerfulTide-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260725_2057-CheerfulTide-workitem-transitioned
+  created: '2026-07-25T20:57:07+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-25T20:57:07+00:00'
+  summary: Transitioned WorkItem 'BACK-20260725_2052-ResoluteMoss' from 'backlog'
+    to 'in-progress'
+  subject: BACK-20260725_2052-ResoluteMoss
+  subject_kind: WorkItem
+  actor: BACK-20260725_2052-ResoluteMoss
+---

--- a/context/logs/2026/07/LOG-20260725_2100-BrightClover-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260725_2100-BrightClover-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260725_2100-BrightClover-workitem-transitioned
+  created: '2026-07-25T21:00:51+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-25T21:00:51+00:00'
+  summary: Transitioned WorkItem 'BACK-20260725_2052-ResoluteMoss' from 'in-progress'
+    to 'review'
+  subject: BACK-20260725_2052-ResoluteMoss
+  subject_kind: WorkItem
+  actor: BACK-20260725_2052-ResoluteMoss
+---

--- a/context/logs/2026/07/LOG-20260725_2101-AssuredDeer-workitem-archive-moved.md
+++ b/context/logs/2026/07/LOG-20260725_2101-AssuredDeer-workitem-archive-moved.md
@@ -1,0 +1,16 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260725_2101-AssuredDeer-workitem-archive-moved
+  created: '2026-07-25T21:01:02+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-07-25T21:01:02+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260725_2052-ResoluteMoss' to /workspace/context/workitems/done/2026/07/BACK-20260725_2052-ResoluteMoss-tmux-forge-open-discussions.md
+  subject: BACK-20260725_2052-ResoluteMoss
+  subject_kind: WorkItem
+  actor: BACK-20260725_2052-ResoluteMoss
+  details:
+    path: /workspace/context/workitems/done/2026/07/BACK-20260725_2052-ResoluteMoss-tmux-forge-open-discussions.md
+---

--- a/context/logs/2026/07/LOG-20260725_2101-StoutAnt-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260725_2101-StoutAnt-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260725_2101-StoutAnt-workitem-transitioned
+  created: '2026-07-25T21:01:02+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-25T21:01:02+00:00'
+  summary: Transitioned WorkItem 'BACK-20260725_2052-ResoluteMoss' from 'review' to
+    'done'
+  subject: BACK-20260725_2052-ResoluteMoss
+  subject_kind: WorkItem
+  actor: BACK-20260725_2052-ResoluteMoss
+---

--- a/context/workitems/done/2026/07/BACK-20260725_2052-ResoluteMoss-tmux-forge-open-discussions.md
+++ b/context/workitems/done/2026/07/BACK-20260725_2052-ResoluteMoss-tmux-forge-open-discussions.md
@@ -1,0 +1,34 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260725_2052-ResoluteMoss-tmux-forge-open-discussions
+  created: '2026-07-25T20:52:03+00:00'
+  updated: '2026-07-25T21:01:02+00:00'
+spec:
+  title: Show open GitHub Discussions in tmux forge status
+  state: done
+  type: bug
+  priority: medium
+  description: Extend the aibox-shipped PowerKit forge plugin on both v0.x and v1.x
+    to count repository-global open GitHub Discussions, render them alongside open
+    issues and pull requests, degrade gracefully when Discussions or GraphQL access
+    is unavailable, and cover command construction plus rendering with focused regression
+    tests.
+  started_at: '2026-07-25T20:57:07+00:00'
+  completed_at: '2026-07-25T21:01:02+00:00'
+---
+
+## Transition note (2026-07-25T20:57:07+00:00)
+
+Implemented exact repository-global GraphQL totalCount metrics for open issues, pull requests, and Discussions on v0.x; focused shell, rendering, and Rust configuration tests pass. Porting the same change to v1.x.
+
+
+## Transition note (2026-07-25T21:00:51+00:00)
+
+Both version-line commits are clean. Focused forge tests, bash syntax, cargo fmt, zero-warning clippy, and the complete Rust test suites pass on v0.x and v1.x.
+
+
+## Transition note (2026-07-25T21:01:02+00:00)
+
+Implemented and validated on both v0.x and v1.x. GitHub issue, pull-request, and Discussion counts are exact repository-global GraphQL totals; Discussions render as D<count> and failures degrade independently.

--- a/docs-site/docs/reference/configuration.md
+++ b/docs-site/docs/reference/configuration.md
@@ -188,7 +188,7 @@ elements-spacing = "both"
 # netspeed-cache-ttl-seconds: network throughput cache TTL.
 # kubernetes-cache-ttl-seconds: local kubeconfig context cache TTL.
 # cloud-cache-ttl-seconds: local cloud CLI/context cache TTL.
-# github-cache-ttl-seconds: local repo + GitHub issue/PR count cache TTL.
+# github-cache-ttl-seconds: local repo + GitHub issue/PR/discussion count cache TTL.
 interval-seconds = 15
 aibox-metrics-cache-ttl-seconds = 30
 netspeed-cache-ttl-seconds = 10

--- a/images/base-debian/config/tmux/powerkit-plugins/forge.sh
+++ b/images/base-debian/config/tmux/powerkit-plugins/forge.sh
@@ -2,7 +2,7 @@
 # aibox-shipped PowerKit plugin: forge — multi-provider git forge status.
 #
 # Auto-detects the hosting provider from `git remote get-url origin` and
-# renders a "<LABEL> <branch> I<issues> P<prs>" segment with graceful
+# renders a "<LABEL> <branch> I<issues> P<prs> D<discussions>" segment with graceful
 # degradation when network calls fail or credentials are absent.
 #
 # Supported providers:
@@ -22,7 +22,7 @@
 # Configuration options (all via tmux set -g @powerkit_plugin_forge_<name>):
 #   label         Override the provider label (e.g. "MY" for a custom Gitea).
 #   show_branch   Show current branch name (default true).
-#   show_counts   Fetch and show open issue/PR counts (default true).
+#   show_counts   Fetch and show open issue/PR/discussion counts (default true).
 #   timeout       Network call timeout in seconds (default 3).
 #   cache_ttl     Cache lifetime in seconds (default 120).
 #   github_hosts  Whitespace-separated GitHub hostnames and SSH aliases (default github.com).
@@ -42,7 +42,7 @@ POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && p
 plugin_get_metadata() {
     metadata_set "id" "forge"
     metadata_set "name" "Forge"
-    metadata_set "description" "Display git forge branch plus open issue and PR counts (multi-provider)"
+    metadata_set "description" "Display git forge branch plus open issue, PR, and discussion counts (multi-provider)"
 }
 
 # =============================================================================
@@ -52,7 +52,7 @@ plugin_get_metadata() {
 plugin_declare_options() {
     declare_option "label"         "string" ""    "Segment label override (empty = auto from provider)"
     declare_option "show_branch"   "bool"   "true" "Show the current git branch"
-    declare_option "show_counts"   "bool"   "true" "Show open issue and PR counts"
+    declare_option "show_counts"   "bool"   "true" "Show open issue, PR, and discussion counts"
     declare_option "timeout"       "number" "3"   "Network call timeout in seconds"
     declare_option "cache_ttl"     "number" "120" "Cache duration in seconds"
     declare_option "github_hosts"  "string" "github.com" "Whitespace-separated GitHub hostnames and SSH aliases"
@@ -228,28 +228,36 @@ _urlencode() {
 # Count helpers
 # =============================================================================
 
-# GitHub: use gh CLI (matches upstream github.sh exactly)
+# GitHub: use independent GraphQL totalCount queries so the values are exact
+# and one unavailable metric does not suppress the other two.
 _gh_count_github() {
     local kind="$1" owner="$2" name="$3" timeout_s="$4"
     has_cmd gh || return 1
-    local repo="${owner}/${name}" count
+    local count query jq_filter
     case "$kind" in
         issues)
-            if has_cmd timeout; then
-                count="$(timeout "${timeout_s}s" gh issue list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null)" || return 1
-            else
-                count="$(gh issue list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null)" || return 1
-            fi
+            query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issues(states:OPEN){totalCount}}}'
+            jq_filter='.data.repository.issues.totalCount'
             ;;
         prs)
-            if has_cmd timeout; then
-                count="$(timeout "${timeout_s}s" gh pr list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null)" || return 1
-            else
-                count="$(gh pr list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null)" || return 1
-            fi
+            query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){pullRequests(states:OPEN){totalCount}}}'
+            jq_filter='.data.repository.pullRequests.totalCount'
+            ;;
+        discussions)
+            query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){discussions(first:1,states:OPEN){totalCount}}}'
+            jq_filter='.data.repository.discussions.totalCount'
             ;;
         *) return 1 ;;
     esac
+    if has_cmd timeout; then
+        count="$(timeout "${timeout_s}s" gh api graphql \
+            -f query="$query" -F owner="$owner" -F name="$name" \
+            --jq "$jq_filter" 2>/dev/null)" || return 1
+    else
+        count="$(gh api graphql \
+            -f query="$query" -F owner="$owner" -F name="$name" \
+            --jq "$jq_filter" 2>/dev/null)" || return 1
+    fi
     [[ "$count" =~ ^[0-9]+$ ]] || return 1
     printf '%s' "$count"
 }
@@ -335,7 +343,7 @@ _gh_count_gitea() {
 
 plugin_collect() {
     local remote url provider label owner repo_name api_base
-    local branch show_counts timeout_s issues prs
+    local branch show_counts timeout_s issues prs discussions
 
     # Must be inside a git repo
     _git rev-parse --is-inside-work-tree >/dev/null || return 0
@@ -369,6 +377,7 @@ plugin_collect() {
         github)
             issues="$(_gh_count_github issues "$owner" "$repo_name" "$timeout_s")" || issues=""
             prs="$(_gh_count_github prs    "$owner" "$repo_name" "$timeout_s")" || prs=""
+            discussions="$(_gh_count_github discussions "$owner" "$repo_name" "$timeout_s")" || discussions=""
             ;;
         gitlab)
             issues="$(_gh_count_gitlab issues "$owner" "$repo_name" "$timeout_s" "$api_base")" || issues=""
@@ -382,6 +391,7 @@ plugin_collect() {
 
     [[ -n "$issues" ]] && plugin_data_set "issues" "$issues"
     [[ -n "$prs" ]]    && plugin_data_set "prs"    "$prs"
+    [[ -n "$discussions" ]] && plugin_data_set "discussions" "$discussions"
 }
 
 # =============================================================================
@@ -389,7 +399,7 @@ plugin_collect() {
 # =============================================================================
 
 plugin_render() {
-    local label branch issues prs show_branch
+    local label branch issues prs discussions show_branch
     local -a parts=()
 
     # Only render when a provider was detected
@@ -406,8 +416,10 @@ plugin_render() {
 
     issues="$(plugin_data_get issues)"
     prs="$(plugin_data_get prs)"
+    discussions="$(plugin_data_get discussions)"
     [[ -n "$issues" ]] && parts+=("I${issues}")
     [[ -n "$prs" ]]    && parts+=("P${prs}")
+    [[ -n "$discussions" ]] && parts+=("D${discussions}")
 
     local IFS=' '
     printf '%s' "${parts[*]}"

--- a/scripts/test-forge-plugin.sh
+++ b/scripts/test-forge-plugin.sh
@@ -10,11 +10,16 @@ mkdir -p "$tmpdir/src/contract"
 printf '%s\n' \
     'get_option() {' \
     '    case "$1" in' \
+    '        show_branch) printf "true" ;;' \
     '        github_hosts) printf "%s" "${TEST_GITHUB_HOSTS:-github.com}" ;;' \
     '        gitea_hosts|forgejo_hosts) printf "" ;;' \
     '        *) printf "" ;;' \
     '    esac' \
-    '}' > "$tmpdir/src/contract/plugin_contract.sh"
+    '}' \
+    'declare -Ag TEST_PLUGIN_DATA=()' \
+    'plugin_data_set() { TEST_PLUGIN_DATA["$1"]="$2"; }' \
+    'plugin_data_get() { printf "%s" "${TEST_PLUGIN_DATA[$1]:-}"; }' \
+    > "$tmpdir/src/contract/plugin_contract.sh"
 
 POWERKIT_ROOT="$tmpdir"
 export POWERKIT_ROOT
@@ -49,7 +54,30 @@ has_cmd() { command -v "$1" >/dev/null; }
 TEST_GH_ARGS="$tmpdir/gh-args"
 export TEST_GH_ARGS
 [[ "$(_gh_count_github issues bnaard internal 1)" == "7" ]]
-[[ "$(<"$TEST_GH_ARGS")" == "issue list --repo bnaard/internal --state open --json number --jq length" ]]
+issue_args="$(<"$TEST_GH_ARGS")"
+[[ "$issue_args" == *"api graphql"* ]]
+[[ "$issue_args" == *"issues(states:OPEN)"* ]]
+[[ "$issue_args" == *"--jq .data.repository.issues.totalCount"* ]]
+
+[[ "$(_gh_count_github discussions bnaard internal 1)" == "7" ]]
+discussion_args="$(<"$TEST_GH_ARGS")"
+[[ "$discussion_args" == *"api graphql"* ]]
+[[ "$discussion_args" == *"states:OPEN"* ]]
+[[ "$discussion_args" == *"-F owner=bnaard -F name=internal"* ]]
+[[ "$discussion_args" == *"--jq .data.repository.discussions.totalCount"* ]]
+
+[[ "$(_gh_count_github prs bnaard internal 1)" == "7" ]]
+pr_args="$(<"$TEST_GH_ARGS")"
+[[ "$pr_args" == *"pullRequests(states:OPEN)"* ]]
+[[ "$pr_args" == *"--jq .data.repository.pullRequests.totalCount"* ]]
+
+plugin_data_set provider github
+plugin_data_set label GH
+plugin_data_set branch main
+plugin_data_set issues 2
+plugin_data_set prs 3
+plugin_data_set discussions 4
+[[ "$(plugin_render)" == "GH main I2 P3 D4" ]]
 
 TEST_GITHUB_HOSTS="github.com"
 _provider="" _label="" _owner="" _repo_name="" _api_base=""


### PR DESCRIPTION
## Summary

Port repository-global open GitHub Discussion counts to the tmux Forge segment on the v1.x line. The segment now renders D plus the count alongside exact GraphQL totals for issues and pull requests.

## Behavior

- I is the number of all open repository issues.
- P is the number of all open repository pull requests, independent of the checked-out branch.
- D is the number of all open repository Discussions; closed threads are excluded.
- Each metric degrades independently when unavailable.

## Validation

- Focused forge shell and rendering tests
- Bash syntax and cargo fmt
- Cargo clippy with warnings denied
- Full cargo test: 1131 unit, 88 E2E passed with 1 ignored, 41 integration

Refs: BACK-20260725_2052-ResoluteMoss