### PR TITLE
fix: restore processkit command projections

### DIFF
--- a/.agents/skills/pk-explain-routing/SKILL.md
+++ b/.agents/skills/pk-explain-routing/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: pk-explain-routing
+description: Use the model-recommender skill to explain the model-routing trace for $ARGUMENTS.
+---
+
+Use the model-recommender skill to explain the model-routing trace for $ARGUMENTS.

--- a/.agents/skills/pk-publish/SKILL.md
+++ b/.agents/skills/pk-publish/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: pk-publish
+description: Use the release-semver skill to execute the publish phase of the
+---
+
+Use the release-semver skill to execute the publish phase of the
+prepared release.

--- a/.agents/skills/pk-reconcile/SKILL.md
+++ b/.agents/skills/pk-reconcile/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: pk-reconcile
+description: "Use the project-reconciliation skill to reconcile the requested migration,"
+---
+
+Use the project-reconciliation skill to reconcile the requested migration,
+health, and repository queues with guarded remediation.

--- a/.agents/skills/pk-release/SKILL.md
+++ b/.agents/skills/pk-release/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: pk-release
+description: "Use the release-semver skill to prepare a $ARGUMENTS release: bump the"
+---
+
+Use the release-semver skill to prepare a $ARGUMENTS release: bump the
+version, curate and verify the matching CHANGELOG.md entry, create the tag
+on the designated release-integration branch, publish, and verify.

--- a/.agents/skills/pk-repo-reconcile/SKILL.md
+++ b/.agents/skills/pk-repo-reconcile/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: pk-repo-reconcile
+description: Use the repo-management skill to plan and apply guarded repository
+---
+
+Use the repo-management skill to plan and apply guarded repository
+reconciliation for $ARGUMENTS: inspect provider state, open issues,
+open change requests, local changes, commits, and pushes.

--- a/.agents/skills/pk-research/SKILL.md
+++ b/.agents/skills/pk-research/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: pk-research
+description: Use the research-with-confidence skill to investigate $ARGUMENTS with
+---
+
+Use the research-with-confidence skill to investigate $ARGUMENTS with
+explicit confidence labels on all findings.

--- a/.agents/skills/pk-supply-chain/SKILL.md
+++ b/.agents/skills/pk-supply-chain/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: pk-supply-chain
+description: Run the supply-chain-audit skill.
+---
+
+Run the supply-chain-audit skill.
+
+Default behavior:
+
+- Discover manifests under `--root` (or the project root).
+- Run local manifest checks only.
+- Keep security and quality probes off unless `--run-security`
+  and/or `--run-quality` are passed.

--- a/.agents/skills/pk-team-create/SKILL.md
+++ b/.agents/skills/pk-team-create/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: pk-team-create
+description: "Command: pk-team-create"
+---
+
+# Command: pk-team-create
+
+Full team derivation from scratch (v2 / catalog-driven). Selects
+catalog Roles via the archetype-catalog mapping, opens RoleSlots
+under the chartering Scope, fills them with TeamMembers, rewrites
+`context/team/roster.md`, and emits a chartering DecisionRecord that
+supersedes the prior team DecisionRecord. **No archetype Role
+entities are written.**
+
+## Syntax
+
+```
+pk-team-create
+  --chartering-scope <SCOPE-id>      # required — Scope that owns the team's RoleSlots
+  --subscription <provider>:<tier>   # e.g. anthropic:max-5x
+  --providers <list|"any">           # comma-separated; "any" = all accessible
+  --parallelism-cap <int>            # max RoleSlots opened per archetype, default 5
+  --governance-floor <0-5>           # G-score floor, default 3
+  [--weight-overrides <json>]        # {"C":0.60,"K":0.20,"L":0.10,"G":0.10}
+                                     # CLI > DEC-*-TeamWeights > skill defaults
+  [--threshold-overrides <json>]     # {"heavy_min":0.70,"medium_min":0.40}
+                                     # CLI > DEC-*-TeamWeights > skill defaults
+  [--landscape-artifact <ART-id>]    # explicit landscape override; skips discovery
+  [--landscape <artifact-id>]        # alias for --landscape-artifact (kept for compat)
+  [--archetype-catalog-mapping <path>]
+                                     # CLI override of the archetype→catalog
+                                     # mapping (replace mode). Project override
+                                     # at context/team/archetype-catalog-mapping.yaml
+                                     # is auto-detected; this flag wins over both.
+  [--budget-drift-threshold <float>] # drift alert threshold %, default 20
+  [--projection-method <method>]     # heuristic | model-recommender-quote | manual
+                                     # default: heuristic
+  [--dry-run]                        # print plan; write nothing
+```
+
+## Process (sequential)
+
+### Step 1 — Resolve landscape snapshot
+
+Three-level precedence (see `references/landscape-resolution.md`):
+
+1. If `--landscape-artifact <ART-id>` (or alias `--landscape`) is
+   supplied, load that artifact directly. Record
+   `inputs_snapshot.landscape_artifact_source: "explicit"`.
+2. Else query artifact index for the most-recently-created artifact
+   tagged both `landscape-summary` **and** `landscape-summary-project`
+   whose `spec.project_id` matches the current project context.
+   Record `inputs_snapshot.landscape_artifact_source: "project-tag"`.
+3. Else fall back to the most-recently-created artifact tagged
+   `landscape-summary` (kit default). Record
+   `inputs_snapshot.landscape_artifact_source: "kit-default"`.
+
+If no artifact is found at any level, **abort** with:
+> "No landscape-summary artifact found. Run the Haiku landscape-ingest
+> task to produce an ART-*-LandscapeSnapshot artifact before running
+> pk-team-create."
+
+If the resolved artifact is older than 90 days, emit a warning but
+continue. Record the artifact ID and its `created` date in the
+DecisionRecord `inputs_snapshot`.
+
+### Step 2 — Query accessible models
+
+```
+model-recommender.check_availability()
+model-recommender.query_models(
+  providers=<--providers>,
+  G_floor=<--governance-floor>,
+  apply_user_filter=true
+)
+model-recommender.get_pricing(sort_by="value_score")
+```
+
+Filter out any model with availability != "operational" unless the
+owner explicitly passes `--allow-degraded`.
+
+### Step 3 — Resolve weights + thresholds, then apply tiering formula
+
+**Weight resolution (before scoring):**
+
+```
+CLI --weight-overrides <json>
+  > DEC-*-TeamWeights.weight_overrides (tag: team-weights-override,
+      most recent accepted; see references/team-weights-decision-schema.md)
+    > skill defaults: {C:0.60, K:0.20, L:0.10, G:0.10}
+```
+
+**Threshold resolution (before classification):**
+
+```
+CLI --threshold-overrides <json>
+  > DEC-*-TeamWeights.tier_thresholds (same DEC; validated on load)
+    > skill defaults: {heavy_min:0.70, medium_min:0.40}
+```
+
+Validate any threshold override against the rules in
+`references/team-weights-decision-schema.md` (§Threshold validation
+rules). Violations are hard errors — abort before scoring.
+
+Record `inputs_snapshot.weights_source` and
+`inputs_snapshot.tier_thresholds_source` with the resolution level
+used (`"cli"`, `"dec-team-weights"`, or `"skill-default"`), and
+store the actual values in `inputs_snapshot.weights` and
+`inputs_snapshot.tier_thresholds`.
+
+**Scoring:**
+
+For each accessible candidate model `m`:
+
+1. Compute raw dimension values:
+   - `C_raw(m)` = (swe_bench_verified + swe_bench_pro +
+                   community_rating) / 3
+   - `K_raw(m)` = 1 / (output_price_per_1M × quota_burn_vs_flagship)
+   - `L_raw(m)` = output_tokens_per_sec
+   - `G_raw(m)` = G-score from model-recommender (0–5 scale,
+                  normalise to 0–1 by dividing by 5)
+
+2. Min-max normalise each dimension across the full candidate set:
+   `norm(x) = clamp((x - min) / (max - min), 0.01, 1.00)`
+
+3. Compute TierScore using resolved weights `{C, K, L, G}`:
+   `TierScore(m) = C×norm(C) + K×norm(K) + L×norm(L) + G×norm(G)`
+
+4. Classify using resolved thresholds:
+   - TierScore ≥ `heavy_min` → **heavy**
+   - TierScore ≥ `medium_min` and < `heavy_min` → **medium**
+   - TierScore < `medium_min` → **light**
+
+5. Tier-collapse rule: if fewer than 3 distinct tiers result, promote
+   the two highest-scoring light models to medium.
+
+See `references/tiering-formula.md` for the full formula and worked
+example.
+
+### Step 4 — Load archetype-catalog mapping + role-archetypes override, then map archetypes
+
+**Layer A — archetype-catalog mapping (eager validation — before archetype mapping):**
+
+Resolve the archetype → catalog `(ROLE-id, seniority)` mapping with
+three-level precedence:
+
+1. `--archetype-catalog-mapping <path>` flag (CLI; replace semantics).
+2. `context/team/archetype-catalog-mapping.yaml` (project; delta
+   semantics by default — top-level `override_semantics: replace`
+   switches to replace).
+3. Kit default: `assets/archetype-catalog-mapping.yaml` shipped with
+   the team-creator skill.
+
+Validate eagerly: every archetype entry must declare a `role` that
+starts with `ROLE-` and a non-empty `seniority`. Replace-mode
+overrides must list all 8 archetypes (missing archetypes are a hard
+error).
+
+Record:
+- `inputs_snapshot.archetype_catalog_mapping_file`: `"kit-default"`,
+  `"project"`, or `"cli"` — which layer was applied.
+- `inputs_snapshot.archetype_catalog_overrides`: per-archetype
+  per-field deltas relative to the kit default. Empty list when the
+  kit default was used verbatim.
+
+**Layer B — role-archetypes override (eager validation — before archetype mapping):**
+
+If `context/team/role-archetypes.yaml` exists, load it now and
+validate it immediately against the rules in
+`references/role-archetypes-override.md` (§Validation invariants).
+Validation failures are hard errors — abort before any mapping begins.
+This includes: PM pin must remain heavy, all rationales non-empty,
+all 8 archetypes present in `replace` mode. (The legacy
+`clone_cap_override` field is no longer accepted — capacity is the
+count of RoleSlots opened in step 6 below.)
+
+Record `inputs_snapshot.archetype_override_file: "present"` (or
+`"absent"`) and list each overridden role with its new pin and
+rationale summary in `inputs_snapshot.archetype_overrides`.
+
+**Archetype mapping:**
+
+For each of the 8 role archetypes:
+
+1. Select the archetype's pinned tier — from the (possibly-overridden)
+   archetype table. Kit defaults (`references/role-archetypes.md`)
+   apply for any archetype not listed in a delta override, or when no
+   override file is present.
+2. From the models classified into that tier, pick the highest TierScore.
+3. If preferred_providers are supplied and two models score within 0.05
+   of each other, prefer the model from the preferred provider.
+4. If the pinned tier has no candidates: apply the override-when rule
+   from the active archetype table; if no override applies, fail
+   with a clear message.
+5. Resolve the archetype's `(role, seniority)` pair via the mapping
+   from Layer A. Verify `role` is present in `context/roles/`; fail
+   with a clear message if the catalog Role file is missing.
+
+### Step 5 — Deactivate prior team (if re-running)
+
+If `context/team/roster.md` already exists:
+
+1. Parse the prior team's RoleSlot and Binding IDs from roster.md.
+2. For each prior `role-slot-fill` Binding:
+   `binding-management.end_binding(id, reason=
+     "superseded by pk-team-create run <ISO-timestamp>")`
+3. For each prior RoleSlot under the prior chartering Scope:
+   `team-manager.close_role_slot(id, reason=
+     "superseded by pk-team-create run <ISO-timestamp>")`.
+   The slot state machine forbids reopening — re-charters always
+   emit fresh `SLOT-*` IDs under the new chartering Scope. There is
+   no Actor-template / Actor-clone distinction in v2; capacity is
+   expressed by RoleSlot count, not by clone Actors.
+
+If the prior team predates v2 (its roster references v1
+`role-assignment` Bindings and archetype Roles), do NOT touch those
+entities. The Phase A migration apply script
+(`team-manager/scripts/apply_migration_2139.py`) is responsible for
+back-filling the v1 surface; pk-team-create only operates on the v2
+RoleSlot surface.
+
+### Step 6 — Write entities
+
+Skip if `--dry-run`.
+
+For each of the 8 archetypes, look up `(role, seniority)` in the
+mapping resolved in step 4. Open one RoleSlot per parallelism unit
+(rank 1..N, where N is `--parallelism-cap`; `project-manager` is
+always exactly 1 slot at rank=1):
+
+```
+team-manager.create_role_slot(
+  scope=<--chartering-scope>,
+  role=<ROLE-id from mapping>,
+  seniority=<seniority from mapping>,
+  rank=<int 1..N>,
+  rationale="archetype=<archetype-name> tier=<tier> "
+            "score=<tier-score> model=<model-id>",
+  default_model_profile=<ART-*-ModelProfile-*>     # optional
+)
+```
+
+Then, for each TeamMember selected to fill a slot:
+
+```
+team-manager.fill_role_slot(
+  id=<SLOT-id>,
+  team_member_slug=<team-member-slug>,
+  rationale="<why this person for this slot>",
+  valid_from=<today>,
+  valid_until=<chartering Scope's ends_at, if any>
+)
+```
+
+`fill_role_slot` writes the `role-slot-fill` Binding inline. No
+archetype Role, Actor, or `role-assignment` Binding is written by
+pk-team-create.
+
+Ephemeral archetypes that have no persistent TeamMember to assign
+(e.g. `assistant`, when handled by ad-hoc dispatch) leave the slot
+in `state=open` with a `default_model_profile` set; the resolver
+pre-step in `team-manager.get_interlocutor_runtime_binding` will
+return the open slot's profile for ephemeral lookups.
+
+### Step 7 — Write roster.md
+
+Write `context/team/roster.md` with:
+- Narrative preamble (team charter, subscription, governance floor)
+- Routing table: role → actor → model-id → tier → tier-score
+- Parallelism cap and PM clone-cap note
+- Weights used (from inputs or defaults)
+- Landscape artifact ID and date
+- DecisionRecord ID (written in step 8)
+
+### Step 7.5 — Compute budget projection
+
+After step 6 writes all RoleSlots and before writing the chartering
+DecisionRecord, iterate every created slot and compute a cost projection.
+
+For each RoleSlot:
+
+1. Call `model-recommender.get_pricing(<model_profile>)` to fetch the
+   live unit cost.  Snapshot the returned `price_per_token_usd` into
+   `unit_cost_usd` in the projection row.
+2. Determine the effective time window for the slot:
+   - If the slot is filled by a `type=consultant` TeamMember: intersect
+     the consultant's `engagement_window` with the chartering Scope's
+     `{starts_at, ends_at}`. Use the intersected window.
+   - Otherwise: use the chartering Scope's full window.
+3. Apply heuristic formula (when `--projection-method heuristic`):
+   ```
+   weeks = ceil(effective_window_days / 7)
+   projected_total_usd = unit_cost_usd
+                         × (avg_input_tokens + avg_output_tokens)
+                         × expected_invocations_per_week
+                         × weeks
+   ```
+   Defaults when not pinned by the landscape artifact:
+   - `expected_invocations_per_week`: 50
+   - `avg_tokens_per_invocation.input`: 8000
+   - `avg_tokens_per_invocation.output`: 2000
+
+4. Sum slot `projected_total_usd` values into `projected_total`.
+
+5. Build the `budget_projection` block (see shape in step 8 below).
+   Pass `drift_threshold_pct` from `--budget-drift-threshold` (default 20).
+
+Skip budget projection if the chartering Scope has no `starts_at`/`ends_at`
+dates; log a warning and set `budget_projection: null` in the snapshot.
+
+### Step 8 — Write chartering DecisionRecord
+
+```
+decision-record-write(
+  title="Team composition — <subscription> — <date>",
+  state="accepted",
+  supersedes=[<prior-team-decisionrecord-id>],  # if re-running
+  inputs_snapshot={
+    subscription: ...,
+    governance_floor: ...,
+    parallelism_cap: ...,
+    weights: {C, K, L, G},
+    weights_source: "cli" | "dec-team-weights" | "skill-default",
+    tier_thresholds: {heavy_min, medium_min},
+    tier_thresholds_source: "cli" | "dec-team-weights" | "skill-default",
+    landscape_artifact: <ART-id>,
+    landscape_artifact_date: <date>,
+    landscape_artifact_source: "explicit" | "project-tag" | "kit-default",
+    tier_scores: {<model-id>: <score>, ...},
+    weight_overrides_applied: <bool>,
+    # v2 catalog-mapping audit (additionalProperties=true on inputs_snapshot)
+    archetype_catalog_mapping_file:
+      "kit-default" | "project" | "cli",
+    archetype_catalog_overrides: [
+      {archetype, field, kit_default, project_value}, ...
+    ],
+    archetype_override_file: "present" | "absent",
+    archetype_override_semantics: "delta" | "replace" | null,
+    archetype_overrides: [...],   # list of {role, kit_default_pin, override_pin}
+    chartering_scope: <SCOPE-id>,
+    role_slots: [
+      {archetype, slot_id, role, seniority, rank}, ...
+    ],
+    # Gap 5 — budget projection (additionalProperties=true; additive)
+    budget_projection: {
+      currency: USD,
+      window: {starts_at: <ISO>, ends_at: <ISO>},  # = chartering Scope window
+      projected_total: <float>,
+      projection_method: heuristic | model-recommender-quote | manual,
+      slot_projections: [
+        {
+          slot: SLOT-<id>,
+          role: ROLE-<id>,
+          seniority: <enum>,
+          model_profile: ART-*-ModelProfile-*,
+          expected_invocations_per_week: <int>,
+          avg_tokens_per_invocation: {input: <int>, output: <int>},
+          unit_cost_usd: <float>,          # snapshotted from get_pricing at charter time
+          projected_total_usd: <float>,
+          effective_window: {starts_at: <ISO>, ends_at: <ISO>},
+        }, ...
+      ],
+      drift_threshold_pct: 20,             # from --budget-drift-threshold, default 20
+      notes: <free-text or null>,
+    }
+  }
+)
+```
+
+The `inputs_snapshot.weights` block is the canonical weight store
+that `pk-team-rebalance` will read on future runs. The
+`chartering_scope` and `role_slots` blocks are the v2 provenance
+back-pointer from the DEC to the RoleSlots opened in step 6.
+
+The `budget_projection` block is Gap 5 (SUB-4 / SwiftReef). It is
+additive (`additionalProperties: true` on the decision_record schema);
+old DecisionRecords without this block validate cleanly. The block is
+the source of truth that `pk-team-review` Step 5c reads for drift
+detection.
+
+## Dry-run output format
+
+```
+=== pk-team-create DRY RUN ===
+Subscription: <value>   Governance floor: <value>
+Chartering Scope: <SCOPE-id>
+Landscape: <artifact-id> (<date>)
+Weights: C=0.60 K=0.20 L=0.10 G=0.10
+Mapping source: kit-default | project | cli   (overrides: <count>)
+
+Candidate models scored:
+  <model-id>  TierScore=0.92  → heavy
+  <model-id>  TierScore=0.61  → medium
+  ...
+
+RoleSlot plan (per archetype):
+  project-manager  → ROLE-product-manager / senior  (heavy, score=0.92)
+    1 slot at rank=1, fill: TEAMMEMBER-<slug>, model=<model-id>
+  senior-architect → ROLE-solutions-architect / senior  (heavy, score=0.87)
+    N slots at rank=1..N, fill: TEAMMEMBER-<slug>, model=<model-id>
+  ...
+
+Entities to write (skipped in dry-run):
+  <total RoleSlot count> RoleSlot entities
+  <total fill count>     role-slot-fill Binding entities
+  context/team/roster.md
+  DecisionRecord superseding <DEC-id>
+===========================
+```
+
+## State side-effects (non-dry-run)
+
+Creates: one RoleSlot per parallelism unit (under the chartering
+Scope), one `role-slot-fill` Binding per filled slot, roster.md,
+1 DecisionRecord. Closes prior RoleSlots and ends prior
+`role-slot-fill` Bindings on re-charter. Does NOT write archetype
+Role entities, Actor entities, or `role-assignment` Bindings —
+those v1 surfaces are read-only during the deprecation window.

--- a/.agents/skills/pk-team-rebalance/SKILL.md
+++ b/.agents/skills/pk-team-rebalance/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: pk-team-rebalance
+description: "Command: pk-team-rebalance"
+---
+
+# Command: pk-team-rebalance
+
+Apply a `pk-team-review` recommendation. Targeted re-tiering of one or
+more roles without full team recreation. Requires `--confirm` to
+prevent accidental writes.
+
+## Syntax
+
+```
+pk-team-rebalance
+  --roles <list|"all">         # comma-separated role names, or "all"
+  --confirm                    # required; prevents accidental writes
+  --reason <string>            # recorded in the DecisionRecord amendment
+  [--landscape-artifact <ART-id>]  # explicit landscape override
+  [--landscape <artifact-id>]      # alias for --landscape-artifact
+  [--weight-overrides <json>]      # override stored weights for this run
+  [--threshold-overrides <json>]   # override stored thresholds for this run
+```
+
+## Process (sequential)
+
+### Step 1 — Load governing DecisionRecord + DEC-*-TeamWeights check
+
+```
+decision-record.get_decision(<governing-DEC-id>)
+```
+
+Read `spec.inputs_snapshot` to retrieve:
+- Stored formula weights (used unless `--weight-overrides` supplied)
+- `governance_floor`
+- `parallelism_cap`
+- The landscape artifact ID from the prior run
+
+**DEC-*-TeamWeights newer-than-governing-DEC check:**
+
+Query the decision index for the most-recent accepted DecisionRecord
+tagged `team-weights-override` (see
+`references/team-weights-decision-schema.md`). If one exists and its
+`metadata.created` is **newer** than the governing team
+DecisionRecord's `metadata.created`, emit this warning and do NOT
+silently apply the new weights:
+
+```
+WARNING: A newer DEC-*-TeamWeights record (created <ISO-date>)
+post-dates the governing team DecisionRecord (created <ISO-date>).
+Weight policy has changed since the last pk-team-create run. This
+targeted rebalance uses stored weights from the governing DEC.
+To apply the updated weights across all roles, run:
+  pk-team-rebalance --roles all --confirm --reason "<reason>"
+```
+
+CLI `--weight-overrides` and `--threshold-overrides` always override
+stored values regardless of DEC age.
+
+If `--roles all` is specified, re-run the full `pk-team-create` logic
+(steps 1–8 of `pk-team-create`) and write a new DecisionRecord instead
+of amending. The remainder of this document covers the non-`all`
+path.
+
+### Step 2 — Resolve landscape snapshot
+
+Same resolution logic as `pk-team-create` Step 1. If `--landscape` is
+not supplied, use the latest `landscape-summary` artifact. Warn if
+older than 90 days; do not block.
+
+### Step 3 — Resolve archetype names → catalog (role, seniority) and re-score
+
+`--roles` accepts archetype names (`developer`, `senior-architect`,
+...). Resolve each name through the archetype-catalog mapping
+(`assets/archetype-catalog-mapping.yaml`, layered with
+`context/team/archetype-catalog-mapping.yaml` if present) into the
+catalog `(ROLE-id, seniority)` pair. Operate on the matching
+`RoleSlot(s)` in the active chartering Scope.
+
+For each archetype in `--roles`:
+
+1. Look up `(role, seniority)` via the mapping. Abort if the
+   archetype is not present and no project override defines it.
+2. Query accessible models scoped to that archetype's pinned tier:
+   ```
+   model-recommender.query_models(
+     G_floor=<governance_floor>,
+     apply_user_filter=true
+   )
+   ```
+3. Apply the tiering formula with stored (or override) weights.
+4. Select the best-scoring candidate for the tier.
+5. If the best candidate is the same model currently filling the
+   archetype's RoleSlot(s): report "no change needed"; skip writes.
+
+### Step 4 — End old role-slot-fill Bindings
+
+For each archetype where a model change is needed, list the
+matching RoleSlots in the active chartering Scope via
+`team-manager.list_role_slots(scope=<chartering-scope>, role=<ROLE-id>,
+state="filled")`, then for each filled slot end its current fill
+Binding:
+
+```
+binding-management.end_binding(
+  id=<current-role-slot-fill-BIND-id>,
+  reason="superseded by pk-team-rebalance: <--reason> (<ISO-timestamp>)"
+)
+```
+
+### Step 5 — Re-fill the existing RoleSlots
+
+A targeted rebalance does NOT close-and-reopen the slot — capacity
+(slot count) hasn't changed; only the TeamMember and the model
+underneath it have. For each affected RoleSlot:
+
+```
+team-manager.fill_role_slot(
+  id=<SLOT-id>,
+  team_member_slug=<new-team-member-slug>,
+  rationale="rebalanced <ISO-timestamp>: <--reason> "
+            "(model: <new-model-id>, score: <score>)",
+  valid_from=<today>,
+  valid_until=<chartering Scope's ends_at, if any>
+)
+```
+
+(If the new TeamMember does not yet exist in `context/team-members/`,
+provision it first via the team-member skill. Ephemeral
+`(role, seniority)` dispatches that have no persistent TeamMember
+re-attach to the slot's `default_model_profile` instead — no fill
+write is needed.)
+
+### Step 6 — _(folded into step 5)_
+
+v1 split this into "create new role-assignment Binding"; v2's
+`fill_role_slot` writes the `role-slot-fill` Binding inline, so a
+separate step is no longer required.
+
+### Step 7 — Update roster.md in-place
+
+Rewrite the affected rows in `context/team/roster.md`'s routing table.
+Update the "Last rebalanced" timestamp and append the reason to the
+history section.
+
+### Step 8 — Amend governing DecisionRecord
+
+Append to the governing DecisionRecord's `progress_notes`:
+
+```
+Rebalanced on <ISO-timestamp> by <actor>:
+  Roles changed: <list>
+  Reason: <--reason>
+  New assignments: <role> → <model-id> (score: <score>)
+  Weights used: C=<C> K=<K> L=<L> G=<G>
+  Landscape: <artifact-id> (<date>)
+```
+
+A new DecisionRecord is NOT written unless `--roles all` is used.
+
+## The `--roles all` shortcut
+
+`pk-team-rebalance --roles all --confirm --reason "<reason>"` is
+equivalent to running `pk-team-create` with the stored weights and
+subscription, except:
+- A new DecisionRecord IS written (superseding the current one).
+- The deactivation sequence from `pk-team-create` Step 5 applies in full.
+
+Use this when the landscape has shifted so broadly that targeted
+rebalancing would touch every role anyway.
+
+## State side-effects
+
+Ends N old `role-slot-fill` Bindings. Re-fills the affected RoleSlots
+(no slot create/close — capacity is unchanged) and writes N new
+`role-slot-fill` Bindings via `team-manager.fill_role_slot`. Amends
+roster.md in-place. Appends to the governing DecisionRecord's
+`progress_notes`. Does NOT write a new DecisionRecord (unless
+`--roles all`).
+
+## Safety
+
+- `--confirm` is always required. The command prints the plan and
+  exits if `--confirm` is absent.
+- Dry-run preview is printed before writing, even with `--confirm`:
+  show the plan and ask for explicit "proceed" confirmation in
+  interactive mode; in non-interactive mode proceed immediately after
+  showing the plan.

--- a/.agents/skills/pk-team-review/SKILL.md
+++ b/.agents/skills/pk-team-review/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: pk-team-review
+description: "Command: pk-team-review"
+---
+
+# Command: pk-team-review
+
+Read-only health-check. Compares current team assignments against the
+latest landscape snapshot and surfaces tier-drift, unavailable models,
+and new outperformers. No entities are written.
+
+## Syntax
+
+```
+pk-team-review
+  [--landscape-artifact <ART-id>]  # explicit landscape override; skips discovery
+  [--landscape <artifact-id>]      # alias for --landscape-artifact
+  [--threshold <float>]            # flag if tier-score drifted > N pts, default 0.15
+  [--budget-scope <SCOPE-id>]      # filter budget drift query to a specific scope
+  [--budget-drift-threshold <float>]
+                                   # override the projection's drift_threshold_pct
+```
+
+## Process (sequential, read-only)
+
+### Step 1 — Load current team
+
+1. Read `context/team/roster.md` to get the active role → model mapping.
+2. Resolve the governing DecisionRecord (the most recent `pk-team-create`
+   DecisionRecord) via `decision-record.get_decision`.
+3. Extract stored formula weights and tier scores from
+   `spec.inputs_snapshot`. These are the baseline scores for the diff.
+4. Extract `landscape_artifact` ID and date from `inputs_snapshot`.
+
+### Step 2 — Load landscape snapshot
+
+Landscape resolution follows the same three-level precedence as
+`pk-team-create` (see `references/landscape-resolution.md`):
+
+1. If `--landscape-artifact <ART-id>` (or alias `--landscape`) is
+   supplied, load that artifact directly.
+2. Otherwise use the artifact ID stored in the governing DecisionRecord
+   `inputs_snapshot.landscape_artifact`. If neither is available,
+   apply the three-level discovery: project-tagged artifact first,
+   then kit default `landscape-summary`.
+3. If the artifact is older than 90 days, include a staleness warning
+   in the output. Do not block.
+
+### Step 3 — Re-score current assignments
+
+For each currently-assigned model:
+```
+model-recommender.get_pricing(<model-id>)
+model-recommender.get_profile(<model-id>)
+```
+
+Recompute `TierScore` using the weights from `inputs_snapshot`
+(not from `--weight-overrides` — the baseline uses stored weights).
+Apply the same normalisation across the current accessible candidate set.
+
+### Step 4 — Query for new candidates
+
+```
+model-recommender.query_models(
+  G_floor=<stored_governance_floor>,
+  apply_user_filter=true
+)
+```
+
+Score all accessible candidates with the stored weights. Identify any
+model that:
+- Would out-score the current assignment for its role by more than
+  `--threshold` (default 0.15).
+- Appeared in the landscape since the last `pk-team-create` run.
+
+### Step 5 — Detect unavailable models
+
+```
+model-recommender.check_availability()
+```
+
+Flag any currently-assigned model whose availability is `degraded`
+or `major_outage`.
+
+### Step 5b — Check consultant engagement windows
+
+Call `team-manager.query_consultant_findings()`.
+
+This returns findings with code `team.consultant.expired_but_active`
+(severity: warning) for every active TeamMember where `type=consultant`
+AND `engagement_window.ends_at < now`. Include the findings in the diff
+report (see CONSULTANT WARNINGS section below). This step is read-only.
+
+### Step 5c — Check budget drift
+
+Call `team-manager.query_budget_drift(scope_id?, threshold_pct?)`.
+
+Where:
+- `scope_id` = `--budget-scope` flag value (or omitted to auto-detect
+  from the governing DecisionRecord's `chartering_scope`).
+- `threshold_pct` = `--budget-drift-threshold` flag value (or omitted to
+  use the projection's stored `drift_threshold_pct`, default 20).
+
+**Logic inside `query_budget_drift`:**
+
+1. Read the most-recent chartering DecisionRecord that contains a
+   `budget_projection` block in its `inputs_snapshot`.
+2. If no `budget_projection` block is found: return `status=no_projection_on_file`
+   and emit an informational note in the diff report:
+   > "no budget projection on file — drift check skipped"
+3. Query event-log for invocation events within the chartering Scope's window
+   bound to the projection's RoleSlots.  Sum actual cost
+   (token counts × unit_cost_usd from the projection snapshot).
+4. Compute `drift_pct = (actual - projected) / projected × 100`.
+5. If `|drift_pct| > drift_threshold_pct`:
+   - Over-spend: emit finding `team.budget.drift`, severity **warning**
+     (actionable — consider rebalance or scope reduction).
+   - Under-spend: emit finding `team.budget.drift`, severity **info**
+     (capacity planning signal — model may be cheaper than expected or
+     invocation volume is lower than chartered).
+6. Include per-slot drift table in the BUDGET DRIFT section below.
+
+This step is fully read-only.
+
+### Step 6 — Emit diff report
+
+Output format (stdout only — no files written). Each row is keyed by
+**archetype name** (resolved through the
+`assets/archetype-catalog-mapping.yaml` mapping, layered with the
+project override) so the operator sees the same names accepted by
+`pk-team-rebalance --roles`. The underlying `(SLOT-id, ROLE-id,
+seniority)` tuple is shown in parentheses for traceability.
+
+```
+=== pk-team-review — <date> ===
+Baseline: DecisionRecord <DEC-id> (<pk-team-create date>)
+Chartering Scope: <SCOPE-id>
+Landscape: <artifact-id> (<artifact date>) [STALE: >90 days if applicable]
+Weights used: C=<C> K=<K> L=<K> G=<G>
+Threshold: <threshold>
+Mapping source: kit-default | project | cli   (overrides: <count>)
+
+TIER-DRIFT (score delta > threshold):
+  developer (SLOT-q2-2026-software-engineer-1, ROLE-software-engineer/senior):
+    <old-model-id> (baseline 0.62) → new score 0.44  ▼0.18
+    → Best alternative: <new-model-id> (score 0.71, heavy)
+    → Recommendation: rebalance this archetype
+
+UNAVAILABLE:
+  junior-developer (SLOT-q2-2026-software-engineer-2,
+                    ROLE-software-engineer/junior):
+    <model-id> — status: major_outage
+    → Best fallback: <model-id> (score 0.38, light)
+
+NEW OUTPERFORMERS:
+  assistant (SLOT-q2-2026-assistant-1, ROLE-assistant/specialist):
+    <new-model-id> (score 0.52) outperforms current
+    <model-id> (score 0.31) by 0.21 — within light tier, no tier-shift
+
+CONSULTANT WARNINGS [team.consultant.expired_but_active]:
+  <TEAMMEMBER-slug> (<name>, engaged_for: <SCOPE-id>):
+    engagement_window ended <ends_at> — still active
+    → deactivate or extend engagement_window via update_team_member
+
+BUDGET DRIFT [team.budget.drift | WARNING/INFO]:
+  Projected: $<projected_total>   Actual: $<actual_total>
+  Drift: <drift_pct>%  (threshold: ±<threshold_pct>%)
+  Direction: over-spend (WARNING — actionable) | under-spend (INFO)
+
+  Per-slot drift:
+    <SLOT-id> (<role>/<seniority>):
+      projected $<projected_total_usd>  actual $<actual_cost_usd>
+      drift <slot_drift_pct>% (<direction>)
+    ...
+
+  → over-spend: consider pk-team-rebalance or scope reduction
+  → under-spend: volume or price lower than chartered (no action required)
+
+  [If no budget_projection block in chartering DEC]:
+  BUDGET DRIFT: no budget projection on file — drift check skipped
+
+STABLE (no action needed):
+  project-manager, senior-architect, senior-researcher,
+  junior-architect, junior-researcher
+
+SUMMARY:
+  2 archetypes recommended for rebalance
+  1 archetype urgently needs replacement (major_outage)
+  1 consultant with expired engagement window (see CONSULTANT WARNINGS)
+  1 budget drift finding: over-spend +32% (see BUDGET DRIFT)
+  Run: pk-team-rebalance --roles developer,junior-developer --confirm \
+       --reason "<reason>"
+=============================
+```
+
+Omit empty sections. Always emit the SUMMARY even if no issues found.
+Include a count of consultant warnings in the SUMMARY line even when
+no other issues are detected.
+
+## State side-effects
+
+None. This command is fully read-only.
+
+## Distinction from pk-team-create
+
+`pk-team-review` reads and diffs; `pk-team-create` writes. Running
+`pk-team-review` is always safe and reversible. Only run `pk-team-create`
+or `pk-team-rebalance` when you have reviewed the diff and confirmed
+the recommended changes.


### PR DESCRIPTION
## Summary

Regenerates the ten Codex skill projections introduced by the processkit v0.28.4 integration. Clean release checkouts now satisfy the processkit command consistency gate.

## Validation

- generated through the aibox harness-command synchronizer
- staged diff passes git diff --check
- release doctors will be rerun before v0.28.13