### PR TITLE
chore: release v0.28.13

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.28.12"
+version = "0.28.13"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.28.12"
+version = "0.28.13"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -603,6 +603,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.4",
         note: "Patch release: integrates processkit v0.28.4 and makes companion E2E validation work from linked release worktrees.",
     },
+    CompatEntry {
+        aibox_version: "0.28.13",
+        processkit_version: "v0.28.4",
+        note: "Patch release: adds open GitHub Discussion counts to the tmux Forge status segment and restores the complete generated Codex command projection set.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.


### PR DESCRIPTION
Promotes the validated v0.28.13 release candidate to v0.x-release.