### PR TITLE
fix: prepare clean checkout before release host

### DIFF
--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -2560,18 +2560,81 @@ cmd_release_finalize_runtime() {
 
 # ── Host-side release (run on macOS after container-side `release`) ──────────
 
+release_worktree_for_branch() {
+  local release_branch="$1"
+  git -C "${PROJECT_ROOT}" worktree list --porcelain | awk \
+    -v wanted="refs/heads/${release_branch}" '
+      $1 == "worktree" {
+        path = substr($0, length("worktree ") + 1)
+      }
+      $1 == "branch" && $2 == wanted {
+        print path
+        exit
+      }
+    '
+}
+
+stash_release_host_changes() {
+  local worktree="$1" tag="$2" label="$3"
+  if [[ -z "$(git -C "${worktree}" status --porcelain --untracked-files=all)" ]]; then
+    return
+  fi
+
+  local stash_message="pre-release-host-${tag}-${label}-$(date -u +%Y%m%dT%H%M%SZ)"
+  info "Preserving dirty ${label} checkout in a named stash..."
+  git -C "${worktree}" stash push --include-untracked -m "${stash_message}" >/dev/null \
+    || die "Could not preserve dirty ${label} checkout at ${worktree}."
+  ok "Saved ${label} checkout as stash '${stash_message}'"
+}
+
+prepare_release_host_checkout() {
+  local version="$1" tag release_branch branch_owner project_root_real owner_real
+  tag="v${version}"
+  release_branch="$(release_branch_for_version "${version}")"
+
+  info "Preparing a clean host checkout for ${release_branch} and ${tag}..."
+  (
+    cd "${PROJECT_ROOT}"
+    git worktree prune
+    git fetch origin \
+      "refs/heads/${release_branch}:refs/remotes/origin/${release_branch}" \
+      "refs/tags/${tag}:refs/tags/${tag}" >/dev/null
+
+    branch_owner="$(release_worktree_for_branch "${release_branch}")"
+    project_root_real="$(cd "${PROJECT_ROOT}" && pwd -P)"
+    if [[ -n "${branch_owner}" ]]; then
+      owner_real="$(cd "${branch_owner}" 2>/dev/null && pwd -P || true)"
+    else
+      owner_real=""
+    fi
+
+    if [[ -n "${branch_owner}" && "${owner_real}" != "${project_root_real}" ]]; then
+      stash_release_host_changes "${branch_owner}" "${tag}" "linked-worktree"
+      git -C "${branch_owner}" switch --detach >/dev/null \
+        || die "Could not detach ${release_branch} from linked worktree ${branch_owner}."
+      ok "Released ${release_branch} from linked worktree ${branch_owner}"
+    fi
+
+    stash_release_host_changes "${PROJECT_ROOT}" "${tag}" "primary"
+    if [[ "$(git branch --show-current)" != "${release_branch}" ]]; then
+      git switch "${release_branch}" >/dev/null \
+        || die "Could not switch the primary checkout to ${release_branch}."
+    fi
+    git reset --keep "origin/${release_branch}" \
+      || die "Could not synchronize the clean host checkout with origin/${release_branch}."
+  )
+  ok "Host checkout prepared at origin/${release_branch}"
+}
+
 ensure_release_host_checkout_current() {
   local version="$1" tag release_branch
   tag="v${version}"
   release_branch="$(release_branch_for_version "${version}")"
 
+  prepare_release_host_checkout "${version}"
   info "Verifying host checkout is current with origin/${release_branch} and ${tag}..."
   (
     cd "${PROJECT_ROOT}"
-    git fetch origin \
-      "refs/heads/${release_branch}:refs/remotes/origin/${release_branch}" \
-      "refs/tags/${tag}:refs/tags/${tag}" >/dev/null
-
     local head remote_head tag_commit
     head=$(git rev-parse HEAD)
     remote_head=$(git rev-parse "origin/${release_branch}")
@@ -2583,7 +2646,7 @@ ensure_release_host_checkout_current() {
     fi
 
     if [[ "${head}" != "${remote_head}" ]]; then
-      die "release-host must run from current origin/${release_branch} containing ${tag}. Run: git fetch origin ${release_branch} && git switch ${release_branch} && git reset --keep origin/${release_branch}"
+      die "release-host could not prepare current origin/${release_branch} containing ${tag}; inspect the checkout and named pre-release-host stashes."
     fi
   )
   ok "Host checkout matches the ${release_branch} release line and contains ${tag}"

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -81,4 +81,49 @@ release_run_parallel_validation 9.9.9 \
 [[ -f "$(release_evidence_key_path scheduler-fast)" ]] \
   || die "parallel scheduler did not record the fast probe"
 
+host_remote="${test_root}/host-remote.git"
+host_seed="${test_root}/host-seed"
+host_primary="${test_root}/host-primary"
+host_linked="${test_root}/host-linked"
+git init --bare "${host_remote}" >/dev/null
+git init -b main "${host_seed}" >/dev/null
+git -C "${host_seed}" config user.name "Release Test"
+git -C "${host_seed}" config user.email "release-test@example.invalid"
+printf 'base\n' > "${host_seed}/tracked.txt"
+git -C "${host_seed}" add tracked.txt
+git -C "${host_seed}" commit -m "test: seed release repo" >/dev/null
+git -C "${host_seed}" branch v0.x-release
+git -C "${host_seed}" tag v0.28.13
+git -C "${host_seed}" remote add origin "${host_remote}"
+git -C "${host_seed}" push origin main v0.x-release v0.28.13 >/dev/null
+git -C "${host_remote}" symbolic-ref HEAD refs/heads/main
+git clone "${host_remote}" "${host_primary}" >/dev/null
+git -C "${host_primary}" config user.name "Release Test"
+git -C "${host_primary}" config user.email "release-test@example.invalid"
+git -C "${host_primary}" worktree add "${host_linked}" v0.x-release >/dev/null
+
+printf 'primary dirty\n' >> "${host_primary}/tracked.txt"
+printf 'primary untracked\n' > "${host_primary}/primary-untracked.txt"
+printf 'linked dirty\n' >> "${host_linked}/tracked.txt"
+printf 'linked untracked\n' > "${host_linked}/linked-untracked.txt"
+
+saved_project_root="${PROJECT_ROOT}"
+PROJECT_ROOT="${host_primary}"
+prepare_release_host_checkout 0.28.13
+[[ "$(git -C "${host_primary}" branch --show-current)" == "v0.x-release" ]] \
+  || die "release-host preparation did not switch the primary checkout"
+[[ "$(git -C "${host_primary}" rev-parse HEAD)" == \
+   "$(git -C "${host_primary}" rev-parse origin/v0.x-release)" ]] \
+  || die "release-host preparation did not synchronize the release branch"
+[[ -z "$(git -C "${host_primary}" status --porcelain --untracked-files=all)" ]] \
+  || die "release-host preparation left the primary checkout dirty"
+[[ -z "$(git -C "${host_linked}" branch --show-current)" ]] \
+  || die "release-host preparation did not detach the linked release worktree"
+[[ -z "$(git -C "${host_linked}" status --porcelain --untracked-files=all)" ]] \
+  || die "release-host preparation left the linked release worktree dirty"
+[[ "$(git -C "${host_primary}" stash list --format='%s' | \
+    grep -c 'pre-release-host-v0.28.13-')" -eq 2 ]] \
+  || die "release-host preparation did not preserve both dirty checkouts"
+PROJECT_ROOT="${saved_project_root}"
+
 ok "maintain.sh release evidence probe passed"


### PR DESCRIPTION
## Summary

Makes `release-host` prepare its own clean version-line checkout before host publication starts.

Dirty tracked and untracked changes are preserved in timestamped `pre-release-host-*` stashes. If another linked worktree owns the release branch, its dirty state is stashed and the worktree is detached so the primary checkout can switch safely. The primary checkout is then synchronized to the exact remote release line before the existing tag/reachability verification runs.

## Validation

- `bash -n scripts/maintain.sh`
- `bash -n scripts/test-maintain-release.sh`
- `./scripts/test-maintain-release.sh`
- regression fixture covers dirty primary and linked worktrees, untracked files, branch detachment, named stashes, and exact remote synchronization