### PR TITLE
fix(v0): install reconciliation skill dependencies

### DIFF
--- a/cli/src/container.rs
+++ b/cli/src/container.rs
@@ -4603,6 +4603,8 @@ mod tests {
         let body = serialize_config_with_comments(&config);
         assert!(body.contains("enabled = ["));
         assert!(body.contains("\"pk-doctor\""));
+        assert!(body.contains("\"project-reconciliation\""));
+        assert!(body.contains("\"repo-management\""));
         assert!(body.contains("\"status-briefing\""));
         assert!(body.contains("\"workitem-management\""));
     }
@@ -4614,6 +4616,8 @@ mod tests {
         config.skills.exclude = vec!["legal-review".to_string()];
         let added = add_missing_standard_processkit_skills(&mut config);
         assert!(added.contains(&"changelog".to_string()));
+        assert!(added.contains(&"project-reconciliation".to_string()));
+        assert!(added.contains(&"repo-management".to_string()));
         assert!(!config.skills.include.contains(&"legal-review".to_string()));
         assert!(config.skills.include.contains(&"logo-design".to_string()));
     }

--- a/cli/src/processkit_vocab.rs
+++ b/cli/src/processkit_vocab.rs
@@ -124,8 +124,10 @@ pub const STANDARD_PROCESSKIT_SKILLS: &[&str] = &[
     "pk-doctor",
     "processkit-gateway",
     "process-management",
+    "project-reconciliation",
     "prompt-engineering",
     "release-audit",
+    "repo-management",
     "retrospective",
     "role-management",
     "runtime-prune",
@@ -605,6 +607,18 @@ mod tests {
         assert!(
             STANDARD_PROCESSKIT_SKILLS.contains(&"runtime-prune"),
             "runtime-prune is part of the standard processkit operating surface"
+        );
+    }
+
+    #[test]
+    fn standard_processkit_skills_include_reconciliation_dependencies() {
+        assert!(
+            STANDARD_PROCESSKIT_SKILLS.contains(&"project-reconciliation"),
+            "pk-reconcile requires its owning project-reconciliation skill"
+        );
+        assert!(
+            STANDARD_PROCESSKIT_SKILLS.contains(&"repo-management"),
+            "project-reconciliation and pk-repo-reconcile require repo-management"
         );
     }
 


### PR DESCRIPTION
## Summary

Ensure v0 projects that receive the `pk-reconcile` and `pk-repo-reconcile` command projections also install their owning `project-reconciliation` and `repo-management` skills. Existing derived projects are repaired on their next `aibox apply`, unless either skill is explicitly excluded.

## Root cause

The command projections were restored in v0.28.13, but the standard skill reconciliation set did not include the two backing skills. That could leave `context/skills/devops/repo-management/mcp/server.py` absent even though the command entrypoint was available. The processkit v0.28.4 release artifact itself contains the complete repo-management MCP server, so this is an aibox selection bug rather than an upstream packaging defect.

## Validation

- `cargo fmt -- --check`
- `cargo test`: 1,060 unit, 90 E2E plus 1 ignored, 30 integration
- `cargo clippy --all-targets -- -D warnings`
- verified `processkit-v0.28.4.tar.gz` contains repo-management `SKILL.md`, `mcp-config.json`, and `mcp/server.py`