### PR TITLE
chore: release v0.28.14

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.28.13"
+version = "0.28.14"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.28.13"
+version = "0.28.14"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -608,6 +608,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.4",
         note: "Patch release: adds open GitHub Discussion counts to the tmux Forge status segment and restores the complete generated Codex command projection set.",
     },
+    CompatEntry {
+        aibox_version: "0.28.14",
+        processkit_version: "v0.28.4",
+        note: "Patch release: ensures pk-reconcile and pk-repo-reconcile install their project-reconciliation and repo-management skill dependencies.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/docs-site/docs/reference/compatibility.md
+++ b/docs-site/docs/reference/compatibility.md
@@ -12,6 +12,9 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.28.14 | v0.28.4 | ensures `pk-reconcile` and `pk-repo-reconcile` install their `project-reconciliation` and `repo-management` skill dependencies |
+| 0.28.13 | v0.28.4 | adds open GitHub Discussion counts to the tmux Forge status segment and restores the complete generated Codex command projection set |
+| 0.28.12 | v0.28.4 | integrates processkit v0.28.4 and makes companion E2E validation work from linked release worktrees |
 | 0.28.11 | v0.28.3 | adds the `cloudflare` addon, which installs cloudflared from Cloudflare's signed package repository rather than Debian's archive |
 | 0.28.10 | v0.28.3 | reconciles standard processkit skills, recommends tooling-linked skills interactively, upgrades prerelease processkit surfaces, and serializes release Tier 2 E2E validation |
 | 0.28.6 | v0.28.3 | fixes Kubernetes addon checksum verification for Helm, Kustomize, and k9s archives on amd64 and arm64; and integrates processkit v0.28.3 authenticated GitHub repository reconciliation |


### PR DESCRIPTION
Promotes the validated v0.28.14 release candidate to v0.x-release.