### PR TITLE
docs: clarify aibox maturity and v1 boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,43 @@
 # aibox
 
-**Reproducible AI workspaces from one `aibox.toml`.**
+**Turn one project contract into a reproducible, AI-ready workspace.**
 
-> **Project status:** actively maintained. The latest minor release line is
-> supported; security and correctness fixes are released on the newest version.
-> See [SECURITY.md](SECURITY.md) for reporting and support details.
+> **Maturity:** usable project — active development. The maintained v0.x line
+> supports Linux containers on Docker, Podman, and OrbStack; macOS is supported
+> as a container host. Windows hosts and production workload orchestration are
+> not supported. See the [compatibility matrix](https://projectious-work.github.io/aibox/docs/reference/compatibility)
+> and [SECURITY.md](SECURITY.md).
 
-`aibox` is a Rust CLI for projects that want a dependable terminal-first AI
-development environment without hand-maintaining devcontainer glue. It turns a
-declarative `aibox.toml` into standard `.devcontainer/` files, a project image,
-runtime UI configuration, selected AI harnesses, and pinned processkit context
-under `context/`.
+`aibox` is a Rust CLI for developers who want a dependable terminal-first AI
+environment without rebuilding devcontainer, toolchain, and agent-runtime glue
+for every repository. Today, the maintained v0.x line turns a declarative
+`aibox.toml` into standard `.devcontainer/` files, a project image, runtime UI
+configuration, selected AI harnesses, and pinned processkit context.
 
-The design goal is simple: a fresh clone plus `aibox apply` should reproduce the
-same workspace, with the same tools, the same agent entry points, and the same
-project context.
+The useful outcome is a workspace another developer or agent can reproduce from
+a fresh clone with the same tools, entry points, and project context:
+`aibox init` → `aibox apply` → `aibox up`.
 
 ![aibox dev layout](docs-site/static/screencasts/layout-dev.gif)
+
+_The recording shows the generated development container running the managed
+tmux layout, shell, editor, file browser, diagnostics, and configured AI
+harnesses from one project contract._
+
+## What works, what is changing
+
+| Area | Current maintained v0.x | Accepted v1 direction |
+| --- | --- | --- |
+| Workspace image and local runtime | Generates and runs Docker/Podman/OrbStack devcontainers | Owns reproducible workspace images and deploys them to pre-existing Compose or Kubernetes targets |
+| Processkit | Downloads, installs, and updates pinned processkit content | Delegates installation policy to the versioned processkit CLI protocol |
+| Connection | `aibox up` starts and attaches locally | Deployment and `aibox connect` are separate, backend-neutral operations |
+| Infrastructure | Uses an existing container runtime | Consumes existing targets; never provisions clusters, VMs, networks, identities, or cloud accounts |
+
+V1 is under active development in the independent `v1.x` line. The supported
+v0.x workflow remains available while its migration and rollback gates are
+proven. Follow [the v1 architecture epic](https://github.com/projectious-work/aibox/issues/179)
+for implementation status; do not treat planned v1 behavior as current v0
+behavior.
 
 ## Why aibox
 
@@ -110,6 +131,12 @@ aibox intentionally does not own process semantics. If a behavior is about how
 agents plan, record decisions, or manage work items, it belongs in processkit.
 If it is about generating containers, selecting addons, wiring harness config,
 or launching the workspace, it belongs in aibox.
+
+Within the [Projectious](https://projectious.work/) ecosystem, aibox is the
+workspace image and deployment layer. Processkit owns agent-working practices
+and their installation policy; infrastructure templates may supply target
+references. Aibox is deliberately not a generic application platform or an
+infrastructure provisioner.
 
 ## Documentation
 

--- a/docs-site/src/pages/index.js
+++ b/docs-site/src/pages/index.js
@@ -19,9 +19,13 @@ function Hero() {
         <h1 className="hero__title">{siteConfig.title}</h1>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <p className={styles.heroDescription}>
-          Generate standard devcontainer files, selected tool addons,
-          provider-neutral agent context, and a terminal workspace from one
-          project contract.
+          Turn one project contract into a reproducible devcontainer, selected
+          tools, provider-neutral agent entry points, and a managed terminal
+          workspace.
+        </p>
+        <p className={styles.maturity}>
+          Usable project — active development · Linux containers · macOS host
+          support · Docker, Podman, and OrbStack
         </p>
         <div className={styles.buttons}>
           <Link className="button button--secondary button--lg" to="/docs/getting-started/installation">
@@ -93,6 +97,51 @@ aibox up`}</code></pre>
   );
 }
 
+function Boundaries() {
+  return (
+    <section className={styles.boundaries}>
+      <div className="container">
+        <h2>Useful today, explicit about tomorrow</h2>
+        <div className="row">
+          <div className="col col--4">
+            <h3>What works</h3>
+            <p>
+              The maintained v0.x line generates and runs reproducible local
+              AI workspaces from <code>aibox.toml</code>, including pinned
+              processkit context.
+            </p>
+          </div>
+          <div className="col col--4">
+            <h3>What changes in v1</h3>
+            <p>
+              Aibox becomes the workspace image and deployment layer for
+              existing Compose and Kubernetes targets. Processkit installation
+              is delegated to processkit&apos;s versioned CLI protocol.
+            </p>
+          </div>
+          <div className="col col--4">
+            <h3>What aibox does not own</h3>
+            <p>
+              Aibox does not provision clusters, VMs, networks, identities, or
+              cloud accounts, and it is not a general production application
+              orchestrator.
+            </p>
+          </div>
+        </div>
+        <p className={styles.boundaryLinks}>
+          <Link to="/docs/reference/compatibility">Compatibility and support</Link>
+          {' · '}
+          <Link to="https://github.com/projectious-work/aibox/issues/179">
+            v1 architecture and progress
+          </Link>
+          {' · '}
+          <Link to="https://projectious.work/">Projectious ecosystem</Link>
+        </p>
+      </div>
+    </section>
+  );
+}
+
 export default function Home() {
   const {siteConfig} = useDocusaurusContext();
   return (
@@ -101,6 +150,7 @@ export default function Home() {
       <main>
         <Features />
         <QuickStart />
+        <Boundaries />
       </main>
     </Layout>
   );

--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -20,6 +20,16 @@
   opacity: 0.9;
 }
 
+.maturity {
+  display: inline-block;
+  max-width: 680px;
+  margin: 0 0 1.5rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
 .buttons {
   display: flex;
   align-items: center;
@@ -44,6 +54,16 @@
   text-align: left;
   padding: 1rem 2rem;
   border-radius: 8px;
+}
+
+.boundaries {
+  padding: 3rem 0;
+  background: var(--ifm-color-emphasis-100);
+}
+
+.boundaryLinks {
+  margin: 1.5rem 0 0;
+  font-weight: 600;
 }
 
 @media screen and (max-width: 996px) {


### PR DESCRIPTION
## Summary

Aligns the public README and canonical documentation landing page with aibox's current supported v0.x workflow, accepted v1 responsibility boundary, known platform limits, demonstrated end-to-end outcome, and Projectious ecosystem role.

This gives new visitors an accurate first-screen explanation of what works now, what is changing in v1, and what aibox deliberately does not own.

## Changes

- adopts the shared `Usable project — active development` maturity language
- states supported hosts/runtimes and unsupported boundaries near the top
- captions the real workspace demonstration with what it proves
- separates current v0.x behavior from the accepted v1 direction
- adds concise what-works / what-changes / does-not-own guidance
- positions aibox as the workspace image and deployment layer within Projectious

## Validation

- `npm ci`
- `npm run build` (Docusaurus production build and link validation)
- `git diff --check`

The existing docs dependency lock reports one low and two high npm advisories; this documentation-only change does not alter dependencies.

Fixes #199