### PR TITLE
fix(v1): harden disposable cluster preflight

### DIFF
--- a/.devcontainer/docker-compose.override.yml
+++ b/.devcontainer/docker-compose.override.yml
@@ -44,6 +44,10 @@ services:
     security_opt:
       - seccomp=unconfined
     privileged: true
+    # kind's Podman provider starts a systemd-based node container. Keep the
+    # companion in the host cgroup namespace so controllers delegated by the
+    # outer runtime remain available to that nested node.
+    cgroup: host
     cap_add:
       - SYS_ADMIN
       - NET_ADMIN

--- a/cli/tests/e2e/kubernetes_kind.rs
+++ b/cli/tests/e2e/kubernetes_kind.rs
@@ -18,17 +18,35 @@ fn kubernetes_kind_prerequisite_and_deterministic_cleanup() {
         "Kubernetes release gate is intentionally pinned to the Podman companion provider"
     );
 
-    let preflight = runner.exec("kind version && kubectl version --client && grep -qw pids /sys/fs/cgroup/cgroup.controllers");
+    let preflight = runner.exec(
+        "set -eu; \
+         kind version; \
+         kubectl version --client; \
+         test \"$(cat /proc/self/cgroup)\" = '0::/'; \
+         grep -qw pids /sys/fs/cgroup/cgroup.controllers; \
+         grep -qw pids /sys/fs/cgroup/cgroup.subtree_control; \
+         test -d /lib/modules",
+    );
     assert!(
         preflight.status.success(),
-        "kind requires nested Podman cgroup delegation including the pids controller. The current companion cannot create a kind node until that host prerequisite is enabled:\n{}",
+        "kind requires a host cgroup namespace, delegated pids controller, and /lib/modules mount. Rebuild the companion from the current Dockerfile.e2e and docker-compose.override.yml:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&preflight.stdout),
         String::from_utf8_lossy(&preflight.stderr)
     );
 
     // A unique name keeps concurrent release jobs isolated.  Trap cleanup is
     // registered before cluster creation so a failed first/changed/drift run
     // cannot leak node containers or kubeconfig state.
-    let run = runner.exec("set -eu; name=aibox-m7c-${RANDOM}; trap 'kind delete cluster --name \"$name\" >/dev/null 2>&1 || true' EXIT; kind create cluster --name \"$name\" --wait 90s; kubectl --context \"kind-$name\" get nodes; kind delete cluster --name \"$name\"; trap - EXIT");
+    let run = runner.exec(
+        "set -eu; \
+         export KIND_EXPERIMENTAL_PROVIDER=podman; \
+         name=aibox-m7c-${RANDOM}; \
+         trap 'kind delete cluster --name \"$name\" >/dev/null 2>&1 || true' EXIT; \
+         kind create cluster --name \"$name\" --wait 90s; \
+         kubectl --context \"kind-$name\" get nodes; \
+         kind delete cluster --name \"$name\"; \
+         trap - EXIT",
+    );
     assert!(
         run.status.success(),
         "kind disposable-cluster smoke failed:\nstdout:\n{}\nstderr:\n{}",


### PR DESCRIPTION
## Summary

Makes the M7c disposable-cluster gate test the cgroup conditions kind actually needs instead of accepting a misleading top-level controller listing.

The E2E companion now uses the host cgroup namespace, and the release-gated test verifies effective `pids` delegation, `/lib/modules`, the unified cgroup namespace, and explicit Podman provider selection before cluster creation.

## Validation

- `cargo fmt -- --check`
- `cargo test --features e2e kubernetes_kind --no-run`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- live companion diagnosis reproduced the nested systemd cgroup failure and confirmed the old preflight was a false positive

The companion must be rebuilt from the updated compose configuration before collecting the final live M7c attestation.

Refs #179