### PR TITLE
docs: publish v1.x preview docs under /v1.x/ subpath

### DIFF
--- a/docs-site/hugo.yaml
+++ b/docs-site/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: "https://projectious-work.github.io/aibox/"
+baseURL: "https://projectious-work.github.io/aibox/v1.x/"
 title: aibox
 description: "Reproducible AI workspaces from one aibox.toml"
 theme: [docsy]

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DOCS_ROOT="${PROJECT_ROOT}/docs-site"
-DOCS_BASE_URL="${DOCS_BASE_URL:-https://projectious-work.github.io/aibox/}"
+DOCS_BASE_URL="${DOCS_BASE_URL:-https://projectious-work.github.io/aibox/v1.x/}"
 BUILD_DIR="${DOCS_ROOT}/public"
 
 BUILD_ARGS=("$@")

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -1284,9 +1284,9 @@ cmd_docs_serve() {
   if [[ ! -d "${PROJECT_ROOT}/docs-site/node_modules" ]]; then
     npm --prefix "${PROJECT_ROOT}/docs-site" ci
   fi
-  info "Serving docs with Hugo and Docsy at http://localhost:1313/aibox/ ..."
+  info "Serving docs with Hugo and Docsy at http://localhost:1313/aibox/v1.x/ ..."
   hugo server --source "${PROJECT_ROOT}/docs-site" \
-    --bind 0.0.0.0 --baseURL "http://localhost:1313/aibox/"
+    --bind 0.0.0.0 --baseURL "http://localhost:1313/aibox/v1.x/"
 }
 
 cmd_docs_deploy() {
@@ -1325,7 +1325,20 @@ cmd_docs_deploy() {
   # Bug (b): use ${tmpdir:-} so trap is safe even if mktemp never ran (set -u).
   trap '[[ -n "${tmpdir:-}" ]] && rm -rf "${tmpdir}"' EXIT
 
-  cp -r "${PROJECT_ROOT}/docs-site/public/." "${tmpdir}/"
+  # This branch publishes the v1.x preview docs under the /v1.x/ subpath.
+  # The stable v0.x line publishes at the site root on the same gh-pages
+  # branch. Clone the existing gh-pages tree first (if any) so a
+  # v1.x-only rebuild here never touches the root; only replace the
+  # v1.x/ subtree.
+  if git clone -q --depth 1 --branch gh-pages "${remote_url}" "${tmpdir}" 2>/dev/null; then
+    info "Found existing gh-pages branch — preserving everything outside v1.x/"
+    rm -rf "${tmpdir}/.git" "${tmpdir}/v1.x"
+  else
+    info "No existing gh-pages branch — starting fresh"
+  fi
+
+  mkdir -p "${tmpdir}/v1.x"
+  cp -r "${PROJECT_ROOT}/docs-site/public/." "${tmpdir}/v1.x/"
   touch "${tmpdir}/.nojekyll"
 
   info "Pushing to gh-pages branch..."


### PR DESCRIPTION
## Summary
- Move this line's Hugo/Docsy docs publish target from the gh-pages root to `/v1.x/`, so it can coexist with the stable v0.x line publishing at root (companion change on `v0.x-release`).
- Update `docs-site/hugo.yaml` baseURL and `scripts/build-docs.sh`'s default `DOCS_BASE_URL` to the `/v1.x/` subpath.
- Update `cmd_docs_serve` to serve at the matching local subpath, and `cmd_docs_deploy` to clone the existing gh-pages tree first and only replace the `v1.x/` subtree — so a v1.x deploy never wipes the v0.x root, and vice versa.

## Test plan
- [x] `git submodule update --init --recursive docs-site/themes/docsy`
- [x] `npm --prefix docs-site ci`
- [x] `hugo --source docs-site --gc --minify --cleanDestinationDir --baseURL https://projectious-work.github.io/aibox/v1.x/` — 151 pages, 0 errors
- [x] Verified generated HTML links resolve under `/aibox/v1.x/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)