### PR TITLE
fix(docs): unreadable dark-navy headings on cover/lead landing sections

### DIFF
--- a/docs-site/assets/scss/_styles_project.scss
+++ b/docs-site/assets/scss/_styles_project.scss
@@ -22,6 +22,19 @@
     url("/aibox/img/layouts/layout-dev.svg") center / cover;
 }
 
+// Docsy's dark/primary box wrappers set body text to white, but headings
+// render via var(--bs-heading-color), which only tracks the site-wide
+// light/dark toggle -- not an individually-colored dark block. Without this,
+// headings on the cover/lead sections render in the light-mode heading color
+// (dark navy) on a dark background and are unreadable.
+.td-box--dark,
+.td-box--primary {
+  h1, h2, h3, h4, h5, h6,
+  .h1, .h2, .h3, .h4, .h5, .h6 {
+    color: #fff;
+  }
+}
+
 .td-content > h1,
 .td-content > h2,
 .td-content > h3 {


### PR DESCRIPTION
## Summary
- The homepage cover block and lead/quick-start sections (`.td-box--dark`, `.td-box--primary`) set body text to white, but headings render via `var(--bs-heading-color)`, which tracks the site-wide light/dark toggle, not an individually-colored dark block.
- Result: headline text rendered in the light-mode heading color (`#1d3352`, dark navy) on a dark background — unreadable.
- Adds an explicit `color: #fff` override for `h1`-`h6` inside those wrappers, matching the specificity pattern Docsy already uses for `.td-footer`.

## Test plan
- [x] Rebuilt with `hugo --gc --minify --cleanDestinationDir`
- [x] Confirmed compiled CSS: `.td-box--dark h1, ..., .td-box--primary h1, ... {color:#fff}` now present with correct specificity (0,1,1) over the base `h1{color:var(--bs-heading-color)}` (0,0,1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)