### PR TITLE
fix(docs): unreadable dark-navy headings on cover/lead landing sections

### DIFF
--- a/docs-site/assets/scss/_styles_project.scss
+++ b/docs-site/assets/scss/_styles_project.scss
@@ -22,6 +22,19 @@
     url("/aibox/img/layouts/layout-dev.svg") center / cover;
 }
 
+// Docsy's dark/primary box wrappers set body text to white, but headings
+// render via var(--bs-heading-color), which only tracks the site-wide
+// light/dark toggle -- not an individually-colored dark block. Without this,
+// headings on the cover/lead sections render in the light-mode heading color
+// (dark navy) on a dark background and are unreadable.
+.td-box--dark,
+.td-box--primary {
+  h1, h2, h3, h4, h5, h6,
+  .h1, .h2, .h3, .h4, .h5, .h6 {
+    color: #fff;
+  }
+}
+
 .td-content > h1,
 .td-content > h2,
 .td-content > h3 {


### PR DESCRIPTION
## Summary
Same fix as v0.x-release (#205): `.td-box--dark`/`.td-box--primary` set body text white but headings used `var(--bs-heading-color)` (dark navy), unreadable on the dark cover/lead sections. Adds explicit `color: #fff` override for headings inside those wrappers.

## Test plan
- [x] `hugo --source docs-site --gc --minify --cleanDestinationDir --baseURL https://projectious-work.github.io/aibox/v1.x/` — 151 pages, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)