### PR TITLE
fix(docs): keep main landing hero text readable

### DIFF
--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -13,6 +13,11 @@
   max-width: 760px;
 }
 
+.heroBanner :global(.hero__title),
+.heroBanner :global(.hero__subtitle) {
+  color: #fff;
+}
+
 .heroDescription {
   font-size: 1.2rem;
   max-width: 600px;


### PR DESCRIPTION
## Summary

Keeps the landing-page headline and subtitle readable against the dark hero artwork on the current `main` documentation site. No user action is required.

## Root cause

The global brand stylesheet assigns dark heading and subtitle colors. Docusaurus's dark hero background does not reliably override those more specific declarations, producing dark text on a dark background.

## Fix

Apply a page-scoped white foreground to `.hero__title` and `.hero__subtitle`. The equivalent Docsy block-scoped override is already merged on `v0.x-release` and `v1.x-dev`.

## Validation

- `npm ci`
- `npm run build`
- verified compiled CSS contains the scoped white hero selector
- verified Hugo builds and compiled white heading selectors on `v0.x-release` and `v1.x-dev`
