### PR TITLE
fix(v1): pin processkit alpha 2 consumer gate

### DIFF
--- a/cli/src/processkit_protocol.rs
+++ b/cli/src/processkit_protocol.rs
@@ -5,9 +5,9 @@
 //! evidence. It has no knowledge of processkit layouts, skills, packages,
 //! templates, migrations, or harness projections.
 //!
-//! Consumer compatibility is currently validated against processkit PR #123.
-//! Stable-v1 release remains gated on a tagged processkit prerelease containing
-//! this protocol and matching producer and consumer compatibility evidence.
+//! Consumer compatibility is validated against the exact-pinned processkit
+//! v1.0.0-alpha.2 release assets. Stable-v1 remains gated on the rest of the
+//! parity, migration, rollback, interruption, and secret-safety evidence.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
@@ -468,15 +468,36 @@ mod tests {
         let Some(cli) = std::env::var_os("AIBOX_PROCESSKIT_V1_TEST_CLI") else {
             return;
         };
-        let distribution = std::env::var_os("AIBOX_PROCESSKIT_V1_TEST_DISTRIBUTION")
-            .expect("consumer gate requires AIBOX_PROCESSKIT_V1_TEST_DISTRIBUTION");
         let project = TempDir::new().unwrap();
 
-        let mut install = InstallerRequest::development(
-            InstallerOperation::Install,
-            project.path().to_path_buf(),
-            distribution.into(),
-        );
+        let mut install = match (
+            std::env::var_os("AIBOX_PROCESSKIT_V1_TEST_ENVELOPE"),
+            std::env::var_os("AIBOX_PROCESSKIT_V1_TEST_SIGNATURE"),
+            std::env::var_os("AIBOX_PROCESSKIT_V1_TEST_TRUST_STORE"),
+        ) {
+            (Some(envelope), Some(signature), Some(trust_store)) => {
+                InstallerRequest::signed_release(
+                    InstallerOperation::Install,
+                    project.path().to_path_buf(),
+                    envelope.into(),
+                    signature.into(),
+                    trust_store.into(),
+                )
+            }
+            (None, None, None) => {
+                let distribution = std::env::var_os("AIBOX_PROCESSKIT_V1_TEST_DISTRIBUTION")
+                    .expect(
+                        "consumer gate requires signed release inputs or \
+                         AIBOX_PROCESSKIT_V1_TEST_DISTRIBUTION",
+                    );
+                InstallerRequest::development(
+                    InstallerOperation::Install,
+                    project.path().to_path_buf(),
+                    distribution.into(),
+                )
+            }
+            _ => panic!("consumer gate signed release inputs must be provided together"),
+        };
         install.profiles = vec!["minimal".into()];
         install.harnesses = vec!["codex".into()];
 
@@ -517,17 +538,6 @@ mod tests {
             updated.changes,
             vec![serde_json::json!({"count": 0})],
             "an unchanged producer update must report zero changes"
-        );
-        let state: Value = serde_json::from_slice(
-            &fs::read(project.path().join(".processkit/state.json")).unwrap(),
-        )
-        .unwrap();
-        assert!(
-            state["ownedPaths"].as_array().is_some_and(|paths| paths
-                .iter()
-                .any(|path| path["ownership"] == "managed-keys"
-                    && path["operation"] == "managed-keys-create/v1")),
-            "unchanged update must retain create ownership for uninstall"
         );
         assert_eq!(
             invoke(

--- a/cli/src/v1_release_readiness.rs
+++ b/cli/src/v1_release_readiness.rs
@@ -178,7 +178,7 @@ fn m5_gate() -> ReleaseGate {
             title: "M5 production processkit protocol integration (#118)".to_string(),
             status: GateStatus::Passed,
             blocking: true,
-            evidence: "The compiled protocol boundary no longer declares the processkit producer integration provisional.".to_string(),
+            evidence: "The installer/v1alpha1 consumer gate is exact-pinned to the signed processkit v1.0.0-alpha.2 release and validates plan, install, verify, unchanged update, and uninstall.".to_string(),
             remediation: "Keep producer-version, migration, interruption, and rollback evidence with the release candidate.".to_string(),
         }
     }
@@ -706,7 +706,7 @@ mod tests {
     }
 
     #[test]
-    fn audit_blocks_known_m5_and_missing_m7c_evidence() {
+    fn audit_passes_tagged_m5_and_blocks_missing_m7c_evidence() {
         let dir = TempDir::new().unwrap();
         let report = release_readiness(dir.path());
         assert!(!report.ready);
@@ -715,7 +715,7 @@ mod tests {
                 .gates
                 .iter()
                 .any(|gate| gate.id == "m5-processkit-production-integration"
-                    && gate.status == GateStatus::Blocked)
+                    && gate.status == GateStatus::Passed)
         );
         assert!(
             report

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -512,7 +512,7 @@ fn stable_v1_readiness_json_is_machine_readable_while_blocked() {
     assert_eq!(report["ready"], false);
     let gates = report["gates"].as_array().unwrap();
     assert!(gates.iter().any(|gate| {
-        gate["id"] == "m5-processkit-production-integration" && gate["status"] == "blocked"
+        gate["id"] == "m5-processkit-production-integration" && gate["status"] == "passed"
     }));
     assert!(gates.iter().any(|gate| {
         gate["id"] == "m7c-live-disposable-cluster-evidence" && gate["status"] == "blocked"

--- a/docs/architecture/v1-processkit-protocol-fixtures.md
+++ b/docs/architecture/v1-processkit-protocol-fixtures.md
@@ -2,8 +2,10 @@
 
 The M5 consumer is aligned with the producer-owned
 `processkit.projectious.work/installer/v1alpha1` contract implemented by
-processkit PR #123. Aibox supplies only the operation, target root, release
-input paths, profiles, harness intent, and explicit mutation acknowledgement.
+processkit `v1.0.0-alpha.2` (tagged commit
+`c232656a695dfb72dafaaddc19f406eba0e24c6a`). Aibox supplies only the
+operation, target root, release input paths, profiles, harness intent, and
+explicit mutation acknowledgement.
 Processkit owns all installation policy and interprets the request without
 aibox inspecting layouts, skills, templates, migrations, MCP topology, or
 harness projections.
@@ -14,22 +16,32 @@ removed after invocation. Aibox validates the versioned result envelope and
 preserves producer extensions without interpreting processkit-owned state,
 changes, conflicts, warnings, errors, or provenance.
 
-For development compatibility testing against a processkit checkout:
+The release gate downloads the exact-pinned source archive, native Linux
+aarch64 installer, signed release envelope, signature, and public key. It
+verifies the published archive and installer SHA-256 values before exercising
+the signed-release request path:
+
+```sh
+./scripts/test-processkit-v1-consumer.sh
+```
+
+For development compatibility testing against a processkit checkout, pass its
+path explicitly:
 
 ```sh
 ./scripts/test-processkit-v1-consumer.sh /path/to/processkit
 ```
 
-The gate builds the standalone producer and exercises install, verify, update,
-and uninstall through the aibox adapter in an arbitrary disposable project.
+The gate exercises plan, install, verify, unchanged update, and uninstall
+through the aibox adapter in an arbitrary disposable project.
 Unit coverage additionally fixes request validation, forward-compatible result
 decoding, exit/status agreement, request-file cleanup, and recover-before-retry
 semantics.
 
 ## Stable-release gate
 
-The bounded v0 installer remains intact. Stable v1 stays blocked until a tagged
-processkit prerelease contains this protocol, the producer's
-`scripts/test-installer-local.sh` passes for that tag, and this consumer gate
-passes against the same tag. Cancellation is process cancellation; the only
-supported next operation is `recover`, followed by one retry.
+The bounded v0 installer remains intact. The tagged producer dependency is now
+satisfied by processkit `v1.0.0-alpha.2`; stable v1 remains blocked on the
+remaining parity, migration, rollback, interruption, and secret-safety gates.
+Cancellation is process cancellation; the only supported next operation is
+`recover`, followed by one retry.

--- a/scripts/test-processkit-v1-consumer.sh
+++ b/scripts/test-processkit-v1-consumer.sh
@@ -2,18 +2,80 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PROCESSKIT_ROOT="${1:-}"
+PROCESSKIT_VERSION="v1.0.0-alpha.2"
+PROCESSKIT_RELEASE_BASE="https://github.com/projectious-work/processkit/releases/download/${PROCESSKIT_VERSION}"
+PROCESSKIT_ARCHIVE_SHA256="7fae02905fb07c56261a38aee1c0c07aea7c1c96152ae226ddde8898eeaf7b5c"
+PROCESSKIT_INSTALLER_SHA256="7a67abedb63bc151700c4a72a8ec7e71b35d820da052c59ad75c7e3bdf095d1e"
+PROCESSKIT_SIGNING_KEY_ID="74d3034333501f61162b8d392392b4533982b5f7d020a838d724fe0d429bf01f"
+PROCESSKIT_TARGET="aarch64-unknown-linux-gnu"
 
-if [[ -z "${PROCESSKIT_ROOT}" || ! -f "${PROCESSKIT_ROOT}/installer/Cargo.toml" ]]; then
-  echo "usage: $0 /path/to/processkit-checkout" >&2
-  exit 2
-fi
-
-cargo build --manifest-path "${PROCESSKIT_ROOT}/installer/Cargo.toml" --bin processkit
-
-AIBOX_PROCESSKIT_V1_TEST_CLI="${PROCESSKIT_ROOT}/installer/target/debug/processkit" \
-AIBOX_PROCESSKIT_V1_TEST_DISTRIBUTION="${PROCESSKIT_ROOT}/src" \
+run_gate() {
   cargo test \
     --manifest-path "${PROJECT_ROOT}/cli/Cargo.toml" \
     processkit_protocol::tests::real_producer_lifecycle_when_configured \
     -- --exact --nocapture
+}
+
+if [[ -n "${1:-}" ]]; then
+  PROCESSKIT_ROOT="$1"
+  if [[ ! -f "${PROCESSKIT_ROOT}/installer/Cargo.toml" ]]; then
+    echo "usage: $0 [/path/to/processkit-checkout]" >&2
+    exit 2
+  fi
+  cargo build --manifest-path "${PROCESSKIT_ROOT}/installer/Cargo.toml" --bin processkit
+  AIBOX_PROCESSKIT_V1_TEST_CLI="${PROCESSKIT_ROOT}/installer/target/debug/processkit" \
+  AIBOX_PROCESSKIT_V1_TEST_DISTRIBUTION="${PROCESSKIT_ROOT}/src" \
+    run_gate
+  exit
+fi
+
+command -v curl >/dev/null || {
+  echo "curl is required for the tagged processkit consumer gate" >&2
+  exit 2
+}
+command -v sha256sum >/dev/null || {
+  echo "sha256sum is required for the tagged processkit consumer gate" >&2
+  exit 2
+}
+
+RELEASE_DIR="$(mktemp -d)"
+trap 'rm -rf "${RELEASE_DIR}"' EXIT
+
+archive="processkit-${PROCESSKIT_VERSION}.tar.gz"
+installer="processkit-${PROCESSKIT_VERSION}-${PROCESSKIT_TARGET}"
+envelope="processkit-${PROCESSKIT_VERSION}.release.json"
+signature="processkit-${PROCESSKIT_VERSION}.release.sig"
+public_key="processkit-${PROCESSKIT_VERSION}.release.pub.pem"
+
+for asset in "${archive}" "${installer}" "${envelope}" "${signature}" "${public_key}"; do
+  curl --fail --silent --show-error --location \
+    --output "${RELEASE_DIR}/${asset}" \
+    "${PROCESSKIT_RELEASE_BASE}/${asset}"
+done
+
+printf '%s  %s\n' "${PROCESSKIT_ARCHIVE_SHA256}" "${RELEASE_DIR}/${archive}" \
+  | sha256sum --check
+printf '%s  %s\n' "${PROCESSKIT_INSTALLER_SHA256}" "${RELEASE_DIR}/${installer}" \
+  | sha256sum --check
+chmod 0755 "${RELEASE_DIR}/${installer}"
+
+cat >"${RELEASE_DIR}/trust-store.json" <<EOF
+{
+  "apiVersion": "processkit.projectious.work/local-trust/v1alpha1",
+  "kind": "TrustStore",
+  "keys": [
+    {
+      "keyId": "${PROCESSKIT_SIGNING_KEY_ID}",
+      "algorithm": "Ed25519",
+      "publicKeyFile": "${public_key}",
+      "status": "active"
+    }
+  ]
+}
+EOF
+
+AIBOX_PROCESSKIT_V1_TEST_CLI="${RELEASE_DIR}/${installer}" \
+AIBOX_PROCESSKIT_V1_TEST_ENVELOPE="${RELEASE_DIR}/${envelope}" \
+AIBOX_PROCESSKIT_V1_TEST_SIGNATURE="${RELEASE_DIR}/${signature}" \
+AIBOX_PROCESSKIT_V1_TEST_TRUST_STORE="${RELEASE_DIR}/trust-store.json" \
+  run_gate


### PR DESCRIPTION
Summary

Pins the v1 consumer compatibility gate to processkit `v1.0.0-alpha.2` and exercises its signed production release path. This satisfies the tagged-producer M5 dependency while retaining the v0 compatibility bridge and leaving stable v1 blocked on M7c.

Changes

- download the exact tagged archive, native aarch64 installer, signed envelope, signature, and public key
- verify the published archive and installer SHA-256 values before execution
- exercise plan, install, verify, unchanged update, and uninstall through signed release inputs
- keep checkout-path mode for producer development
- treat processkit installation state as opaque and validate observable adapter cleanup
- mark the M5 readiness gate passed and update its unit/integration expectations
- document the immutable producer evidence and remaining stable-v1 gates

Validation

- `./scripts/test-processkit-v1-consumer.sh`
- `cargo build`
- `cargo test` (1,132 unit; 88 E2E passed, 1 ignored; 41 integration)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`

Refs: #186
