### PR TITLE
fix(v1): delegate kind e2e through systemd

### DIFF
--- a/.devcontainer/Dockerfile.e2e
+++ b/.devcontainer/Dockerfile.e2e
@@ -2,7 +2,9 @@
 # E2E Test Companion Container
 # =============================================================================
 # Simulates a user's host machine for end-to-end testing of the aibox CLI.
-# Runs podman (rootless) for container operations and sshd for remote access.
+# Runs podman (rootless) for container operations and systemd-managed sshd for
+# remote access.  systemd owns the companion cgroup boundary so SSH sessions
+# receive a delegated user slice capable of hosting nested kind nodes.
 # Also includes terminal tools (tmux, yazi, vim, starship, asciinema) for
 # headless visual testing via asciinema recordings.
 # Started alongside the dev-container as the "e2e-runner" service.
@@ -95,6 +97,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     nftables \
     # SSH server for remote test execution
     openssh-server \
+    # PID 1 and the per-user manager provide cgroup v2 delegation to kind
+    systemd \
+    systemd-sysv \
+    dbus \
+    dbus-user-session \
     # Utilities needed by aibox and tests
     bubblewrap \
     curl \
@@ -165,13 +172,23 @@ RUN mkdir -p /run/sshd \
     && sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config \
     && sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
     && sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config \
-    && sed -i 's/^AcceptEnv.*/#AcceptEnv/' /etc/ssh/sshd_config
+    && sed -i 's/^AcceptEnv.*/#AcceptEnv/' /etc/ssh/sshd_config \
+    && systemctl enable ssh.service
 
 # ── Test user ─────────────────────────────────────────────────────────────────
 RUN groupadd --gid 1000 testuser \
     && useradd --uid 1000 --gid testuser --shell /bin/bash --create-home testuser \
     && echo "testuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/testuser \
-    && chmod 0440 /etc/sudoers.d/testuser
+    && chmod 0440 /etc/sudoers.d/testuser \
+    && mkdir -p /var/lib/systemd/linger \
+    && touch /var/lib/systemd/linger/testuser
+
+# kind's rootless Podman provider must run in a delegated systemd user scope.
+# Keep this explicit even though systemd 252+ delegates controllers by default,
+# so the companion contract remains stable across base-image changes.
+RUN mkdir -p /etc/systemd/system/user@.service.d \
+    && printf '[Service]\nDelegate=yes\n' \
+       > /etc/systemd/system/user@.service.d/delegate.conf
 
 # ── SSH directory for authorized keys (mounted at runtime) ───────────────────
 # The .ssh directory is mounted from .aibox-e2e-runner-home/.ssh/ via
@@ -184,6 +201,8 @@ RUN mkdir -p /home/testuser/.ssh && chmod 700 /home/testuser/.ssh \
 RUN mkdir -p /home/testuser/.config/containers \
     && printf '[storage]\ndriver = "vfs"\n' \
        > /home/testuser/.config/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "systemd"\n\n[containers]\nlog_driver = "k8s-file"\npids_limit = 8192\n' \
+       > /home/testuser/.config/containers/containers.conf \
     && chown -R testuser:testuser /home/testuser/.config
 
 # Ensure subuid/subgid ranges exist for rootless podman
@@ -201,6 +220,7 @@ RUN mkdir -p /workspaces && chown testuser:testuser /workspaces
 # deploy the latest build without rebuilding this image.
 RUN mkdir -p /opt/aibox/addons && chown -R testuser:testuser /opt/aibox
 
-# ── Entrypoint: start sshd ───────────────────────────────────────────────────
+# ── Entrypoint: systemd starts sshd and the lingering testuser manager ───────
 EXPOSE 22
-CMD ["sh", "-c", "mkdir -p /run/sshd && exec /usr/sbin/sshd -D -e"]
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/.devcontainer/docker-compose.override.yml
+++ b/.devcontainer/docker-compose.override.yml
@@ -44,10 +44,10 @@ services:
     security_opt:
       - seccomp=unconfined
     privileged: true
-    # kind's Podman provider starts a systemd-based node container. Keep the
-    # companion in the host cgroup namespace so controllers delegated by the
-    # outer runtime remain available to that nested node.
-    cgroup: host
+    # systemd is PID 1 inside a private cgroup namespace. It delegates a user
+    # slice to testuser, where SSH-triggered kind runs in a Delegate=yes scope.
+    # A private namespace confines systemd to this companion's subtree.
+    cgroup: private
     cap_add:
       - SYS_ADMIN
       - NET_ADMIN
@@ -56,3 +56,5 @@ services:
     tmpfs:
       - /tmp
       - /run
+      - /run/lock
+    stop_grace_period: 30s

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,15 +37,27 @@ The repo devcontainer also needs an SSH client (`openssh-client`) because Tier 2
 cd /workspace/cli && cargo build
 
 # 2. Run E2E tier 2 tests (deploys binary to companion via SCP on first run).
-# The expensive visual matrix tests are opt-in and do not run here.
-cd /workspace/cli && cargo test --features e2e
+# This also runs the release-gated disposable kind cluster; visual matrices
+# remain opt-in.
+cd /workspace && ./scripts/maintain.sh test-e2e
 
 # Run a specific E2E test
 cd /workspace/cli && cargo test --features e2e -- lifecycle
 ```
 
 The deploy step is guarded by `std::sync::Once` — runs once per `cargo test` invocation.
-Re-running after a code change: `cargo build` again, then re-run `cargo test --features e2e`.
+Re-running after a code change: `cargo build` again, then re-run
+`./scripts/maintain.sh test-e2e`.
+
+The companion must be rebuilt after changes to its Dockerfile or Compose
+override. It runs systemd as PID 1 in a private cgroup namespace so SSH
+sessions receive a delegated user slice for rootless Podman:
+
+```bash
+docker compose -f .devcontainer/docker-compose.yml \
+  -f .devcontainer/docker-compose.override.yml \
+  up -d --build --force-recreate aibox-e2e-testrunner
+```
 
 ### Visual E2E tiers
 

--- a/cli/tests/e2e/kubernetes_kind.rs
+++ b/cli/tests/e2e/kubernetes_kind.rs
@@ -1,14 +1,14 @@
 //! Release-gated disposable Kubernetes validation.
 //!
-//! This deliberately remains ignored in ordinary Tier-2 runs: kind requires
-//! the nested Podman host to delegate the cgroup `pids` controller.  The
-//! runner image has pinned kubectl/kind, while CI/release infrastructure must
-//! opt in with `cargo test --features e2e kubernetes_kind -- --ignored`.
+//! This remains ignored in a plain `cargo test --features e2e` invocation
+//! because it creates a real cluster. `maintain.sh test-e2e` opts in and makes
+//! it part of release validation. The companion runs systemd as PID 1 and the
+//! cluster creation command in an explicitly delegated user scope.
 
 use super::runner::E2eRunner;
 
 #[test]
-#[ignore = "release gate: requires nested Podman with delegated cgroup pids controller"]
+#[ignore = "release gate: run through maintain.sh test-e2e"]
 fn kubernetes_kind_prerequisite_and_deterministic_cleanup() {
     let runner = E2eRunner::new();
     runner.ensure_deployed();
@@ -22,14 +22,17 @@ fn kubernetes_kind_prerequisite_and_deterministic_cleanup() {
         "set -eu; \
          kind version; \
          kubectl version --client; \
-         test \"$(cat /proc/self/cgroup)\" = '0::/'; \
+         test \"$(ps -p 1 -o comm= | tr -d ' ')\" = systemd; \
+         test \"$(stat -fc %T /sys/fs/cgroup)\" = cgroup2fs; \
          grep -qw pids /sys/fs/cgroup/cgroup.controllers; \
          grep -qw pids /sys/fs/cgroup/cgroup.subtree_control; \
+         test \"$(podman info --format '{{.Host.CgroupManager}}')\" = systemd; \
+         systemd-run --user --scope -p Delegate=yes --quiet true; \
          test -d /lib/modules",
     );
     assert!(
         preflight.status.success(),
-        "kind requires a host cgroup namespace, delegated pids controller, and /lib/modules mount. Rebuild the companion from the current Dockerfile.e2e and docker-compose.override.yml:\nstdout:\n{}\nstderr:\n{}",
+        "kind requires systemd PID 1, a delegated SSH user scope, cgroup v2 controllers, and /lib/modules. Rebuild the companion from the current Dockerfile.e2e and docker-compose.override.yml:\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&preflight.stdout),
         String::from_utf8_lossy(&preflight.stderr)
     );
@@ -42,7 +45,9 @@ fn kubernetes_kind_prerequisite_and_deterministic_cleanup() {
          export KIND_EXPERIMENTAL_PROVIDER=podman; \
          name=aibox-m7c-${RANDOM}; \
          trap 'kind delete cluster --name \"$name\" >/dev/null 2>&1 || true' EXIT; \
-         kind create cluster --name \"$name\" --wait 90s; \
+         systemd-run --user --scope -p Delegate=yes --quiet \
+           env KIND_EXPERIMENTAL_PROVIDER=podman \
+           kind create cluster --name \"$name\" --wait 90s; \
          kubectl --context \"kind-$name\" get nodes; \
          kind delete cluster --name \"$name\"; \
          trap - EXIT",

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -617,6 +617,26 @@ fn release_scripts_publish_checksum_sidecars() {
 }
 
 #[test]
+fn e2e_companion_delegates_kind_through_systemd() {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let root = manifest_dir.parent().unwrap();
+    let dockerfile = std::fs::read_to_string(root.join(".devcontainer/Dockerfile.e2e")).unwrap();
+    let compose =
+        std::fs::read_to_string(root.join(".devcontainer/docker-compose.override.yml")).unwrap();
+    let kind_gate =
+        std::fs::read_to_string(manifest_dir.join("tests/e2e/kubernetes_kind.rs")).unwrap();
+    let maintain = std::fs::read_to_string(root.join("scripts/maintain.sh")).unwrap();
+
+    assert!(dockerfile.contains("CMD [\"/sbin/init\"]"));
+    assert!(dockerfile.contains("Delegate=yes"));
+    assert!(dockerfile.contains("cgroup_manager = \"systemd\""));
+    assert!(dockerfile.contains("log_driver = \"k8s-file\""));
+    assert!(compose.contains("cgroup: private"));
+    assert!(kind_gate.contains("systemd-run --user --scope -p Delegate=yes"));
+    assert!(maintain.contains("kubernetes_kind -- --ignored --nocapture"));
+}
+
+#[test]
 fn image_fallback_tmux_config_does_not_bind_global_ctrl_j() {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let repo_root = std::path::Path::new(manifest_dir).parent().unwrap();

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -11,6 +11,7 @@
 # Commands:
 #   test              Run cargo fmt, clippy, and tests
 #   test-e2e          Run SSH companion E2E tests
+#                     including the release-gated disposable kind cluster
 #   test-e2e-visual   Run all opt-in SSH/asciinema visual E2E tiers
 #   build-images      Build published foundation/runtime images locally
 #   release-runtime-smoke <version> Run generated runtime smoke against a release
@@ -160,7 +161,7 @@ ${bold}Usage:${reset}
 
 ${bold}Development:${reset}
   test                     Run cargo fmt check, clippy, and tests
-  test-e2e                 Run Tier 2 SSH companion E2E tests
+  test-e2e                 Run Tier 2 SSH companion E2E tests and disposable kind gate
   test-e2e-visual-status   Run opt-in visual matrix for layouts/themes/status rows
   test-e2e-visual-tabs     Run opt-in tab traversal for tools and harnesses
   test-e2e-visual-yazi     Run opt-in Yazi previews/git/plugin visual checks
@@ -341,6 +342,12 @@ cmd_test_e2e() {
   info "Running Tier 2 SSH companion E2E tests..."
   (cd "${CLI_DIR}" && cargo test --features e2e --test e2e -- --test-threads="${test_threads}") \
     || status=$?
+  if [[ "${status}" -eq 0 ]]; then
+    info "Running release-gated disposable Kubernetes cluster E2E..."
+    (cd "${CLI_DIR}" && cargo test --features e2e --test e2e \
+      kubernetes_kind -- --ignored --nocapture --test-threads=1) \
+      || status=$?
+  fi
   prune_e2e_companion_storage || warn "Post-suite SSH companion prune failed"
   [[ "${status}" -eq 0 ]] || die "Tier 2 SSH companion E2E tests failed"
   ok "Tier 2 SSH companion E2E tests passed"


### PR DESCRIPTION
Summary

Makes the SSH E2E companion a real cgroup-delegation boundary so rootless Podman can host disposable kind clusters. Release validation now runs the Kubernetes gate through the same over-SSH path as the rest of Tier 2.

Changes

- run systemd as companion PID 1 in a private cgroup namespace
- start sshd as a systemd service and keep a testuser user manager alive
- explicitly delegate the user service controllers
- configure Podman with the systemd cgroup manager, `k8s-file` logging, and a larger PID limit
- run kind inside a `Delegate=yes` user scope
- add the ignored disposable-cluster test to `maintain.sh test-e2e`
- document the one-time companion rebuild and add regression coverage

Validation

- companion Dockerfile built successfully with Podman
- `cargo build`
- `cargo test` (1,132 unit; 88 E2E passed, 1 ignored; 42 integration)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `bash -n scripts/maintain.sh`
- `git diff --check`

Activation

The outer host must force-rebuild the companion once after merge. The old running companion cannot replace its own cgroup boundary from inside itself.

Refs: #186
