### PR TITLE
fix(v0): lock cargo-audit installation

### DIFF
--- a/addons/languages/rust.yaml
+++ b/addons/languages/rust.yaml
@@ -79,7 +79,7 @@ builder: |
   ENV PATH="/home/aibox/.cargo/bin:${PATH}"
 
   {% if tools["cargo-audit"].enabled %}
-  RUN cargo install cargo-audit
+  RUN cargo install cargo-audit --locked
   {% endif %}
 
   RUN install -d /usr/local/bin && \

--- a/cli/src/addon_registry.rs
+++ b/cli/src/addon_registry.rs
@@ -221,6 +221,7 @@ mod tests {
             ("rustc", true, "1.96.1"),
             ("clippy", true, ""),
             ("rustfmt", true, ""),
+            ("cargo-audit", true, ""),
         ]);
         let stage = generate_builder_stage("rust", &tools);
         assert!(stage.is_some());
@@ -232,6 +233,10 @@ mod tests {
         assert!(
             stage.contains("1.96.1"),
             "missing version 1.96.1 in:\n{stage}"
+        );
+        assert!(
+            stage.contains("cargo install cargo-audit --locked"),
+            "cargo-audit must use its published lockfile to avoid MSRV drift:\n{stage}"
         );
     }
 

--- a/cli/src/audit.rs
+++ b/cli/src/audit.rs
@@ -17,7 +17,7 @@ fn check_cargo_audit() -> Result<()> {
         .output()
         .is_err()
     {
-        output::warn("cargo-audit not installed. Install: cargo install cargo-audit");
+        output::warn("cargo-audit not installed. Install: cargo install cargo-audit --locked");
         return Ok(());
     }
 
@@ -124,7 +124,7 @@ pub fn doctor_check_audit_tools() {
     if cargo_audit_available {
         output::ok("cargo-audit available");
     } else {
-        output::warn("cargo-audit not installed (optional: cargo install cargo-audit)");
+        output::warn("cargo-audit not installed (optional: cargo install cargo-audit --locked)");
     }
 
     if pip_audit_available {

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -2005,7 +2005,7 @@ release_visual_gate() {
 release_audit_gate() {
   info "Running cargo audit..."
   command -v cargo-audit &>/dev/null \
-    || (cd "${CLI_DIR}" && cargo install cargo-audit --quiet)
+    || (cd "${CLI_DIR}" && cargo install cargo-audit --locked --quiet)
   local audit_db="${TMPDIR:-/tmp}/aibox-cargo-advisory-db"
   mkdir -p "${audit_db}"
   (cd "${CLI_DIR}" && cargo audit --db "${audit_db}") \


### PR DESCRIPTION
## Summary

Prevent v0.x-derived Rust images from failing when unlocked cargo-audit dependencies raise their minimum supported Rust version.

## Changes

- install cargo-audit with its published lockfile in generated Rust builder stages
- apply the same guard in the release audit fallback and CLI guidance
- add a generator regression assertion

## Validation

- cargo test (1060 unit + 90 Tier-1 E2E + 30 integration passed; 1 expected ignored)
- cargo build
- cargo clippy --all-targets -- -D warnings
- cargo fmt -- --check
- bash -n scripts/maintain.sh
- git diff --check