### PR TITLE
chore(v0): refresh maintenance toolchain

### DIFF
--- a/addons/ai/ai-hermes.yaml
+++ b/addons/ai/ai-hermes.yaml
@@ -11,8 +11,8 @@ tools:
   - name: hermes
     description: "Nous Hermes autonomous AI agent CLI"
     default_enabled: true
-    default_version: "0.18.0"
-    supported_versions: ["0.16.0", "0.18.0"]
+    default_version: "0.19.0"
+    supported_versions: ["0.16.0", "0.18.0", "0.19.0"]
 
 builder: null
 

--- a/addons/docs/docs-hugo.yaml
+++ b/addons/docs/docs-hugo.yaml
@@ -28,7 +28,7 @@ runtime: |
         arm64) HUGO_ARCH="arm64" ;; \
         *) echo "Unsupported Hugo architecture: ${DEB_ARCH}" >&2; exit 1 ;; \
       esac && \
-      HUGO_VERSION="0.163.3" && \
+      HUGO_VERSION="0.164.0" && \
       HUGO_ASSET="hugo_extended_${HUGO_VERSION}_linux-${HUGO_ARCH}.tar.gz" && \
       curl -fsSL \
         "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_ASSET}" \

--- a/addons/docs/docs-mdbook.yaml
+++ b/addons/docs/docs-mdbook.yaml
@@ -22,13 +22,15 @@ builder: null
 runtime: |
   # Addon: docs-mdbook
   RUN ARCH="$(uname -m)" && \
-      MDBOOK_VERSION="0.5.3" && \
+      MDBOOK_VERSION="0.5.4" && \
+      case "${ARCH}" in \
+        aarch64) MDBOOK_SHA256="753e5c5c363ee8a56972344dcf91466f005a51db84a7aeffe427ae3ef83d6d44" ;; \
+        x86_64) MDBOOK_SHA256="5222beabd3e37dc5be0d18ff99b79058469354db5c220153a1b92db5ba12be89" ;; \
+        *) echo "Unsupported mdBook architecture: ${ARCH}" >&2; exit 1 ;; \
+      esac && \
       curl -fsSL \
         "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" \
         -o /tmp/mdbook.tar.gz && \
-      curl -fsSL \
-        "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-${ARCH}-unknown-linux-musl.tar.gz.sha256" \
-        -o /tmp/mdbook.tar.gz.sha256 && \
-      (cd /tmp && sha256sum -c mdbook.tar.gz.sha256) && \
+      echo "${MDBOOK_SHA256}  /tmp/mdbook.tar.gz" | sha256sum -c - && \
       tar -xz -C /usr/local/bin -f /tmp/mdbook.tar.gz && \
-      rm /tmp/mdbook.tar.gz /tmp/mdbook.tar.gz.sha256
+      rm /tmp/mdbook.tar.gz

--- a/addons/docs/docs-mkdocs.yaml
+++ b/addons/docs/docs-mkdocs.yaml
@@ -24,5 +24,5 @@ builder: null
 
 runtime: |
   # Addon: docs-mkdocs
-  RUN UV_CACHE_DIR=/tmp/aibox-uv-cache uv tool install 'mkdocs=={{ tools.mkdocs.version }}' --with 'mkdocs-material==9.7.6' && \
+  RUN UV_CACHE_DIR=/tmp/aibox-uv-cache uv tool install 'mkdocs=={{ tools.mkdocs.version }}' --with 'mkdocs-material==9.7.7' && \
       rm -rf /tmp/aibox-uv-cache

--- a/addons/docs/docs-zensical.yaml
+++ b/addons/docs/docs-zensical.yaml
@@ -17,8 +17,8 @@ tools:
   - name: zensical
     description: "Python documentation site generator"
     default_enabled: true
-    default_version: "0.0.47"
-    supported_versions: ["0.0.43", "0.0.44", "0.0.47"]
+    default_version: "0.0.51"
+    supported_versions: ["0.0.43", "0.0.44", "0.0.47", "0.0.51"]
 
 builder: null
 

--- a/addons/languages/go.yaml
+++ b/addons/languages/go.yaml
@@ -15,8 +15,8 @@ tools:
   - name: go
     description: "Go compiler, tooling, and module workflow"
     default_enabled: true
-    default_version: "1.26.4"
-    supported_versions: ["1.25", "1.26", "1.26.3", "1.26.4"]
+    default_version: "1.26.5"
+    supported_versions: ["1.25", "1.26", "1.26.3", "1.26.4", "1.26.5"]
 
 builder: null
 

--- a/addons/languages/node.yaml
+++ b/addons/languages/node.yaml
@@ -20,8 +20,8 @@ tools:
   - name: pnpm
     description: "Fast disk-efficient Node package manager"
     default_enabled: true
-    default_version: "11.10.0"
-    supported_versions: ["9", "10", "11.1.3", "11.5.2", "11.10.0"]
+    default_version: "11.17.0"
+    supported_versions: ["9", "10", "11.1.3", "11.5.2", "11.10.0", "11.17.0"]
   - name: yarn
     description: "Yarn Node package manager"
     default_enabled: false

--- a/addons/languages/python.yaml
+++ b/addons/languages/python.yaml
@@ -8,7 +8,7 @@ exported_surfaces: ["language-runtime", "build-toolchain", "cli-binary"]
 builder_weight: null
 
 # As of aibox v0.16.5 (DEC-036), python3 (Debian Trixie default, 3.13.x)
-# and uv (0.11.26 from ghcr.io/astral-sh/uv) are unconditionally present
+# and uv (0.11.32 from ghcr.io/astral-sh/uv) are unconditionally present
 # in the base-debian image. This addon now provides ADDITIONAL Python
 # tooling beyond that minimum: alternative Python versions (3.12, 3.14),
 # poetry, pdm, and the recommended skills below.
@@ -27,8 +27,8 @@ tools:
   - name: uv
     description: "Fast Python package manager and virtual environment tool"
     default_enabled: true
-    default_version: "0.11.26"
-    supported_versions: ["0.7", "0.11.10", "0.11.11", "0.11.15", "0.11.19", "0.11.26"]
+    default_version: "0.11.32"
+    supported_versions: ["0.7", "0.11.10", "0.11.11", "0.11.15", "0.11.19", "0.11.26", "0.11.32"]
   - name: pip
     description: "Python package installer for pip-based projects"
     default_enabled: false
@@ -67,7 +67,7 @@ runtime: |
       && rm -rf /var/lib/apt/lists/*
   {% endif %}
 
-  {% if tools.uv.version != "0.11.26" %}
+  {% if tools.uv.version != "0.11.32" %}
   COPY --from=ghcr.io/astral-sh/uv:{{ tools.uv.version }} /uv /usr/local/bin/uv
   COPY --from=ghcr.io/astral-sh/uv:{{ tools.uv.version }} /uvx /usr/local/bin/uvx
   {% endif %}

--- a/addons/languages/rust.yaml
+++ b/addons/languages/rust.yaml
@@ -15,8 +15,8 @@ tools:
   - name: rustc
     description: "Rust compiler toolchain installed via rustup"
     default_enabled: true
-    default_version: "1.96.1"
-    supported_versions: ["1.90", "1.91", "1.92", "1.93", "1.94", "1.94.1", "1.96.0", "1.96.1"]
+    default_version: "1.97.1"
+    supported_versions: ["1.90", "1.91", "1.92", "1.93", "1.94", "1.94.1", "1.96.0", "1.96.1", "1.97.1"]
   - name: clippy
     description: "Rust linter for catching common mistakes and style issues"
     default_enabled: true

--- a/addons/tools/infrastructure.yaml
+++ b/addons/tools/infrastructure.yaml
@@ -14,18 +14,18 @@ tools:
   - name: opentofu
     description: "Open-source Terraform-compatible infrastructure as code CLI"
     default_enabled: true
-    default_version: "1.12.3"
-    supported_versions: ["1.9.0", "1.12.0", "1.12.1", "1.12.3"]
+    default_version: "1.12.5"
+    supported_versions: ["1.9.0", "1.12.0", "1.12.1", "1.12.3", "1.12.5"]
   - name: ansible
     description: "Configuration management and automation engine"
     default_enabled: true
-    default_version: "14.1.0"
-    supported_versions: ["13.7.0", "14.0.0", "14.1.0"]
+    default_version: "14.2.0"
+    supported_versions: ["13.7.0", "14.0.0", "14.1.0", "14.2.0"]
   - name: packer
     description: "Machine image build automation tool"
     default_enabled: true
-    default_version: "1.15.4"
-    supported_versions: ["1.11.2", "1.15.3", "1.15.4"]
+    default_version: "1.16.0"
+    supported_versions: ["1.11.2", "1.15.3", "1.15.4", "1.16.0"]
 
 builder: |
   # ── Infrastructure builder ────────────────────────────────────────────

--- a/addons/tools/kubernetes.yaml
+++ b/addons/tools/kubernetes.yaml
@@ -15,13 +15,13 @@ tools:
   - name: kubectl
     description: "Kubernetes command-line client"
     default_enabled: true
-    default_version: "1.36.2"
-    supported_versions: ["1.36.1", "1.36.2"]
+    default_version: "1.36.3"
+    supported_versions: ["1.36.1", "1.36.2", "1.36.3"]
   - name: helm
     description: "Kubernetes package manager for charts"
     default_enabled: true
-    default_version: "4.2.2"
-    supported_versions: ["3.17.2", "4.2.0", "4.2.2"]
+    default_version: "4.2.3"
+    supported_versions: ["3.17.2", "4.2.0", "4.2.2", "4.2.3"]
   - name: kustomize
     description: "Kubernetes manifest overlay and patching tool"
     default_enabled: true

--- a/aibox.toml
+++ b/aibox.toml
@@ -154,13 +154,13 @@ hugo = { enabled = true } # Fast Go-based static site generator; default off; op
 
 # Documentation/docs-zensical — Zensical – Python docs site; requires python
 # [addons.docs-zensical.tools]
-# zensical = {} # Python documentation site generator; default on; options: {}, { enabled = true|false }, { version = "0.0.43" | "0.0.44" | "0.0.47" (default) or "latest" }
+# zensical = {} # Python documentation site generator; default on; options: {}, { enabled = true|false }, { version = "0.0.43" | "0.0.44" | "0.0.47" | "0.0.51" (default) or "latest" }
 
 # ---- Languages ------------------------------------------------------------
 
 # Languages/go — Go programming language toolchain
 # [addons.go.tools]
-# go = {} # Go compiler, tooling, and module workflow; default on; options: {}, { enabled = true|false }, { version = "1.25" | "1.26" | "1.26.3" | "1.26.4" (default) or "latest" }
+# go = {} # Go compiler, tooling, and module workflow; default on; options: {}, { enabled = true|false }, { version = "1.25" | "1.26" | "1.26.3" | "1.26.4" | "1.26.5" (default) or "latest" }
 
 # Languages/latex — TeX Live LaTeX typesetting system
 # [addons.latex.tools]
@@ -179,21 +179,21 @@ hugo = { enabled = true } # Fast Go-based static site generator; default off; op
 # Languages/node — Node.js runtime with pnpm, yarn, or bun
 [addons.node.tools]
 node = { version = "26" } # Node.js JavaScript and TypeScript runtime; default on; options: {}, { enabled = true|false }, { version = "20" | "22" | "24" | "26" (default) or "latest" }
-pnpm = { version = "11.10.0" } # Fast disk-efficient Node package manager; default on; options: {}, { enabled = true|false }, { version = "9" | "10" | "11.1.3" | "11.5.2" | "11.10.0" (default) or "latest" }
+pnpm = { version = "11.17.0" } # Fast disk-efficient Node package manager; default on; options: {}, { enabled = true|false }, { version = "9" | "10" | "11.1.3" | "11.5.2" | "11.10.0" | "11.17.0" (default) or "latest" }
 # yarn = { enabled = true } # Yarn Node package manager; default off; options: {}, { enabled = true|false }, { version = "4" | "4.16.0" | "4.17.0" (default) or "latest" }
 # bun = { enabled = true } # Bun JavaScript runtime, package manager, and test runner; default off; options: {}, { enabled = true|false }, { version = "1.2" | "1.3.14" (default) or "latest" }
 
 # Languages/python — Python runtime with uv, poetry, or pdm
 [addons.python.tools]
 python = { version = "3.14" } # Python interpreter runtime for applications and scripts; default on; options: {}, { enabled = true|false }, { version = "3.12" | "3.13" | "3.14" (default) or "latest" }
-uv = { version = "0.11.26" } # Fast Python package manager and virtual environment tool; default on; options: {}, { enabled = true|false }, { version = "0.7" | "0.11.10" | "0.11.11" | "0.11.15" | "0.11.19" | "0.11.26" (default) or "latest" }
+uv = { version = "0.11.32" } # Fast Python package manager and virtual environment tool; default on; options: {}, { enabled = true|false }, { version = "0.7" | "0.11.10" | "0.11.11" | "0.11.15" | "0.11.19" | "0.11.26" | "0.11.32" (default) or "latest" }
 # pip = { enabled = true } # Python package installer for pip-based projects; default off; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
 # poetry = { enabled = true } # Python dependency and packaging workflow manager; default off; options: {}, { enabled = true|false }, { version = "1.8" | "2.0" | "2.4.1" (default) or "latest" }
 # pdm = { enabled = true } # Python project and dependency manager using PEP standards; default off; options: {}, { enabled = true|false }, { version = "2.22" | "2.26.9" | "2.27.0" | "2.28.0" (default) or "latest" }
 
 # Languages/rust — Rust toolchain via rustup
 [addons.rust.tools]
-rustc = { version = "1.96.1" } # Rust compiler toolchain installed via rustup; default on; options: {}, { enabled = true|false }, { version = "1.90" | "1.91" | "1.92" | "1.93" | "1.94" | "1.94.1" | "1.96.0" | "1.96.1" (default) or "latest" }
+rustc = { version = "1.97.1" } # Rust compiler toolchain installed via rustup; default on; options: {}, { enabled = true|false }, { version = "1.90" | "1.91" | "1.92" | "1.93" | "1.94" | "1.94.1" | "1.96.0" | "1.96.1" | "1.97.1" (default) or "latest" }
 clippy = {} # Rust linter for catching common mistakes and style issues; default on; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
 rustfmt = {} # Rust code formatter; default on; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
 cargo-audit = {} # Rust dependency vulnerability scanner; default on; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
@@ -233,14 +233,14 @@ lazygit = { enabled = true } # Interactive terminal UI for Git status, commits, 
 
 # Tools/infrastructure — OpenTofu, Ansible, Packer
 # [addons.infrastructure.tools]
-# opentofu = {} # Open-source Terraform-compatible infrastructure as code CLI; default on; options: {}, { enabled = true|false }, { version = "1.9.0" | "1.12.0" | "1.12.1" | "1.12.3" (default) or "latest" }
-# ansible = {} # Configuration management and automation engine; default on; options: {}, { enabled = true|false }, { version = "13.7.0" | "14.0.0" | "14.1.0" (default) or "latest" }
-# packer = {} # Machine image build automation tool; default on; options: {}, { enabled = true|false }, { version = "1.11.2" | "1.15.3" | "1.15.4" (default) or "latest" }
+# opentofu = {} # Open-source Terraform-compatible infrastructure as code CLI; default on; options: {}, { enabled = true|false }, { version = "1.9.0" | "1.12.0" | "1.12.1" | "1.12.3" | "1.12.5" (default) or "latest" }
+# ansible = {} # Configuration management and automation engine; default on; options: {}, { enabled = true|false }, { version = "13.7.0" | "14.0.0" | "14.1.0" | "14.2.0" (default) or "latest" }
+# packer = {} # Machine image build automation tool; default on; options: {}, { enabled = true|false }, { version = "1.11.2" | "1.15.3" | "1.15.4" | "1.16.0" (default) or "latest" }
 
 # Tools/kubernetes — kubectl, Helm, Kustomize, k9s
 # [addons.kubernetes.tools]
-# kubectl = {} # Kubernetes command-line client; default on; options: {}, { enabled = true|false }, { version = "1.36.1" | "1.36.2" (default) or "latest" }
-# helm = {} # Kubernetes package manager for charts; default on; options: {}, { enabled = true|false }, { version = "3.17.2" | "4.2.0" | "4.2.2" (default) or "latest" }
+# kubectl = {} # Kubernetes command-line client; default on; options: {}, { enabled = true|false }, { version = "1.36.1" | "1.36.2" | "1.36.3" (default) or "latest" }
+# helm = {} # Kubernetes package manager for charts; default on; options: {}, { enabled = true|false }, { version = "3.17.2" | "4.2.0" | "4.2.2" | "4.2.3" (default) or "latest" }
 # kustomize = {} # Kubernetes manifest overlay and patching tool; default on; options: {}, { enabled = true|false }, { version = "5.6.0" | "5.8.1" (default) or "latest" }
 # k9s = { enabled = true } # Interactive terminal UI for Kubernetes clusters; default off; options: {}, { enabled = true|false }, { version = "0.50.18" | "0.51.0" (default) or "latest" }
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -107,15 +107,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "autocfg"
@@ -131,15 +131,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -152,15 +152,15 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -209,23 +209,23 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -242,9 +242,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filetime"
@@ -388,22 +388,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -412,15 +406,15 @@ dependencies = [
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -441,24 +435,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -475,9 +458,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -491,9 +474,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -523,21 +506,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -554,13 +529,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -571,22 +545,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -608,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchers"
@@ -623,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memo-map"
@@ -635,9 +603,9 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "minijinja"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
+checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
 dependencies = [
  "memo-map",
  "serde",
@@ -758,16 +726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,18 +736,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -822,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -833,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ring"
@@ -866,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "log",
  "once_cell",
@@ -881,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -901,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -929,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -939,29 +897,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1014,7 +972,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1051,9 +1009,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -1063,9 +1021,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -1092,9 +1050,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1119,7 +1088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1127,38 +1096,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1180,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1202,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -1225,7 +1194,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1284,12 +1253,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1378,28 +1341,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1410,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1420,65 +1365,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1504,7 +1415,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1515,7 +1426,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1626,105 +1537,11 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]
@@ -1739,12 +1556,12 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/cli/src/addon_cmd.rs
+++ b/cli/src/addon_cmd.rs
@@ -461,7 +461,7 @@ name = "test"
 
 [addons.python.tools]
 python = { version = "3.14" }
-	uv = { version = "0.11.26" }
+	uv = { version = "0.11.32" }
 "#,
         )
         .unwrap();

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1501,4 +1501,32 @@ runtime: |
             "grep \" ${HUGO_ASSET}$\" /tmp/hugo_checksums.txt | sed 's#  .*#  /tmp/hugo.tar.gz#' | sha256sum -c"
         ));
     }
+
+    #[test]
+    fn docs_mdbook_installer_uses_published_asset_digests() {
+        let addon = load_repo_addon("docs-mdbook");
+        let mut tools = all_disabled_tools(&addon);
+        tools.insert(
+            "mdbook".to_string(),
+            ToolConfig {
+                enabled: true,
+                version: String::new(),
+            },
+        );
+        let rendered = render_runtime(&addon, &tools).unwrap();
+
+        assert!(rendered.contains(
+            "aarch64) MDBOOK_SHA256=\"753e5c5c363ee8a56972344dcf91466f005a51db84a7aeffe427ae3ef83d6d44\""
+        ));
+        assert!(rendered.contains(
+            "x86_64) MDBOOK_SHA256=\"5222beabd3e37dc5be0d18ff99b79058469354db5c220153a1b92db5ba12be89\""
+        ));
+        assert!(
+            rendered.contains("echo \"${MDBOOK_SHA256}  /tmp/mdbook.tar.gz\" | sha256sum -c -")
+        );
+        assert!(
+            !rendered.contains(".tar.gz.sha256"),
+            "mdBook 0.5.4 does not publish separate checksum assets: {rendered}"
+        );
+    }
 }

--- a/cli/src/addon_registry.rs
+++ b/cli/src/addon_registry.rs
@@ -190,8 +190,8 @@ mod tests {
         assert!(py.supported_versions.contains(&"3.14"));
         assert_eq!(py.default_version, "3.14");
         let uv = addon.tools.iter().find(|t| t.name == "uv").unwrap();
-        assert!(uv.supported_versions.contains(&"0.11.26"));
-        assert_eq!(uv.default_version, "0.11.26");
+        assert!(uv.supported_versions.contains(&"0.11.32"));
+        assert_eq!(uv.default_version, "0.11.32");
     }
 
     #[test]
@@ -199,8 +199,8 @@ mod tests {
         ensure_loaded();
         let addon = get_addon("rust").unwrap();
         let rustc = addon.tools.iter().find(|t| t.name == "rustc").unwrap();
-        assert!(rustc.supported_versions.contains(&"1.96.1"));
-        assert_eq!(rustc.default_version, "1.96.1");
+        assert!(rustc.supported_versions.contains(&"1.97.1"));
+        assert_eq!(rustc.default_version, "1.97.1");
     }
 
     #[test]
@@ -218,7 +218,7 @@ mod tests {
     fn rust_has_builder_stage() {
         ensure_loaded();
         let tools = tc(&[
-            ("rustc", true, "1.96.1"),
+            ("rustc", true, "1.97.1"),
             ("clippy", true, ""),
             ("rustfmt", true, ""),
             ("cargo-audit", true, ""),
@@ -231,8 +231,8 @@ mod tests {
             "missing rust-builder in:\n{stage}"
         );
         assert!(
-            stage.contains("1.96.1"),
-            "missing version 1.96.1 in:\n{stage}"
+            stage.contains("1.97.1"),
+            "missing version 1.97.1 in:\n{stage}"
         );
         assert!(
             stage.contains("cargo install cargo-audit --locked"),
@@ -252,7 +252,7 @@ mod tests {
     #[test]
     fn python_runtime_uses_base_python_uv_without_extra_layers() {
         ensure_loaded();
-        let tools = tc(&[("python", true, "3.13"), ("uv", true, "0.11.26")]);
+        let tools = tc(&[("python", true, "3.13"), ("uv", true, "0.11.32")]);
         let cmds = generate_runtime_commands("python", &tools);
         assert!(
             !cmds.contains("python3-pip"),
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn python_runtime_installs_alternate_python_with_uv() {
         ensure_loaded();
-        let tools = tc(&[("python", true, "3.14"), ("uv", true, "0.11.26")]);
+        let tools = tc(&[("python", true, "3.14"), ("uv", true, "0.11.32")]);
         let cmds = generate_runtime_commands("python", &tools);
         assert!(
             cmds.contains("uv python install 3.14"),
@@ -290,7 +290,7 @@ mod tests {
     #[test]
     fn rust_runtime_copies_from_builder() {
         ensure_loaded();
-        let tools = tc(&[("rustc", true, "1.96.1"), ("x86_64-cross", true, "")]);
+        let tools = tc(&[("rustc", true, "1.97.1"), ("x86_64-cross", true, "")]);
         let cmds = generate_runtime_commands("rust", &tools);
         assert!(
             cmds.contains("COPY --from=rust-builder"),
@@ -379,8 +379,8 @@ mod tests {
         let mistral = generate_runtime_commands("ai-mistral", &tc(&[("mistral", true, "2.4.4")]));
         assert!(mistral.contains("mistralai==2.4.4"), "{mistral}");
 
-        let hermes = generate_runtime_commands("ai-hermes", &tc(&[("hermes", true, "0.18.0")]));
-        assert!(hermes.contains("hermes-agent==0.18.0"), "{hermes}");
+        let hermes = generate_runtime_commands("ai-hermes", &tc(&[("hermes", true, "0.19.0")]));
+        assert!(hermes.contains("hermes-agent==0.19.0"), "{hermes}");
         assert!(
             hermes.contains("UV_TOOL_DIR=/opt/aibox/uv-tools"),
             "Hermes tool environment must remain traversable by the runtime user: {hermes}"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1099,7 +1099,7 @@ pub struct AddonToolsSection {
 /// ```toml
 /// [addons.python.tools]
 /// python = { version = "3.14" }
-/// uv = { version = "0.11.26" }
+/// uv = { version = "0.11.32" }
 /// ```
 ///
 /// Deserialized as `HashMap<String, AddonToolsSection>` where the outer key
@@ -5410,10 +5410,10 @@ uv = { version = "0.7" }
 
 [addons.node.tools]
 node = { version = "26" }
-pnpm = { version = "11.10.0" }
+pnpm = { version = "11.17.0" }
 
 [addons.rust.tools]
-rustc = { version = "1.96.1" }
+rustc = { version = "1.97.1" }
 clippy = {}
 rustfmt = {}
 
@@ -5570,7 +5570,7 @@ name = "my-project"
         // Check specific tool versions
         assert_eq!(config.addons.tool_version("python", "python"), Some("3.14"));
         assert_eq!(config.addons.tool_version("python", "uv"), Some("0.7"));
-        assert_eq!(config.addons.tool_version("rust", "rustc"), Some("1.96.1"));
+        assert_eq!(config.addons.tool_version("rust", "rustc"), Some("1.97.1"));
         assert_eq!(config.addons.tool_version("rust", "clippy"), None);
         assert_eq!(config.addons.tool_version("rust", "rustfmt"), None);
         assert!(config.addons.has_tool("kubernetes", "kubectl"));
@@ -6504,7 +6504,7 @@ harnesses = []
         assert!(config.addons.has_tool("python", "uv"));
         assert!(!config.addons.has_tool("python", "poetry"));
         assert_eq!(config.addons.tool_version("node", "node"), Some("26"));
-        assert_eq!(config.addons.tool_version("node", "pnpm"), Some("11.10.0"));
+        assert_eq!(config.addons.tool_version("node", "pnpm"), Some("11.17.0"));
         assert_eq!(config.addons.tool_version("cloud-aws", "aws-cli"), None);
     }
 

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -190,6 +190,41 @@ fn release_scripts_publish_checksum_sidecars() {
 }
 
 #[test]
+fn release_state_reads_tool_pins_from_their_sources() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let repo_root = std::path::Path::new(manifest_dir).parent().unwrap();
+    let state = std::fs::read_to_string(repo_root.join("scripts/release-check-state.sh"))
+        .expect("read release-check-state.sh");
+
+    assert!(
+        state.contains(
+            r#"uv_pin="$(container_image_tag "${BASE_DOCKERFILE}" "ghcr.io/astral-sh/uv" || true)""#
+        ),
+        "uv release-state inventory must derive the image tag from the Dockerfile"
+    );
+    assert!(
+        state.contains(
+            r#""$(quoted_assignment "${PROJECT_ROOT}/addons/docs/docs-hugo.yaml" HUGO_VERSION || true)""#
+        ) && state.contains(
+            r#""$(quoted_assignment "${PROJECT_ROOT}/addons/docs/docs-mdbook.yaml" MDBOOK_VERSION || true)""#
+        ) && state.contains(
+            r#""$(package_pin "${PROJECT_ROOT}/addons/docs/docs-mkdocs.yaml" mkdocs-material || true)""#
+        ),
+        "documentation tool inventory must derive pins from addon manifests"
+    );
+    assert!(
+        state.contains("https://static.rust-lang.org/dist/channel-rust-stable.toml")
+            && state.contains(r#"/^\[pkg\.rust\]$/"#),
+        "Rust latest lookup must read the stable toolchain manifest rather than rustup's own version"
+    );
+    assert!(
+        state.contains("Status: Cargo.lock is current for the active Rust toolchain.")
+            && state.contains("Locking 0 packages"),
+        "a current Cargo.lock must not produce an actionable update disposition"
+    );
+}
+
+#[test]
 fn image_fallback_tmux_config_does_not_bind_global_ctrl_j() {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let repo_root = std::path::Path::new(manifest_dir).parent().unwrap();

--- a/docs-site/content/docs/addons/documentation.md
+++ b/docs-site/content/docs/addons/documentation.md
@@ -16,8 +16,8 @@ Documentation addons install static site generators and documentation tools.
 | `docs-mdbook` | mdBook | Binary download |
 | `docs-hugo` | Hugo Extended | Binary download |
 
-Current curated pins are Docusaurus 3.10.1, Hugo 0.163.3, mdBook 0.5.3,
-MkDocs 1.6.1 with Material 9.7.6, and Zensical 0.0.47. Starlight remains
+Current curated pins are Docusaurus 3.10.1, Hugo 0.164.0, mdBook 0.5.4,
+MkDocs 1.6.1 with Material 9.7.7, and Zensical 0.0.51. Starlight remains
 scaffolded through the upstream `create-starlight` package.
 
 ## Example

--- a/docs-site/content/docs/addons/language-runtimes.md
+++ b/docs-site/content/docs/addons/language-runtimes.md
@@ -12,7 +12,7 @@ Language runtimes install compilers, interpreters, and package managers into you
 ```toml
 [addons.python.tools]
 python = { version = "3.14" }   # 3.12, 3.13, 3.14
-uv = { version = "0.11.26" }    # 0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26
+uv = { version = "0.11.32" }    # 0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26, 0.11.32
 # poetry = { version = "2.4.1" } # Optional: 1.8, 2.0, 2.4.1
 # pdm = { version = "2.28.0" }   # Optional: 2.22, 2.26.9, 2.27.0, 2.28.0
 ```
@@ -23,7 +23,7 @@ Installs Python, pip, venv, and [uv](https://github.com/astral-sh/uv) (fast pack
 
 ```toml
 [addons.rust.tools]
-rustc = { version = "1.96.1" }  # 1.90, 1.91, 1.92, 1.93, 1.94, 1.94.1, 1.96.0, 1.96.1
+rustc = { version = "1.97.1" }  # 1.90, 1.91, 1.92, 1.93, 1.94, 1.94.1, 1.96.0, 1.96.1, 1.97.1
 clippy = {}                     # Linter (no version selection)
 rustfmt = {}                    # Formatter (no version selection)
 ```
@@ -35,7 +35,7 @@ Installs the Rust toolchain via rustup with clippy and rustfmt. Uses a multi-sta
 ```toml
 [addons.node.tools]
 node = { version = "26" }       # 20, 22, 24, 26
-pnpm = { version = "11.10.0" }  # 9, 10, 11.1.3, 11.5.2, 11.10.0
+pnpm = { version = "11.17.0" }  # 9, 10, 11.1.3, 11.5.2, 11.10.0, 11.17.0
 # yarn = { version = "4.17.0" } # Optional: 4, 4.16.0, 4.17.0
 # bun = { version = "1.3.14" }  # Optional
 ```
@@ -46,7 +46,7 @@ Installs Node.js via NodeSource, plus pnpm as default package manager. Yarn and 
 
 ```toml
 [addons.go.tools]
-go = { version = "1.26.4" }     # 1.25, 1.26, 1.26.3, 1.26.4
+go = { version = "1.26.5" }     # 1.25, 1.26, 1.26.3, 1.26.4, 1.26.5
 ```
 
 Installs Go and sets up GOPATH.

--- a/docs-site/content/docs/addons/overview.md
+++ b/docs-site/content/docs/addons/overview.md
@@ -33,16 +33,16 @@ aibox describe addon-catalog -o json
 ```toml
 [addons.python.tools]
 python = { version = "3.14" }
-uv = { version = "0.11.26" }
+uv = { version = "0.11.32" }
 
 [addons.rust.tools]
-rustc = { version = "1.96.1" }
+rustc = { version = "1.97.1" }
 clippy = {}
 rustfmt = {}
 
 [addons.node.tools]
 node = { version = "26" }
-pnpm = { version = "11.10.0" }
+pnpm = { version = "11.17.0" }
 ```
 
 Each addon has **default-enabled tools** that are included automatically, and **optional tools** you can enable explicitly. Tools with version selection let you pick from curated, tested versions.
@@ -61,10 +61,10 @@ After editing `aibox.toml`, run `aibox apply` to regenerate the Dockerfile and r
 
 | Addon | Default Tools | Optional Tools |
 |-------|--------------|----------------|
-| `python` | python (3.12/3.13/3.14), uv (0.7/0.11.10/0.11.11/0.11.15/0.11.19/0.11.26) | poetry (1.8/2.0/2.4.1), pdm (2.22/2.26.9/2.27.0/2.28.0) |
-| `rust` | rustc (1.90/1.91/1.92/1.93/1.94/1.94.1/1.96.0/1.96.1), clippy, rustfmt | — |
-| `node` | node (20/22/24/26), pnpm (9/10/11.1.3/11.5.2/11.10.0) | yarn (4/4.16.0/4.17.0), bun (1.2/1.3.14) |
-| `go` | go (1.25/1.26/1.26.3/1.26.4) | — |
+| `python` | python (3.12/3.13/3.14), uv (0.7/0.11.10/0.11.11/0.11.15/0.11.19/0.11.26/0.11.32) | poetry (1.8/2.0/2.4.1), pdm (2.22/2.26.9/2.27.0/2.28.0) |
+| `rust` | rustc (1.90/1.91/1.92/1.93/1.94/1.94.1/1.96.0/1.96.1/1.97.1), clippy, rustfmt | — |
+| `node` | node (20/22/24/26), pnpm (9/10/11.1.3/11.5.2/11.10.0/11.17.0) | yarn (4/4.16.0/4.17.0), bun (1.2/1.3.14) |
+| `go` | go (1.25/1.26/1.26.3/1.26.4/1.26.5) | — |
 | `typst` | typst (0.13.1/0.14.2/0.15.0) | — |
 | `latex` | texlive-core, texlive-recommended, texlive-fonts, biber, texlive-code, texlive-diagrams, texlive-math | texlive-music, texlive-chemistry |
 
@@ -174,7 +174,7 @@ Recipe version: 1.0.0
 
   TOOL      DEFAULT    VERSION  SUPPORTED
   python        yes       3.14  3.12, 3.13, 3.14
-  uv            yes    0.11.26  0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26
+  uv            yes    0.11.32  0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26, 0.11.32
   poetry         no      2.4.1  1.8, 2.0, 2.4.1
   pdm            no     2.28.0  2.22, 2.26.9, 2.27.0, 2.28.0
 ```

--- a/docs-site/content/docs/addons/tool-bundles.md
+++ b/docs-site/content/docs/addons/tool-bundles.md
@@ -74,7 +74,7 @@ ansible = {}       # Configuration management
 packer = {}        # Machine image builder
 ```
 
-OpenTofu defaults to 1.12.0, Packer to 1.15.3, and Ansible to 13.7.0.
+OpenTofu defaults to 1.12.5, Packer to 1.16.0, and Ansible to 14.2.0.
 OpenTofu and Packer are installed in a multi-stage builder. Ansible is installed via pip.
 
 ## Kubernetes
@@ -87,7 +87,7 @@ kustomize = {}     # Configuration customization
 # k9s = {}         # Optional: terminal UI for Kubernetes
 ```
 
-kubectl defaults to 1.36.2, Helm to 4.2.2, Kustomize to 5.8.1, and k9s to 0.51.0.
+kubectl defaults to 1.36.3, Helm to 4.2.3, Kustomize to 5.8.1, and k9s to 0.51.0.
 All tools are downloaded as static binaries in a multi-stage builder.
 
 ## Cloud Providers

--- a/docs-site/content/docs/getting-started/new-project.md
+++ b/docs-site/content/docs/getting-started/new-project.md
@@ -155,7 +155,7 @@ schema_version = "1.0.0"
 # Run `aibox get addon` to see all available addons.
 # [addons.python.tools]
 # python = { version = "3.14" }
-# uv     = { version = "0.11.26" }
+# uv     = { version = "0.11.32" }
 
 # AI harnesses — controls which AI CLIs/configs are enabled.
 [ai]

--- a/docs-site/content/docs/reference/configuration.md
+++ b/docs-site/content/docs/reference/configuration.md
@@ -65,10 +65,10 @@ schema_version = "1.0.0"              # Context schema version (semver)
 
 [addons.python.tools]                 # Addon: Python runtime
 python = { version = "3.14" }
-uv     = { version = "0.11.26" }
+uv     = { version = "0.11.32" }
 
 [addons.rust.tools]                   # Addon: Rust toolchain
-rustc   = { version = "1.96.1" }
+rustc   = { version = "1.97.1" }
 clippy  = {}
 rustfmt = {}
 
@@ -446,7 +446,7 @@ to install their CLIs.
 ```toml
 [addons.python.tools]
 python = { version = "3.14" }
-uv = { version = "0.11.26" }
+uv = { version = "0.11.32" }
 ```
 
 For interactive Git tooling:

--- a/images/base-debian/Dockerfile
+++ b/images/base-debian/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV CARGO_HOME=/cargo RUSTUP_HOME=/rustup PATH="/cargo/bin:${PATH}"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    sh -s -- -y --profile minimal --default-toolchain 1.96.1
+    sh -s -- -y --profile minimal --default-toolchain 1.97.1
 
 COPY config/bin/aibox_status_core.rs config/bin/aibox-status.rs config/bin/aibox-diagnostics.rs /build/aibox-runtime-tools/
 RUN mkdir -p /build/aibox-runtime-tools/bin && \
@@ -70,7 +70,7 @@ RUN ARCH=$(uname -m) && \
 
 # ── ripgrep (no aarch64 musl build — use gnu) ────────────────────────────────
 FROM fetch-base AS fetch-ripgrep
-ARG RIPGREP_VERSION=15.1.0
+ARG RIPGREP_VERSION=15.2.0
 RUN ARCH=$(uname -m) && \
     RG_LIBC=$(case $ARCH in x86_64) echo musl;; *) echo gnu;; esac) && \
     curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
@@ -101,7 +101,7 @@ RUN ARCH=$(uname -m) && \
 
 # ── eza (no aarch64 musl build — use gnu) ────────────────────────────────────
 FROM fetch-base AS fetch-eza
-ARG EZA_VERSION=0.23.4
+ARG EZA_VERSION=0.23.5
 RUN ARCH=$(uname -m) && \
     EZA_SUFFIX=$(case $ARCH in x86_64) echo "unknown-linux-musl";; aarch64) echo "unknown-linux-gnu";; esac) && \
     curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
@@ -120,7 +120,7 @@ RUN ARCH=$(uname -m) && \
 
 # ── fzf (uses amd64/arm64 instead of x86_64/aarch64) ────────────────────────
 FROM fetch-base AS fetch-fzf
-ARG FZF_VERSION=0.73.1
+ARG FZF_VERSION=0.74.1
 RUN ARCH=$(uname -m) && \
     FZF_ARCH=$(case $ARCH in aarch64) echo arm64;; x86_64) echo amd64;; esac) && \
     curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
@@ -278,7 +278,7 @@ COPY --from=build-aibox-runtime-tools /build/aibox-runtime-tools/bin/aibox-diagn
 # image since v0.16.5 (DEC-036) so processkit's PEP 723 MCP server
 # scripts run via `uv run` out of the box. Works against the
 # externally-installed python3 from apt above.
-COPY --from=ghcr.io/astral-sh/uv:0.11.26 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /uvx /usr/local/bin/
 ENV UV_CACHE_DIR=/tmp/aibox/uv-cache
 
 ARG AIBOX_IMAGE_SOURCE_SHA=unknown

--- a/scripts/record-asciinema.sh
+++ b/scripts/record-asciinema.sh
@@ -335,7 +335,7 @@ for c in a i b o x ' ' i n i t ' ' m y - p r o j e c t ' ' - - y e s ' ' - - b a
   sleep 0.06
 done
 echo
-printf 'y\n' | aibox init my-project --yes --base debian --profile human-dev --user aibox --theme gruvbox --prompt default --tmux-status extended --addon python --addon-tool python:python=3.14 --addon-tool python:uv=0.11.26 --harness claude --processkit-version v0.26.15 --no-container 2>&1 || true
+printf 'y\n' | aibox init my-project --yes --base debian --profile human-dev --user aibox --theme gruvbox --prompt default --tmux-status extended --addon python --addon-tool python:python=3.14 --addon-tool python:uv=0.11.32 --harness claude --processkit-version v0.26.15 --no-container 2>&1 || true
 
 sleep 1
 echo -ne '\033[32m❯\033[0m '

--- a/scripts/release-check-state.sh
+++ b/scripts/release-check-state.sh
@@ -89,6 +89,25 @@ dockerfile_arg() {
   grep -E "^ARG ${arg}=" "${file}" | head -n 1 | sed -E "s/^ARG ${arg}=//"
 }
 
+quoted_assignment() {
+  local file="$1" name="$2"
+  sed -nE "s/.*${name}=\"([^\"]+)\".*/\\1/p" "${file}" | head -n 1
+}
+
+package_pin() {
+  local file="$1" package="$2"
+  grep -oE "${package}==[0-9]+([.][0-9]+)+" "${file}" \
+    | head -n 1 \
+    | sed -E "s/^${package}==//"
+}
+
+container_image_tag() {
+  local file="$1" image="$2"
+  grep -oE "${image}:[0-9]+([.][0-9]+)+" "${file}" \
+    | head -n 1 \
+    | sed -E "s#^${image}:##"
+}
+
 sha256_file() {
   local file="$1"
   if command -v sha256sum >/dev/null 2>&1; then
@@ -381,9 +400,24 @@ go_latest() {
 }
 
 rust_latest() {
-  if command -v rustup >/dev/null 2>&1; then
-    rustup check 2>/dev/null | awk '/up to date:/ {for (i = 1; i <= NF; i++) if ($i == "date:") {print $(i + 1); exit}}'
+  local output
+  if output="$(run_with_timeout 8s curl -fsSL https://static.rust-lang.org/dist/channel-rust-stable.toml 2>&1)"; then
+    awk '
+      /^\[pkg\.rust\]$/ { in_rust = 1; next }
+      in_rust && /^version = / {
+        value = $0
+        sub(/^version = "/, "", value)
+        sub(/ .*/, "", value)
+        print value
+        exit
+      }
+    ' <<<"${output}"
+    return 0
   fi
+  if grep -Eiq 'could not resolve|temporary failure|no such host|network is unreachable|connection timed out|i/o timeout|error connecting' <<<"${output}"; then
+    record_network_failure "Rust stable lookup: ${output//$'\n'/ }"
+  fi
+  return 1
 }
 
 check_apt_managed() {
@@ -457,7 +491,7 @@ check_github_pin "starship" "${BASE_DOCKERFILE}" "STARSHIP_VERSION" "starship/st
 section "Unpinned Image Inputs"
 line "| Input | Current selector | Latest/Review target | Status |"
 line "|---|---|---|---|"
-uv_pin="0.11.26"
+uv_pin="$(container_image_tag "${BASE_DOCKERFILE}" "ghcr.io/astral-sh/uv" || true)"
 uv_latest="$(github_latest_release astral-sh/uv || true)"
 uv_status="current"
 if [[ -z "${uv_latest}" ]]; then
@@ -491,10 +525,10 @@ line "For latest-by-default harnesses, check upstream release notes and install-
 section "Addon Tool Version Pins"
 line "| Tool | Current | Latest | Source | Status |"
 line "|---|---:|---:|---|---|"
-check_addon_version "Hugo" "0.162.1" "$(normalize_version "$(github_latest_release gohugoio/hugo || true)")" "GitHub gohugoio/hugo"
-check_addon_version "mdBook" "0.5.3" "$(normalize_version "$(github_latest_release rust-lang/mdBook || true)")" "GitHub rust-lang/mdBook"
+check_addon_version "Hugo" "$(quoted_assignment "${PROJECT_ROOT}/addons/docs/docs-hugo.yaml" HUGO_VERSION || true)" "$(normalize_version "$(github_latest_release gohugoio/hugo || true)")" "GitHub gohugoio/hugo"
+check_addon_version "mdBook" "$(quoted_assignment "${PROJECT_ROOT}/addons/docs/docs-mdbook.yaml" MDBOOK_VERSION || true)" "$(normalize_version "$(github_latest_release rust-lang/mdBook || true)")" "GitHub rust-lang/mdBook"
 check_addon_tool_pypi "MkDocs" "${PROJECT_ROOT}/addons/docs/docs-mkdocs.yaml" "mkdocs" "mkdocs"
-check_addon_version "MkDocs Material" "9.7.6" "$(pypi_latest mkdocs-material || true)" "PyPI mkdocs-material"
+check_addon_version "MkDocs Material" "$(package_pin "${PROJECT_ROOT}/addons/docs/docs-mkdocs.yaml" mkdocs-material || true)" "$(pypi_latest mkdocs-material || true)" "PyPI mkdocs-material"
 check_addon_tool_pypi "Zensical" "${PROJECT_ROOT}/addons/docs/docs-zensical.yaml" "zensical" "zensical"
 check_addon_version "Starlight scaffold" "floating" "$(npm_latest create-starlight || true)" "npm create-starlight" "latest by default"
 check_addon_version "Go" "$(addon_tool_default "${PROJECT_ROOT}/addons/languages/go.yaml" go || true)" "$(go_latest || true)" "go.dev"
@@ -554,15 +588,25 @@ line "### cargo update --dry-run"
 if ! command -v cargo >/dev/null 2>&1; then
   line "cargo is not available on PATH in this environment. Run this check in the release container before publishing."
   warnings_found=1
-elif (cd "${CLI_DIR}" && run_with_timeout 120s cargo update --dry-run) >> "${REPORT}" 2>&1; then
-  line ""
-  line "Status: dry-run completed. Review the output above for lockfile-resolvable crate updates."
-  line ""
-  line "Disposition required: if updates are listed, either apply them with a real \`cargo update\` and rerun validation, or create a processkit WorkItem for the deferred crate-update pass before continuing the release."
 else
-  line ""
-  line "Status: cargo update --dry-run failed or could not reach the index; rerun before release if network was unavailable."
-  warnings_found=1
+  cargo_update_output=""
+  if cargo_update_output="$(cd "${CLI_DIR}" && run_with_timeout 120s cargo update --dry-run 2>&1)"; then
+    printf '%s\n' "${cargo_update_output}" >> "${REPORT}"
+    line ""
+    if grep -Eq 'Locking 0 packages' <<<"${cargo_update_output}"; then
+      line "Status: Cargo.lock is current for the active Rust toolchain."
+    else
+      line "Status: lockfile-resolvable crate updates are available."
+      line ""
+      line "Disposition required: apply them with a real \`cargo update\` and rerun validation, or create a processkit WorkItem for the deferred crate-update pass before continuing the release."
+      mark_update
+    fi
+  else
+    printf '%s\n' "${cargo_update_output}" >> "${REPORT}"
+    line ""
+    line "Status: cargo update --dry-run failed or could not reach the index; rerun before release if network was unavailable."
+    warnings_found=1
+  fi
 fi
 
 section "Addon Inventory"


### PR DESCRIPTION
## Summary

Prepare the v0.x maintenance patch with current security and correctness-sensitive tool pins, a refreshed Rust lockfile, and a release-state gate that reads authoritative source pins. Derived projects receive current language/tooling defaults after applying the patch release; older curated versions remain selectable.

## Changes

- refresh Rust, Go, uv, pnpm, ripgrep, eza, fzf, Hugo, mdBook, MkDocs Material, Zensical, OpenTofu, Ansible, Packer, kubectl, Helm, and Hermes Agent
- update Cargo.lock to all Rust 1.96-compatible dependency resolutions
- verify mdBook 0.5.4 assets using GitHub-published SHA-256 digests
- derive release-state uv/Hugo/mdBook/Material pins from source files
- read Rust stable from the official channel manifest
- report a current Cargo.lock without a false actionable disposition
- reconcile all five outstanding v1-to-v0 port obligations

## Validation

- cargo test: 1060 unit + 90 Tier-1 E2E + 31 integration passed; 1 expected ignored
- cargo build
- cargo clippy --all-targets -- -D warnings
- cargo audit: clean
- cargo fmt -- --check
- Hugo/Docsy docs build: 147 pages
- release-state: no newer pinned dependency, Cargo.lock current
- version-line port gate: clear
- upstream release-asset names checked for both Linux architectures
- pk-doctor schema_filename: 0 errors, 0 warnings