### PR TITLE
chore(v0): refresh final release lockfile

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]


### PR DESCRIPTION
## Summary

Refresh the final two Rust dependency resolutions detected by the v0.28.15 Phase 0 release-state gate.

## Updates

- clap_complete 4.6.7 -> 4.6.8
- toml_parser 1.1.2 -> 1.1.3

## Validation

- cargo test: 1061 unit, 90 Tier-1 E2E, and 31 integration passed; 1 expected ignored
- cargo clippy --all-targets -- -D warnings
- cargo audit: clean
- cargo update --dry-run: 0 packages