### PR TITLE
chore: record v1 alpha candidate handover

### DIFF
--- a/context/logs/2026/07/LOG-20260727_1836-SharpHarvest-session-handover.md
+++ b/context/logs/2026/07/LOG-20260727_1836-SharpHarvest-session-handover.md
@@ -1,0 +1,61 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260727_1836-SharpHarvest-session-handover
+  created: '2026-07-27T18:36:50+00:00'
+spec:
+  event_type: session.handover
+  timestamp: '2026-07-27T18:36:25Z'
+  summary: 'Session handover — v1.0.0-alpha.1 candidate promoted and release remains
+    fail-closed on live M7c evidence and processkit #134'
+  actor: TEAMMEMBER-avery
+  subject: LOG-20260727_1836-IdealTide-session-handover
+  subject_kind: LogEntry
+  details:
+    session_date: '2026-07-27'
+    current_state: 'The processkit v1.0.0-alpha.3 consumer lifecycle, expanded M7c
+      kind lifecycle, alpha evidence gates, shared maintenance ports, and all 20 cross-line
+      obligations are implemented and merged. PRs #220 and #222 landed on v1.x-dev;
+      PRs #221 and #223 promoted the candidate to v1.x-pre-release at 70e658b3554f6ca9bb49d00413ed6694f335ce96.
+      Formatting, clippy, cargo audit, 1,139 unit tests, 90 Tier-1 E2E tests, 43 integration
+      tests, the exact processkit producer tests, and the 151-page Hugo build passed.
+      No v1.0.0-alpha.1 tag or release was created because publication correctly remains
+      blocked.'
+    open_threads:
+    - BACK-20260725_1003-GiftedBlossom-implement-m7c-disposable-cluster-e2e-and is
+      blocked until the SSH companion is rebuilt with systemd as PID 1 and the systemd
+      cgroup manager, then candidate-bound M7c evidence must pass.
+    - 'processkit issue #134 tracks pk-doctor supply_chain false positives for Docsy
+      git-submodule package manifests; these are the only remaining pk-doctor ERRORs
+      and block release Phase 0 until fixed upstream and synced.'
+    - BACK-20260725_1003-MightyVale-complete-m5-production-processkit-protocol-delegation
+      remains marked in-progress although its alpha.3 implementation and producer
+      validation are merged; close it after final candidate/release verification.
+    - BACK-20260724_1843-PatientLynx-implement-aibox-v1-orchestration remains in-progress
+      as the umbrella v1 implementation WorkItem.
+    - BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon remains in-progress
+      and should be reviewed against the already-ported isolated toolchain changes.
+    - BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags remains in-progress.
+    - BACK-20260514_0925-VastHare-tmux-theme-switch-prefix-menu-binding and BACK-20260514_0924-ActiveSummit-tmux-layout-chooser-prefix-menu-binding
+      remain in-progress.
+    - Primary /workspace is on v0.x-release at 0d90cecb with the user's uncommitted
+      aibox.toml modification intentionally preserved. Five pre-existing stashes remain
+      and were not altered.
+    next_recommended_action: On the host, rebuild the aibox-e2e-testrunner using both
+      devcontainer compose files with --build --force-recreate, verify systemd is
+      PID 1, then run ./scripts/maintain.sh test-e2e from exact v1.x-pre-release candidate
+      70e658b3554f6ca9bb49d00413ed6694f335ce96 to generate M7c evidence.
+    branch: v0.x-release (primary workspace); remote release candidate v1.x-pre-release
+    commit: 0d90cecb (primary workspace); 70e658b3554f6ca9bb49d00413ed6694f335ce96
+      (v1 prerelease candidate)
+    behavioral_retrospective:
+    - 'A metadata-only port attestation initially overstated that the Codex command
+      projections were equivalent; Phase 0 exposed the missing files, and they were
+      then restored and merged through PRs #222/#223.'
+    - 'A GitHub issue body was initially passed with shell-sensitive backticks and
+      was partially command-substituted; issue #134 was immediately corrected using
+      a body file. Future multiline GitHub bodies should always use --body-file.'
+    - 'The release workflow remained fail-closed: no tag, GitHub release, or docs
+      deployment was attempted after M7c and pk-doctor blockers were confirmed.'
+---


### PR DESCRIPTION
Records the canonical session handover for the promoted v1.0.0-alpha.1 candidate, including verified gates, open WorkItems, the host-side M7c rebuild action, and processkit #134.