### PR TITLE
chore: record v0.28.16 session handover

### DIFF
--- a/context/logs/2026/07/LOG-20260727_2057-PeacefulJay-session-handover.md
+++ b/context/logs/2026/07/LOG-20260727_2057-PeacefulJay-session-handover.md
@@ -1,0 +1,71 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260727_2057-PeacefulJay-session-handover
+  created: '2026-07-27T20:57:55+00:00'
+spec:
+  event_type: session.handover
+  timestamp: '2026-07-27T20:57:55+00:00'
+  summary: Session handover — v0.28.16 fully released and publicly verified
+  actor: TEAMMEMBER-avery
+  subject: v0.28.16
+  subject_kind: release
+  details:
+    session_date: '2026-07-27'
+    current_state: aibox v0.28.16 is fully released. The NodeSource HTTP 403 rebuild
+      failure was fixed by installing verified official Node.js version-line tarballs
+      for amd64 and arm64, the authorized worktree changes were included, and both
+      host-side and public release verification completed. The v0.x-release worktree
+      is synchronized with origin at 8801f13c and was clean before this handover entry.
+    open_threads:
+    - 'BACK-20260725_1003-MightyVale-complete-m5-production-processkit-protocol-delegation
+      remains in progress and awaits a compatible released processkit CLI protocol
+      from upstream issue #118.'
+    - BACK-20260725_1003-GiftedBlossom-implement-m7c-disposable-cluster-e2e-and remains
+      blocked.
+    - BACK-20260723_1923-FairFlame-fix-ansible-pip3-infrastructure-addon remains marked
+      in progress and should be reconciled against the fixes already shipped on the
+      v0.28 line.
+    - BACK-20260518_0632-FocusedDaisy-ghcr-foundation-runtime-tags remains marked
+      in progress although v0.28.16 foundation/runtime tags were publicly verified;
+      reconcile its acceptance criteria and close it if satisfied.
+    - Five pre-existing git stashes remain and must be reviewed before later worktree-wide
+      release or cleanup operations.
+    next_recommended_action: 'Run pk-resume, then reassess BACK-20260725_1003-MightyVale
+      against the current release status of processkit issue #118; if the compatible
+      protocol is still unavailable, select the next unblocked item under the v1 orchestration
+      epic.'
+    branch: v0.x-release
+    commit: 8801f13c
+    uncommitted_changes: []
+    stashes:
+    - 'stash@{0}: On v0.x-release: pre-release-host-v0.28.14-primary-20260726T164837Z'
+    - 'stash@{1}: On v0.x-release: pre-release-host-v0.28.13-local-work-2026-07-26'
+    - 'stash@{2}: On main: keep-aibox-toml-comment-drift'
+    - 'stash@{3}: WIP on main: 29d22a12 fix(test): use family theme names in visual
+      + visual_matrix'
+    - 'stash@{4}: On main: pre-v0.25.14-release-unrelated-dirty-state'
+    accomplishments:
+    - 'Released v0.28.16 through protected-branch PR #225 and refreshed generated
+      runtime artifacts through PR #226.'
+    - Published and verified the GitHub release with nine assets, Linux and macOS
+      artifacts, checksums, LICENSE, and deployed documentation.
+    - Verified anonymous GHCR access for base-debian-foundation-v0.28.16, base-debian-runtime-v0.28.16,
+      and base-debian-runtime-latest.
+    - 'Completed release validation: clean cargo audit; 1062 unit, 90 Tier 1 E2E,
+      31 integration, 10 rendered-color, and 38 active Tier 2 tests; six exhaustive
+      visual tests were correctly skipped because no terminal UI changed.'
+    - Recorded DEC-20260727_2019-ZestfulDeer to include the current worktree in v0.28.16.
+    behavioral_retrospective:
+    - The Phase 0 supply-chain gate caught an invalid included worktree change that
+      removed nested-repository exclusion and produced false missing-lock findings
+      in the Docsy submodule; the change and inaccurate release-note claim were corrected
+      before publication, then the gate was rerun cleanly.
+    - A focused cargo test invocation initially used two filters in one command; the
+      checks were immediately rerun separately. This is an existing command-line constraint
+      and does not warrant a new reusable project rule.
+    - 'No promised action was left unexecuted: the container fix, worktree inclusion,
+      release, host phase, public verification, protected-branch reconciliation, and
+      durable handover were all completed.'
+---


### PR DESCRIPTION
## Summary

Records the completed v0.28.16 release state, public verification, remaining work items, preserved stashes, and the recommended next action for the next session.