### PR TITLE
fix(v0.28.17): harden add-on container installers

### DIFF
--- a/addons/languages/go.yaml
+++ b/addons/languages/go.yaml
@@ -16,7 +16,7 @@ tools:
     description: "Go compiler, tooling, and module workflow"
     default_enabled: true
     default_version: "1.26.5"
-    supported_versions: ["1.25", "1.26", "1.26.3", "1.26.4", "1.26.5"]
+    supported_versions: ["1.25.12", "1.26.3", "1.26.4", "1.26.5"]
 
 builder: null
 
@@ -24,13 +24,22 @@ runtime: |
   # Addon: go (runtime)
   RUN ARCH=$(dpkg --print-architecture) && \
       GO_VERSION="{{ tools.go.version }}" && \
+      case "${GO_VERSION}:${ARCH}" in \
+        1.25.12:amd64) GO_SHA256="234828b7a89e0e303d2556310ee549fbcf253d28de937bac3da13d6294262ac1" ;; \
+        1.25.12:arm64) GO_SHA256="8b5884aef89600aef5b0b051fb971f11f49bb996521e911f30f02a66884f7bd2" ;; \
+        1.26.3:amd64) GO_SHA256="2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556" ;; \
+        1.26.3:arm64) GO_SHA256="9d89a3ea57d141c2b22d70083f2c8459ba3890f2d9e818e7e933b75614936565" ;; \
+        1.26.4:amd64) GO_SHA256="1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f" ;; \
+        1.26.4:arm64) GO_SHA256="ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768" ;; \
+        1.26.5:amd64) GO_SHA256="5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053" ;; \
+        1.26.5:arm64) GO_SHA256="fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49" ;; \
+        *) echo "Unsupported Go version/architecture: ${GO_VERSION}/${ARCH}" >&2; exit 1 ;; \
+      esac && \
       curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" \
         -o /tmp/go.tar.gz && \
-      curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz.sha256" \
-        -o /tmp/go.tar.gz.sha256 && \
-      echo "$(cat /tmp/go.tar.gz.sha256)  /tmp/go.tar.gz" | sha256sum -c && \
+      echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - && \
       tar -xz -C /usr/local -f /tmp/go.tar.gz && \
-      rm /tmp/go.tar.gz /tmp/go.tar.gz.sha256 && \
+      rm /tmp/go.tar.gz && \
       ln -sf /usr/local/go/bin/* /usr/local/bin/
 
   ENV GOPATH="/home/aibox/go"

--- a/addons/languages/node.yaml
+++ b/addons/languages/node.yaml
@@ -37,7 +37,7 @@ builder: null
 
 runtime: |
   # Addon: node (runtime)
-  RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl xz-utils && \
+  RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 xz-utils && \
       rm -rf /var/lib/apt/lists/* && \
       DEB_ARCH="$(dpkg --print-architecture)" && \
       case "${DEB_ARCH}" in \

--- a/addons/languages/typst.yaml
+++ b/addons/languages/typst.yaml
@@ -25,14 +25,20 @@ runtime: |
       && rm -rf /var/lib/apt/lists/* \
       && ARCH=$(uname -m) \
       && TYPST_VERSION="{{ tools.typst.version }}" \
+      && case "${TYPST_VERSION}:${ARCH}" in \
+        0.13.1:aarch64) TYPST_SHA256="4f5b7ee6e57fb639019ee0f6bffcf940edad228ede6ff5269a9f05a1544ceed4" ;; \
+        0.13.1:x86_64) TYPST_SHA256="7d214bfeffc2e585dc422d1a09d2b144969421281e8c7f5d784b65fc69b5673f" ;; \
+        0.14.2:aarch64) TYPST_SHA256="491b101aa40a3a7ea82a3f8a6232cabb4e6a7e233810082e5ac812d43fdcd47a" ;; \
+        0.14.2:x86_64) TYPST_SHA256="a6044cbad2a954deb921167e257e120ac0a16b20339ec01121194ff9d394996d" ;; \
+        0.15.0:aarch64) TYPST_SHA256="cdf50ffc7b8ba759ed02200632eda3d78eb8b99aacb6611f4f75684990647620" ;; \
+        0.15.0:x86_64) TYPST_SHA256="59b207df01be2dab9f13e80f73d04d7ff8273ffd46b3dd1b9eef5c60f3eeabea" ;; \
+        *) echo "Unsupported Typst version/architecture: ${TYPST_VERSION}/${ARCH}" >&2; exit 1 ;; \
+      esac \
       && curl -fsSL \
         "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${ARCH}-unknown-linux-musl.tar.xz" \
         -o /tmp/typst.tar.xz \
-      && curl -fsSL \
-        "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${ARCH}-unknown-linux-musl.tar.xz.sha256" \
-        -o /tmp/typst.tar.xz.sha256 \
-      && (cd /tmp && sha256sum -c typst.tar.xz.sha256) \
+      && echo "${TYPST_SHA256}  /tmp/typst.tar.xz" | sha256sum -c - \
       && tar -xJ --strip-components=1 -C /usr/local/bin -f /tmp/typst.tar.xz \
           "typst-${ARCH}-unknown-linux-musl/typst" \
       && chmod +x /usr/local/bin/typst \
-      && rm /tmp/typst.tar.xz /tmp/typst.tar.xz.sha256
+      && rm /tmp/typst.tar.xz

--- a/addons/tools/cloud-aws.yaml
+++ b/addons/tools/cloud-aws.yaml
@@ -20,18 +20,24 @@ runtime: |
   # Addon: cloud-aws
   {% if tools["aws-cli"].enabled %}
   # S2 — BR-SEC-HARDEN: GPG signature verification before install.
-  # AWS CLI public key fingerprint: FB5D B77F D5C1 18B8 0511  ADA8 A631 4593 B8B2 1122
-  # Ref: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html#install-cliv2-linux-verify
-  RUN apt-get update && apt-get install -y --no-install-recommends gpg && \
+  # AWS CLI public key fingerprint: FB5D B77F D5C1 18B8 0511  ADA8 A631 0ACC 4672 475C
+  # Ref: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+  # AWS publishes its signing key inline in the installation guide rather than
+  # as a stable key download. Vendor that documented key so clean builds do not
+  # depend on an SKS/Hockeypuck keyserver being reachable or synchronized.
+  ARG AWS_CLI_PGP_KEY_BASE64=LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptUUlOQkYyQ3I3VUJFQURKWkhjZ3VzT0psN0VOU3l1bVhoODV6MFRSVjB4Sm9yTTJCL0pMMGtIT3lpZ1FsdVVHClpNTGhFTmFHMGJZYXRkcktQKzNIOTFsdkswNTBwWHduTy9SN2ZCL0ZTVG91a2k0Y2lJeDVPdUxsbkpaSXhTengKUHFHbDBta3hJbUxOYkdXb2k2THRvMExZeHFITjJpUXR6bHdUVm1xOTczM3pkM1hmY1hyWjMrTGJsSEFnRXQ1RwpUZk54RUtKOHNvUEx5V213REg2SFdDbmpaL2FJUVJCVElRMDV1VmVFb1l4U2g2d09haTdzcy9LdmVvU05CYll6CmdiZHpvcUkyWThjZ0gybmJmZ3AzRFNhc2FMWkVkQ1NzSXNLMXUwNUNpbkU3azJxWjdLZ0tBVUljVC9jUi9ncmsKQzZWd3NuRFUwT1VDaWRlWGNROFdlSHV0cXZnWkgxSmdLRGJ6bm9JemVRSEpEMjM4R0V1K2VLaFJIY3o4L2plRwo5NHprY2dKT3ozS2JaR1lNaVRoMjc3RnZqOXp6dlpzYk1CQ2VkVjFCVGczVHFndmRYNGJka2hmNWNIKzdOdFdPCmxyRmo2VXdBc0d1a0JUQU94QzBsL2RuU21aaEo3WjFLbUVXaWxyby9nT3JqdE94cVJRdXRsSXFHMjJUYXFvUEcKZllWTitlbjNad2J0OTdrY2daRHdxYnV5a050NjRvWldjNFhLQ2EzbXByRUdDM0liSlRCRnFnbFhtWjdsOXl3RwpFRVVKWU9sYjJYclN1UFdtbDM5YmVXZEtNOGt6cjFPam5sT202K2xwVFJDQmZvMHdhOUY4WVpSaEhQQWt3S2tYClhEZU9HcFdSajRvaE94MGQyR1dreVY1eHlOMTRwMnRRT0NkT09EbXo4MHlVVGdScFBWUVV0T0VoWFFBUkFRQUIKdENGQlYxTWdRMHhKSUZSbFlXMGdQR0YzY3kxamJHbEFZVzFoZW05dUxtTnZiVDZKQWxRRUV3RUlBRDRDR3dNRgpDd2tJQndJR0ZRb0pDQXNDQkJZQ0F3RUNIZ0VDRjRBV0lRVDdYYmQvMWNFWXVBVVJyYWltTVFyTVJuSkhYQVVDCmFrVjB5Z1VKRHFQNGxRQUtDUkNtTVFyTVJuSkhYRkhqRC85ZXlaTFljS3VRT2xMdnRxU0R0VUJpRVpmNlpaak0KaTN5Z1lIOHJKTnR1VG9VSCtIdlNwZTgxOXVySkNxdVhoRHJsSzZOK2FxVzBoQ0x0TkFCSkcvdnNhZklndklZSgpoU0dncGd0Tm5ReU1WMWpWaVJXcVBqYm91dzhPa1lLQlRoVWZUMWkyWSt3bjU4aWZzNk9EQkNtVGV4V3RYc3BBClNpK0d0NDl4RE9XMEFQbWJPUG5JK2E0SEpXNnRWRW82TVdTMFdqenBpQmF5UjNkMUE0cHQ0WXJQZlNkRGdwTG8KaDJTTFFxbFJxdnZWWkphV0JqaGtFck5GcGZzQkEwNnNEY1BFT2IwRzhMQlViUjRXT2NkdmhlNUx1YkpiWnV4QwpBRzlrTlBDVmVRUDFpeHdqZ2pYS3lzYXhlUTZydjBWeklRZ1JwNnRMVkxXaHk2QUtETnZMakZTc21YWjFXbDA4ClkvUmxPSFhsekx1UU1SRTZzUjF3T2RSeGM5VHNyTldUR2lCSzY1Y3ZTV095MDNKZUJrUVE4cGVzcWx0aXl4STkKVTIxa2tnaVh0VFNLTkdmS0s4cE8yN0Q4MVlBTmhScVBLN2lUcDZrdUZpWTJXdE9nOTBLVE1ObElUK0ZmODVZMgpiMXJIajZaMFNyQ2tKdWpoV2szSUJQaWMvd0pnejAxTEVjL09BZFVQbGJ5OTBSSlpjSUJoU2xXaFQ3bVhuWElPCmMwSFdsTlFybnMyczNDVHlZd1pTaVNsWWU5QXBlTHdoakRvOE5oYkZ1Q0F5NjFsNk81VXNSNEFmWnh4L3JHS3YKMndGYjEvUk4vUDRnTmU2dm14WkFQalIwQVFjd0QzdGMyTWNpbU9Mci8yMmttUHo4SUgzSTBYN1dvU0ZyMEJpegpFOTFHN2JiMGhPYi9jQT09Cj1rbnY3Ci0tLS0tRU5EIFBHUCBQVUJMSUMgS0VZIEJMT0NLLS0tLS0K
+  RUN apt-get update && apt-get install -y --no-install-recommends gpg gpg-agent && \
       rm -rf /var/lib/apt/lists/* && \
+      printf '%s' "${AWS_CLI_PGP_KEY_BASE64}" | base64 -d > /tmp/aws-cli-public-key.asc && \
+      test "$(gpg --show-keys --with-colons /tmp/aws-cli-public-key.asc | awk -F: '$1 == "fpr" { print $10; exit }')" = "FB5DB77FD5C118B80511ADA8A6310ACC4672475C" && \
+      gpg --batch --import /tmp/aws-cli-public-key.asc && \
       ARCH="$(uname -m)" && \
       curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip"     -o /tmp/awscli.zip && \
       curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip.sig" -o /tmp/awscli.sig && \
-      gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys A6314593B8B21122 && \
       gpg --verify /tmp/awscli.sig /tmp/awscli.zip && \
       unzip -q /tmp/awscli.zip -d /tmp && \
       /tmp/aws/install && \
-      rm -rf /tmp/aws /tmp/awscli.zip /tmp/awscli.sig
+      rm -rf /tmp/aws /tmp/awscli.zip /tmp/awscli.sig /tmp/aws-cli-public-key.asc
   {% endif %}
   {% if not tools["aws-cli"].enabled %}
   # Variant 1 disable-then-purge: aws CLI v2 installs into /usr/local/aws-cli/

--- a/aibox.toml
+++ b/aibox.toml
@@ -307,7 +307,7 @@ hugo = { enabled = true } # Fast Go-based static site generator; default off; op
 
 # Languages/go — Go programming language toolchain
 # [addons.go.tools]
-# go = {} # Go compiler, tooling, and module workflow; default on; options: {}, { enabled = true|false }, { version = "1.25" | "1.26" | "1.26.3" | "1.26.4" | "1.26.5" (default) or "latest" }
+# go = {} # Go compiler, tooling, and module workflow; default on; options: {}, { enabled = true|false }, { version = "1.25.12" | "1.26.3" | "1.26.4" | "1.26.5" (default) or "latest" }
 
 # Languages/latex — TeX Live LaTeX typesetting system
 # [addons.latex.tools]

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1401,6 +1401,25 @@ runtime: |
     }
 
     #[test]
+    fn cloud_aws_installer_vendors_and_verifies_documented_signing_key() {
+        let addon = load_repo_addon("cloud-aws");
+        let rendered = render_runtime(&addon, &all_enabled_tools(&addon)).unwrap();
+
+        assert!(
+            rendered.contains("gpg gpg-agent")
+                && rendered.contains("AWS_CLI_PGP_KEY_BASE64=")
+                && rendered.contains("FB5DB77FD5C118B80511ADA8A6310ACC4672475C")
+                && rendered.contains("gpg --batch --import /tmp/aws-cli-public-key.asc"),
+            "AWS CLI verification must use the fingerprint-checked key from AWS's install guide: {rendered}"
+        );
+        assert!(rendered.contains("gpg --verify /tmp/awscli.sig /tmp/awscli.zip"));
+        assert!(
+            !rendered.contains("gpg --keyserver"),
+            "AWS CLI builds must not depend on external keyserver availability: {rendered}"
+        );
+    }
+
+    #[test]
     fn purge_cloud_azure_removes_venv_when_disabled() {
         let addon = load_repo_addon("cloud-azure");
         let tools = all_disabled_tools(&addon);
@@ -1511,8 +1530,52 @@ runtime: |
         assert!(rendered.contains("SHASUMS256.txt"));
         assert!(rendered.contains("sha256sum -c -"));
         assert!(
+            rendered.contains("libatomic1"),
+            "official Node.js ARM64 archives require libatomic.so.1: {rendered}"
+        );
+        assert!(
             !rendered.contains("deb.nodesource.com"),
             "Node installation must not depend on the retired NodeSource key endpoint: {rendered}"
+        );
+    }
+
+    #[test]
+    fn go_installer_uses_published_archive_digests() {
+        let addon = load_repo_addon("go");
+        let rendered = render_runtime(&addon, &all_enabled_tools(&addon)).unwrap();
+
+        assert!(rendered.contains(
+            r#"1.26.5:amd64) GO_SHA256="5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053""#
+        ));
+        assert!(rendered.contains(
+            r#"1.26.5:arm64) GO_SHA256="fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49""#
+        ));
+        assert!(rendered.contains(r#"echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c -"#));
+        assert!(
+            !rendered.contains(".tar.gz.sha256"),
+            "go.dev does not publish per-archive checksum sidecars: {rendered}"
+        );
+        assert_eq!(
+            addon.tools[0].supported_versions,
+            ["1.25.12", "1.26.3", "1.26.4", "1.26.5"]
+        );
+    }
+
+    #[test]
+    fn typst_installer_uses_published_archive_digests() {
+        let addon = load_repo_addon("typst");
+        let rendered = render_runtime(&addon, &all_enabled_tools(&addon)).unwrap();
+
+        assert!(rendered.contains(
+            r#"0.15.0:aarch64) TYPST_SHA256="cdf50ffc7b8ba759ed02200632eda3d78eb8b99aacb6611f4f75684990647620""#
+        ));
+        assert!(rendered.contains(
+            r#"0.15.0:x86_64) TYPST_SHA256="59b207df01be2dab9f13e80f73d04d7ff8273ffd46b3dd1b9eef5c60f3eeabea""#
+        ));
+        assert!(rendered.contains(r#"echo "${TYPST_SHA256}  /tmp/typst.tar.xz" | sha256sum -c -"#));
+        assert!(
+            !rendered.contains(".tar.xz.sha256"),
+            "Typst does not publish per-archive checksum sidecars: {rendered}"
         );
     }
 

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -623,6 +623,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.4",
         note: "Patch release: installs Node.js from checksum-verified official release archives after the NodeSource signing-key endpoint became unavailable and refreshes generated runtime and processkit package-selection state.",
     },
+    CompatEntry {
+        aibox_version: "0.28.17",
+        processkit_version: "v0.28.4",
+        note: "Patch release: repairs Go, Typst, AWS CLI, and Node.js add-on installers and adds a clean companion-container build gate for download-based add-on defaults.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/cli/tests/e2e/addon.rs
+++ b/cli/tests/e2e/addon.rs
@@ -115,6 +115,51 @@ fn addon_rebuild_includes_tools_in_dockerfile() {
 }
 
 #[test]
+fn download_based_addons_build_with_published_defaults() {
+    let runner = E2eRunner::new();
+    let test = "addon-download-smoke";
+    runner.cleanup(test);
+
+    let mut args = vec!["init", test, "--base", "debian", "--context", "managed"];
+    for addon in [
+        "ai-claude",
+        "ai-opencode",
+        "cloud-aws",
+        "cloud-gcp",
+        "cloudflare",
+        "docs-hugo",
+        "docs-mdbook",
+        "go",
+        "infrastructure",
+        "kubernetes",
+        "node",
+        "preview-archive",
+        "rust",
+        "typst",
+    ] {
+        args.extend(["--addon", addon]);
+    }
+
+    let init = runner.aibox(test, &args);
+    assert!(
+        init.status.success(),
+        "initializing the download-based add-on smoke project failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let apply = runner.aibox(test, &["apply"]);
+    assert!(
+        apply.status.success(),
+        "one or more published add-on defaults cannot build:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+
+    runner.cleanup(test);
+}
+
+#[test]
 fn get_addon_shows_available() {
     let runner = E2eRunner::new();
     let test = "addon-list";

--- a/context/logs/2026/07/LOG-20260728_0705-BuoyantTulip-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260728_0705-BuoyantTulip-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_0705-BuoyantTulip-workitem-transitioned
+  created: '2026-07-28T07:05:24+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-28T07:05:24+00:00'
+  summary: Transitioned WorkItem 'BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+  subject_kind: WorkItem
+  actor: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+---

--- a/context/logs/2026/07/LOG-20260728_0705-SoftBlossom-workitem-created.md
+++ b/context/logs/2026/07/LOG-20260728_0705-SoftBlossom-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_0705-SoftBlossom-workitem-created
+  created: '2026-07-28T07:05:16+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-07-28T07:05:16+00:00'
+  summary: 'Created WorkItem ''BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures'':
+    ''Fix recurring add-on installer download failures and release v0.28.17'''
+  subject: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+  subject_kind: WorkItem
+  actor: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+---

--- a/context/workitems/2026/07/BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures.md
+++ b/context/workitems/2026/07/BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures.md
@@ -1,0 +1,24 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+  created: '2026-07-28T07:05:15+00:00'
+  updated: '2026-07-28T07:05:24+00:00'
+spec:
+  title: Fix recurring add-on installer download failures and release v0.28.17
+  state: in-progress
+  type: bug
+  priority: high
+  assignee: TEAMMEMBER-avery
+  description: Diagnose the Go add-on checksum failure reported from a v0.28.16 derived
+    project, audit all download-based add-on installers for the recurring failure
+    pattern, implement a durable source/generator-level prevention with regression
+    coverage, regenerate tracked runtime output, validate the v0.x line, and prepare
+    the v0.28.17 patch release.
+  started_at: '2026-07-28T07:05:24+00:00'
+---
+
+## Transition note (2026-07-28T07:05:24+00:00)
+
+Starting v0.28.17 diagnosis, add-on-wide audit, durable fix, regression coverage, and release preparation.

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.28.17 | v0.28.4 | repairs Go, Typst, AWS CLI, and Node.js add-on installers and adds a clean companion-container build gate for download-based add-on defaults |
 | 0.28.16 | v0.28.4 | installs Node.js from checksum-verified official release archives after the NodeSource signing-key endpoint became unavailable and refreshes generated runtime and processkit package-selection state |
 | 0.28.14 | v0.28.4 | ensures `pk-reconcile` and `pk-repo-reconcile` install their `project-reconciliation` and `repo-management` skill dependencies |
 | 0.28.15 | v0.28.4 | refreshes bundled maintenance tools, locks `cargo-audit` installation for Rust compatibility, and publishes the Hugo/Docsy documentation site |


### PR DESCRIPTION
## Summary

- fix Go and Typst archive verification using published SHA-256 digests
- remove AWS CLI builds' dependency on external keyserver availability and add Node ARM64's required libatomic runtime
- add a real Tier 2 clean-container build gate covering download-based add-on defaults

## Validation

- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo audit
- cargo build --release --target aarch64-unknown-linux-gnu
- cargo test --features e2e download_based_addons_build_with_published_defaults -- --nocapture

Refs: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures