### PR TITLE
chore: record v0.28.17 Phase 1 handover

### DIFF
--- a/context/logs/2026/07/LOG-20260728_0902-AdeptGarden-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260728_0902-AdeptGarden-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_0902-AdeptGarden-workitem-transitioned
+  created: '2026-07-28T09:02:30+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-28T09:02:30+00:00'
+  summary: Transitioned WorkItem 'BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures'
+    from 'in-progress' to 'review'
+  subject: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+  subject_kind: WorkItem
+  actor: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+---

--- a/context/workitems/2026/07/BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures.md
+++ b/context/workitems/2026/07/BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures.md
@@ -4,10 +4,10 @@ kind: WorkItem
 metadata:
   id: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
   created: '2026-07-28T07:05:15+00:00'
-  updated: '2026-07-28T07:05:24+00:00'
+  updated: '2026-07-28T09:02:30+00:00'
 spec:
   title: Fix recurring add-on installer download failures and release v0.28.17
-  state: in-progress
+  state: review
   type: bug
   priority: high
   assignee: TEAMMEMBER-avery
@@ -22,3 +22,8 @@ spec:
 ## Transition note (2026-07-28T07:05:24+00:00)
 
 Starting v0.28.17 diagnosis, add-on-wide audit, durable fix, regression coverage, and release preparation.
+
+
+## Transition note (2026-07-28T09:02:30+00:00)
+
+v0.28.17 Phase 1 published from v0.x-release with Linux binaries, checksum sidecars, and docs after all local, audit, cross-build, and Tier 2 gates passed. Host-only release-host 0.28.17 remains for macOS assets, GHCR images, and generated runtime refresh.


### PR DESCRIPTION
## Summary

- move the add-on installer remediation WorkItem to review
- record successful v0.28.17 Phase 1 publication
- retain the explicit host-only release-host 0.28.17 completion step

Refs: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures