### PR TITLE
chore: complete v0.28.17 add-on remediation

### DIFF
--- a/context/logs/2026/07/LOG-20260728_0911-ReadySpruce-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260728_0911-ReadySpruce-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_0911-ReadySpruce-workitem-transitioned
+  created: '2026-07-28T09:11:06+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-28T09:11:06+00:00'
+  summary: Transitioned WorkItem 'BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures'
+    from 'review' to 'done'
+  subject: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+  subject_kind: WorkItem
+  actor: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+---

--- a/context/logs/2026/07/LOG-20260728_0911-RoyalVale-workitem-archive-moved.md
+++ b/context/logs/2026/07/LOG-20260728_0911-RoyalVale-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_0911-RoyalVale-workitem-archive-moved
+  created: '2026-07-28T09:11:06+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-07-28T09:11:06+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures'
+    to /workspace/context/workitems/done/2026/07/BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures.md
+  subject: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+  subject_kind: WorkItem
+  actor: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
+  details:
+    path: /workspace/context/workitems/done/2026/07/BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures.md
+---

--- a/context/workitems/done/2026/07/BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures.md
+++ b/context/workitems/done/2026/07/BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures.md
@@ -4,10 +4,10 @@ kind: WorkItem
 metadata:
   id: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures
   created: '2026-07-28T07:05:15+00:00'
-  updated: '2026-07-28T09:02:30+00:00'
+  updated: '2026-07-28T09:11:06+00:00'
 spec:
   title: Fix recurring add-on installer download failures and release v0.28.17
-  state: review
+  state: done
   type: bug
   priority: high
   assignee: TEAMMEMBER-avery
@@ -17,6 +17,7 @@ spec:
     coverage, regenerate tracked runtime output, validate the v0.x line, and prepare
     the v0.28.17 patch release.
   started_at: '2026-07-28T07:05:24+00:00'
+  completed_at: '2026-07-28T09:11:06+00:00'
 ---
 
 ## Transition note (2026-07-28T07:05:24+00:00)
@@ -27,3 +28,8 @@ Starting v0.28.17 diagnosis, add-on-wide audit, durable fix, regression coverage
 ## Transition note (2026-07-28T09:02:30+00:00)
 
 v0.28.17 Phase 1 published from v0.x-release with Linux binaries, checksum sidecars, and docs after all local, audit, cross-build, and Tier 2 gates passed. Host-only release-host 0.28.17 remains for macOS assets, GHCR images, and generated runtime refresh.
+
+
+## Transition note (2026-07-28T09:11:06+00:00)
+
+Verified v0.28.17 host Phase 2: both macOS archives and checksum sidecars are published; GHCR base-debian foundation/runtime version tags return HTTP 200; runtime-latest matches the v0.28.17 runtime digest; generated-runtime PR #234 is merged; v0.x-release is synchronized.


### PR DESCRIPTION
## Summary

- record verified v0.28.17 host Phase 2 completion
- archive the completed add-on installer remediation WorkItem
- preserve evidence for macOS assets, GHCR manifests, and generated-runtime PR #234

Refs: BACK-20260728_0705-RefinedHarvest-fix-addon-installer-download-failures