### PR TITLE
chore(v1): promote issue 236 gate handover

### DIFF
--- a/context/logs/2026/07/LOG-20260728_1004-FairRabbit-workitem-created.md
+++ b/context/logs/2026/07/LOG-20260728_1004-FairRabbit-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_1004-FairRabbit-workitem-created
+  created: '2026-07-28T10:04:26+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-07-28T10:04:26+00:00'
+  summary: 'Created WorkItem ''BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence'':
+    ''Rebuild companion and produce candidate-bound live M7c evidence'''
+  subject: BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence
+  subject_kind: WorkItem
+  actor: BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence
+---

--- a/context/logs/2026/07/LOG-20260728_1004-HumbleSea-workitem-archive-moved.md
+++ b/context/logs/2026/07/LOG-20260728_1004-HumbleSea-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_1004-HumbleSea-workitem-archive-moved
+  created: '2026-07-28T10:04:21+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-07-28T10:04:21+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization'
+    to /workspace/context/workitems/done/2026/07/BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization.md
+  subject: BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization
+  subject_kind: WorkItem
+  actor: BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization
+  details:
+    path: /workspace/context/workitems/done/2026/07/BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization.md
+---

--- a/context/logs/2026/07/LOG-20260728_1004-QuickDell-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260728_1004-QuickDell-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_1004-QuickDell-workitem-transitioned
+  created: '2026-07-28T10:04:21+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-28T10:04:21+00:00'
+  summary: Transitioned WorkItem 'BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization'
+    from 'review' to 'done'
+  subject: BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization
+  subject_kind: WorkItem
+  actor: BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization
+---

--- a/context/logs/2026/07/LOG-20260728_1004-WildOtter-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260728_1004-WildOtter-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_1004-WildOtter-workitem-transitioned
+  created: '2026-07-28T10:04:17+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-28T10:04:17+00:00'
+  summary: Transitioned WorkItem 'BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization'
+    from 'in-progress' to 'review'
+  subject: BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization
+  subject_kind: WorkItem
+  actor: BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization
+---

--- a/context/workitems/2026/07/BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence.md
+++ b/context/workitems/2026/07/BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence.md
@@ -1,0 +1,22 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence
+  created: '2026-07-28T10:04:26+00:00'
+  labels:
+    github_issue: '236'
+    epic: '179'
+    release_line: v1
+    gate: m7c-live
+spec:
+  title: Rebuild companion and produce candidate-bound live M7c evidence
+  state: backlog
+  type: task
+  priority: critical
+  description: Rebuild the aibox E2E companion with kind, systemd PID 1, delegated
+    cgroup v2 controllers, and required modules; run the exact v1.x-pre-release candidate
+    through the disposable Kubernetes lifecycle; retain schema-valid candidateCommit/binarySha256-bound
+    evidence; rerun release readiness. Do not publish alpha unless this and every
+    other mandatory gate pass.
+---

--- a/context/workitems/done/2026/07/BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization.md
+++ b/context/workitems/done/2026/07/BACK-20260728_0947-ReadyOrchard-implement-issue-236-v1-alpha-stabilization.md
@@ -8,10 +8,10 @@ metadata:
     github_issue: '236'
     release_line: v1
     phase: alpha-stabilization
-  updated: '2026-07-28T09:47:18+00:00'
+  updated: '2026-07-28T10:04:21+00:00'
 spec:
   title: Implement issue 236 v1 alpha stabilization blockers
-  state: in-progress
+  state: done
   type: bug
   priority: critical
   description: 'Implement the approved Phase 0 slice from GitHub issue #236: typed
@@ -20,8 +20,19 @@ spec:
     with partial-failure tests; reconcile v1.x-dev and v1.x-pre-release. Live evidence
     and alpha publication remain fail-closed follow-on gates.'
   started_at: '2026-07-28T09:47:18+00:00'
+  completed_at: '2026-07-28T10:04:21+00:00'
 ---
 
 ## Transition note (2026-07-28T09:47:18+00:00)
 
 Implementation started from issue #236 using three routed parallel agent worktrees for evidence parity, destroy safety, and apply ordering; central integration owns branch reconciliation and release gating.
+
+
+## Transition note (2026-07-28T10:04:17+00:00)
+
+Phase 0 implementation and branch reconciliation merged through PRs #237 and #238; validation passed. Reviewing final scope separation before completion.
+
+
+## Transition note (2026-07-28T10:04:21+00:00)
+
+Review confirms the WorkItem scope is complete: evidence contract, apply/destroy safety, tests, workplan, and branch reconciliation are merged. Live M7c execution and alpha publication are separate fail-closed follow-on work.


### PR DESCRIPTION
Promote the post-validation WorkItem handover so the prerelease branch retains the same fail-closed live M7c gate as development.

Refs: #236, #179, #239