### PR TITLE
chore(v1): promote M7c hardening to pre-release

### DIFF
--- a/.devcontainer/docker-compose.override.yml
+++ b/.devcontainer/docker-compose.override.yml
@@ -34,6 +34,9 @@ services:
     volumes:
       # SSH keys — mounted from host (never committed to git)
       - ../.aibox-e2e-runner-home/.ssh:/home/testuser/.ssh:ro
+      # kind needs the host kernel module tree when it starts nested nodes.
+      # Keep it read-only: the companion must never mutate host modules.
+      - /lib/modules:/lib/modules:ro
     # Podman rootless inside a container needs:
     #   seccomp=unconfined  — allows syscalls used by user-namespace creation
     #   SYS_ADMIN           — allows newuidmap to write /proc/PID/uid_map

--- a/cli/tests/e2e/kubernetes_kind.rs
+++ b/cli/tests/e2e/kubernetes_kind.rs
@@ -46,10 +46,10 @@ fn kubernetes_kind_lifecycle_produces_release_candidate_evidence() {
         "set -eu; kind version; kubectl version --client; \
          test \"$(ps -p 1 -o comm= | tr -d ' ')\" = systemd; \
          test \"$(stat -fc %T /sys/fs/cgroup)\" = cgroup2fs; \
-         grep -qw pids /sys/fs/cgroup/cgroup.controllers; \
-         grep -qw pids /sys/fs/cgroup/cgroup.subtree_control; \
          test \"$(podman info --format '{{.Host.CgroupManager}}')\" = systemd; \
-         systemd-run --user --scope -p Delegate=yes --quiet true; test -d /lib/modules",
+         systemd-run --user --scope --wait --quiet -p Delegate=yes \\
+           /bin/sh -ec 'scope=$(awk -F: \"$1 == 0 { print $3 }\" /proc/self/cgroup); base=/sys/fs/cgroup${scope}; test -r \"${base}/cgroup.controllers\"; for controller in cpu cpuset io memory pids; do grep -qw \"${controller}\" \"${base}/cgroup.controllers\"; done'; \
+         test -d /lib/modules",
     );
     assert!(
         preflight.status.success(),

--- a/cli/tests/e2e/kubernetes_kind.rs
+++ b/cli/tests/e2e/kubernetes_kind.rs
@@ -31,6 +31,26 @@ fn candidate_commit() -> String {
         .to_string()
 }
 
+fn candidate_binary_sha256() -> String {
+    let binary = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/debug/aibox");
+    let output = Command::new("sha256sum")
+        .arg(&binary)
+        .output()
+        .expect("hash test candidate binary");
+    assert!(
+        output.status.success(),
+        "sha256sum of test candidate binary must succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let digest = String::from_utf8(output.stdout)
+        .expect("sha256sum output is UTF-8")
+        .split_whitespace()
+        .next()
+        .expect("sha256sum output contains digest")
+        .to_string();
+    format!("sha256:{digest}")
+}
+
 #[test]
 #[ignore = "release gate: run through maintain.sh test-e2e"]
 fn kubernetes_kind_lifecycle_produces_release_candidate_evidence() {
@@ -59,6 +79,24 @@ fn kubernetes_kind_lifecycle_produces_release_candidate_evidence() {
     );
 
     let commit = candidate_commit();
+    let checked_out_commit = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("cli has a repository parent"),
+        )
+        .output()
+        .expect("resolve checked out candidate commit");
+    assert!(checked_out_commit.status.success());
+    assert_eq!(
+        commit,
+        String::from_utf8(checked_out_commit.stdout)
+            .expect("commit is UTF-8")
+            .trim(),
+        "M7c evidence must be bound to the checked-out release candidate"
+    );
+    let binary_sha256 = candidate_binary_sha256();
     let script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("cli has a repository parent")
@@ -69,7 +107,8 @@ fn kubernetes_kind_lifecycle_produces_release_candidate_evidence() {
     );
     let run = runner.exec(&format!(
         "chmod +x /tmp/test-kubernetes-kind.sh && \
-         AIBOX_M7C_COMMIT={commit} AIBOX_BIN=/usr/local/bin/aibox \
+         AIBOX_M7C_COMMIT={commit} AIBOX_M7C_BINARY_SHA256={binary_sha256} \
+         AIBOX_BIN=/usr/local/bin/aibox \
          AIBOX_ADDONS_DIR=/opt/aibox/addons /tmp/test-kubernetes-kind.sh"
     ));
     assert!(
@@ -83,11 +122,7 @@ fn kubernetes_kind_lifecycle_produces_release_candidate_evidence() {
         serde_json::from_slice(&run.stdout).expect("live M7c suite must return JSON evidence");
     assert_eq!(evidence["status"], "passed");
     assert_eq!(evidence["candidateCommit"], commit);
-    assert!(
-        evidence["binarySha256"]
-            .as_str()
-            .is_some_and(|digest| digest.starts_with("sha256:") && digest.len() == 71)
-    );
+    assert_eq!(evidence["binarySha256"], binary_sha256);
     assert_eq!(
         evidence["scenarios"].as_array().map(Vec::len),
         Some(8),

--- a/cli/tests/e2e/kubernetes_kind.rs
+++ b/cli/tests/e2e/kubernetes_kind.rs
@@ -73,7 +73,11 @@ fn kubernetes_kind_lifecycle_produces_release_candidate_evidence() {
     );
     assert!(
         preflight.status.success(),
-        "kind prerequisite failed:\nstdout:\n{}\nstderr:\n{}",
+        "kind companion is stale or incomplete. Rebuild it from the host with:\n\
+         docker compose -f .devcontainer/docker-compose.yml \
+         -f .devcontainer/docker-compose.override.yml up -d --build --force-recreate \
+         aibox-e2e-testrunner\n\
+         stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&preflight.stdout),
         String::from_utf8_lossy(&preflight.stderr)
     );

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -669,6 +669,8 @@ fn e2e_companion_delegates_kind_through_systemd() {
         "DisposableClusterEvidence",
         "candidateCommit",
         "binarySha256",
+        "AIBOX_M7C_BINARY_SHA256",
+        "deployed candidate binary digest does not match",
         "foreign-destroy-refusal",
     ] {
         assert!(
@@ -676,6 +678,17 @@ fn e2e_companion_delegates_kind_through_systemd() {
             "M7c live lifecycle must cover {required}"
         );
     }
+    assert!(
+        kind_gate.contains("candidate_binary_sha256")
+            && kind_gate
+                .contains("M7c evidence must be bound to the checked-out release candidate"),
+        "the M7c harness must bind the deployed binary and commit to the checked-out candidate"
+    );
+    assert!(
+        maintain.contains("M7c evidence is not bound to the exact candidate binary")
+            && maintain.contains("AIBOX_RELEASE_BINARY_SHA256"),
+        "the release gate must reject evidence from another candidate binary"
+    );
     assert!(maintain.contains("kubernetes_kind -- --ignored --nocapture"));
 }
 

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -650,7 +650,12 @@ fn e2e_companion_delegates_kind_through_systemd() {
     assert!(dockerfile.contains("cgroup_manager = \"systemd\""));
     assert!(dockerfile.contains("log_driver = \"k8s-file\""));
     assert!(compose.contains("cgroup: private"));
-    assert!(kind_gate.contains("systemd-run --user --scope -p Delegate=yes"));
+    assert!(compose.contains("/lib/modules:/lib/modules:ro"));
+    assert!(
+        kind_gate.contains("systemd-run --user --scope --wait --quiet -p Delegate=yes")
+    );
+    assert!(maintain.contains("e2e_companion_preflight"));
+    assert!(maintain.contains("E2E companion is stale. Rebuild it on the Docker host"));
     assert!(kind_gate.contains("copy_file_to"));
     for required in [
         "deploy apply",

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -651,9 +651,7 @@ fn e2e_companion_delegates_kind_through_systemd() {
     assert!(dockerfile.contains("log_driver = \"k8s-file\""));
     assert!(compose.contains("cgroup: private"));
     assert!(compose.contains("/lib/modules:/lib/modules:ro"));
-    assert!(
-        kind_gate.contains("systemd-run --user --scope --wait --quiet -p Delegate=yes")
-    );
+    assert!(kind_gate.contains("systemd-run --user --scope --wait --quiet -p Delegate=yes"));
     assert!(maintain.contains("e2e_companion_preflight"));
     assert!(maintain.contains("E2E companion is stale. Rebuild it on the Docker host"));
     assert!(kind_gate.contains("copy_file_to"));

--- a/context/skills/processkit/pk-doctor/scripts/checks/supply_chain.py
+++ b/context/skills/processkit/pk-doctor/scripts/checks/supply_chain.py
@@ -179,15 +179,28 @@ def _iter_files(root: Path, names: set[str]) -> list[Path]:
         return found
 
     for dirpath, dirnames, filenames in os.walk(root):
+        current = Path(dirpath)
         dirnames[:] = [
             d
             for d in dirnames
-            if d not in _SKIP_DIRS and not d.startswith(".")
+            if d not in _SKIP_DIRS
+            and not d.startswith(".")
+            and not _is_nested_repository(root, current / d)
         ]
         for filename in filenames:
             if _normalize(filename) in wanted:
                 found.append(Path(dirpath) / filename)
     return sorted(found)
+
+
+def _is_nested_repository(repo_root: Path, directory: Path) -> bool:
+    """Return whether ``directory`` is a repository nested below ``repo_root``.
+
+    A Git submodule checkout has a ``.git`` *file*, while a standalone nested
+    checkout has a ``.git`` directory.  Neither is part of the owning
+    project's dependency surface, so both must be pruned before discovery.
+    """
+    return directory != repo_root and (directory / ".git").exists()
 
 
 def _collect_inventory(
@@ -233,10 +246,13 @@ def _find_sbom_files(repo_root: Path) -> list[Path]:
             found.append(path)
 
     for dirpath, dirnames, filenames in os.walk(repo_root):
+        current = Path(dirpath)
         dirnames[:] = [
             d
             for d in dirnames
-            if d not in _SKIP_DIRS and not d.startswith(".")
+            if d not in _SKIP_DIRS
+            and not d.startswith(".")
+            and not _is_nested_repository(repo_root, current / d)
         ]
         for filename in filenames:
             lower = filename.lower()

--- a/context/skills/processkit/pk-doctor/scripts/test_doctor.py
+++ b/context/skills/processkit/pk-doctor/scripts/test_doctor.py
@@ -2609,6 +2609,32 @@ with tempfile.TemporaryDirectory() as tmp:
 
 with tempfile.TemporaryDirectory() as tmp:
     root = Path(tmp)
+    (root / "package.json").write_text(
+        '{"name": "owning-app", "private": true}\n',
+        encoding="utf-8",
+    )
+    (root / "package-lock.json").write_text("{}\n", encoding="utf-8")
+    nested_repo = root / "docs-site" / "themes" / "docsy"
+    nested_repo.mkdir(parents=True)
+    (nested_repo / ".git").write_text(
+        "gitdir: ../../../.git/modules/docs-site/themes/docsy\n",
+        encoding="utf-8",
+    )
+    (nested_repo / "package.json").write_text(
+        '{"name": "docsy-theme", "private": true}\n',
+        encoding="utf-8",
+    )
+    findings = _supply_chain_run({"repo_root": root, "since_files": None})
+    missing = [item for item in findings if item.id == "supply_chain.missing-lockfile"]
+    inventory = next(item for item in findings if item.id == "supply_chain.inventory")
+    check("21c1: nested gitfile repository manifests are excluded", not missing)
+    check(
+        "21c2: nested gitfile repository is absent from inventory",
+        inventory.extra["manifest_counts"] == {"Node": 1, "package.json": 1},
+    )
+
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp)
     policy = root / ".processkit"
     policy.mkdir()
     (policy / "supply-chain-policy.yaml").write_text(

--- a/context/skills/processkit/supply-chain-audit/scripts/supply_chain_audit.py
+++ b/context/skills/processkit/supply-chain-audit/scripts/supply_chain_audit.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -170,7 +171,16 @@ def run_audit(
 def discover_manifests(repo_root: Path | str) -> list[Manifest]:
     root = Path(repo_root).resolve()
     manifests: list[Manifest] = []
-    for package_json in sorted(root.rglob("package.json")):
+    for dirpath, dirnames, filenames in os.walk(root):
+        directory = Path(dirpath)
+        dirnames[:] = [
+            name
+            for name in dirnames
+            if not _is_nested_repository(root, directory / name)
+        ]
+        if "package.json" not in filenames:
+            continue
+        package_json = directory / "package.json"
         if _skip_path(root, package_json):
             continue
         rel_manifest = _rel(root, package_json)
@@ -660,6 +670,11 @@ def _skip_path(root: Path, path: Path) -> bool:
         or part.startswith(".")
         for part in rel.parts
     )
+
+
+def _is_nested_repository(repo_root: Path, directory: Path) -> bool:
+    """Ignore standalone checkouts and submodule worktrees below the project."""
+    return directory != repo_root and (directory / ".git").exists()
 
 
 def _rel(root: Path, path: Path) -> str:

--- a/context/skills/processkit/supply-chain-audit/scripts/test_supply_chain_audit.py
+++ b/context/skills/processkit/supply-chain-audit/scripts/test_supply_chain_audit.py
@@ -59,3 +59,17 @@ with tempfile.TemporaryDirectory() as tmp:
     audit = sca.run_audit(root)
     ids = {finding["id"] for finding in audit["findings"]}
     check("missing app lockfile is error", "supply-chain.lockfile-missing" in ids)
+
+    # Nested repositories are separate ownership domains.  A submodule checkout
+    # uses a .git file rather than a directory, so cover that Git representation.
+    nested = root / "docs-site" / "themes" / "docsy"
+    nested.mkdir(parents=True)
+    (nested / ".git").write_text("gitdir: ../../../.git/modules/docsy\n", encoding="utf-8")
+    (nested / "package.json").write_text(
+        json.dumps({"name": "docsy-theme", "private": True}), encoding="utf-8"
+    )
+    nested_manifests = sca.discover_manifests(root)
+    check(
+        "excludes nested gitfile repository manifests",
+        all(manifest.manifest_path != "docs-site/themes/docsy/package.json" for manifest in nested_manifests),
+    )

--- a/docs-site/content/docs/contributing/e2e-tests.md
+++ b/docs-site/content/docs/contributing/e2e-tests.md
@@ -32,6 +32,28 @@ Missing `docker` or `podman` in the main devcontainer does not mean Tier 2
 cannot talk to the companion. The tests deploy the current `aibox` binary and
 addons with SCP, then use the companion's own runtime for lifecycle checks.
 
+### Rebuilding the Kubernetes-capable companion
+
+The release-gated disposable-cluster test requires the companion to run
+`systemd` as PID 1, use cgroup v2 delegation for rootless Podman, expose the
+read-only host `/lib/modules` tree, and contain both `kind` and `kubectl`.
+`./scripts/maintain.sh test-e2e` verifies this contract before it runs Cargo;
+when the reachable companion is an older image, it automatically rebuilds and
+recreates the service.
+
+If a host daemon restart or a failed build prevents automatic recreation, run
+this from the repository root on the Docker host, then rerun the E2E command:
+
+```bash
+docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.override.yml \
+  up -d --build --force-recreate aibox-e2e-testrunner
+./scripts/maintain.sh test-e2e
+```
+
+Do not accept SSH reachability alone as evidence that this companion is ready:
+an old SSH-only image reports `sshd` as PID 1 and fails the preflight without
+mutating a disposable cluster.
+
 ## `aibox` commands inside the devcontainer
 
 In normal dogfood use, the workspace container is the processkit/runtime side of

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -301,7 +301,7 @@ ensure_e2e_companion() {
   local key="${PROJECT_ROOT}/.aibox-e2e-runner-home/.ssh/id_ed25519"
   local host="${AIBOX_E2E_HOST:-aibox-e2e-testrunner}"
   info "Checking SSH companion E2E container..."
-  local ssh_output=""
+  local ssh_output="" rebuilt=0 attempt
   if [[ -f "${key}" ]] && ssh_output=$(ssh -i "${key}" \
       -o StrictHostKeyChecking=no \
       -o UserKnownHostsFile=/dev/null \
@@ -309,8 +309,12 @@ ensure_e2e_companion() {
       -o LogLevel=ERROR \
       "testuser@${host}" 'echo ok' 2>&1); then
     if grep -qx ok <<<"${ssh_output}"; then
-      ok "SSH companion E2E container is reachable"
-      return
+      if e2e_companion_preflight "${key}" "${host}"; then
+        ok "SSH companion E2E container is reachable and kind-ready"
+        return
+      fi
+      warn "SSH companion is reachable but does not satisfy the systemd/kind contract"
+      rebuilt=1
     fi
   fi
 
@@ -318,10 +322,52 @@ ensure_e2e_companion() {
     warn "SSH companion host '${host}' did not resolve. In restricted Codex sandboxes, Docker DNS for the companion is often unavailable."
     warn "For partial release validation, use --skip e2e,visual or select steps that do not need the companion."
   fi
+  if [[ "${rebuilt}" -eq 1 ]]; then
+    die "E2E companion is stale. Rebuild it on the Docker host: docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.override.yml up -d --build --force-recreate aibox-e2e-testrunner"
+  fi
   _require_runtime
   info "SSH companion not reachable; starting aibox-e2e-testrunner via Compose..."
-  compose up -d aibox-e2e-testrunner \
+  compose up -d --build --force-recreate aibox-e2e-testrunner \
     || die "Failed to start aibox-e2e-testrunner"
+
+  for attempt in $(seq 1 30); do
+    if [[ -f "${key}" ]] && ssh -i "${key}" \
+        -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
+        -o ConnectTimeout=5 \
+        -o LogLevel=ERROR \
+        "testuser@${host}" 'echo ok' >/dev/null 2>&1 \
+        && e2e_companion_preflight "${key}" "${host}"; then
+      ok "SSH companion E2E container is kind-ready"
+      return
+    fi
+    sleep 2
+  done
+  die "E2E companion did not become kind-ready after rebuild. On the host run: docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.override.yml up -d --build --force-recreate aibox-e2e-testrunner"
+}
+
+# The release-gated kind suite needs more than an SSH daemon.  In particular,
+# a service created before the systemd companion migration remains reachable
+# but has sshd as PID 1 and cannot delegate cgroup v2 controllers to rootless
+# Podman.  Keep this probe shell-only so it runs before Cargo deploys any test
+# payload to the companion.
+e2e_companion_preflight() {
+  local key="$1" host="$2"
+  ssh -i "${key}" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o ConnectTimeout=5 \
+    -o LogLevel=ERROR \
+    "testuser@${host}" \
+    'set -eu
+     command -v kind >/dev/null
+     command -v kubectl >/dev/null
+     test "$(ps -p 1 -o comm= | tr -d " ")" = systemd
+     test "$(stat -fc %T /sys/fs/cgroup)" = cgroup2fs
+     test -d /lib/modules
+     test "$(podman info --format "{{.Host.CgroupManager}}")" = systemd
+     systemd-run --user --scope --wait --quiet -p Delegate=yes \
+       /bin/sh -ec '\''scope=$(awk -F: "\$1 == 0 { print \$3 }" /proc/self/cgroup); base=/sys/fs/cgroup${scope}; test -r "${base}/cgroup.controllers"; for controller in cpu cpuset io memory pids; do grep -qw "${controller}" "${base}/cgroup.controllers"; done'\'''
 }
 
 prune_e2e_companion_storage() {

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -2080,7 +2080,7 @@ release_companion_e2e_gate() {
 # remains stricter than an alpha, but it is still the canonical parser for the
 # M5/M7c attestations and must accept the candidate evidence before tagging.
 release_v1_alpha_evidence_gate() {
-  local version="$1" evidence="${PROJECT_ROOT}/.aibox/release-evidence/m7c-live.json"
+  local version="$1" evidence="${PROJECT_ROOT}/.aibox/release-evidence/m7c-live.json" candidate_binary_sha256
   [[ "${version}" == 1.*-* ]] || return 0
   [[ -f "${evidence}" ]] \
     || die "v1 alpha release requires M7c evidence at ${evidence}; run the live disposable-cluster suite first"
@@ -2088,8 +2088,13 @@ release_v1_alpha_evidence_gate() {
     || die "M7c evidence is not bound to release candidate ${RELEASE_CANDIDATE_SHA}"
   grep -Eq "\"binarySha256\"[[:space:]]*:[[:space:]]*\"sha256:[0-9a-f]{64}\"" "${evidence}" \
     || die "M7c evidence does not bind the tested candidate binary digest"
+  [[ -f "${CLI_DIR}/target/debug/aibox" && -x "${CLI_DIR}/target/debug/aibox" && ! -L "${CLI_DIR}/target/debug/aibox" ]] \
+    || die "M7c candidate binary is missing; run the disposable-cluster suite before release gating"
+  candidate_binary_sha256="sha256:$(sha256_file "${CLI_DIR}/target/debug/aibox")"
+  grep -Eq "\"binarySha256\"[[:space:]]*:[[:space:]]*\"${candidate_binary_sha256}\"" "${evidence}" \
+    || die "M7c evidence is not bound to the exact candidate binary"
   "${PROJECT_ROOT}/scripts/test-processkit-v1-consumer.sh"
-  (cd "${PROJECT_ROOT}" && cargo run --quiet --manifest-path "${CLI_DIR}/Cargo.toml" -- \
+  (cd "${PROJECT_ROOT}" && AIBOX_RELEASE_BINARY_SHA256="${candidate_binary_sha256}" cargo run --quiet --manifest-path "${CLI_DIR}/Cargo.toml" -- \
     config release-readiness --output json) \
     || die "v1 alpha release readiness evidence is incomplete"
 }

--- a/scripts/test-kubernetes-kind.sh
+++ b/scripts/test-kubernetes-kind.sh
@@ -3,8 +3,19 @@
 set -euo pipefail
 
 : "${AIBOX_M7C_COMMIT:?missing release candidate commit}"
+: "${AIBOX_M7C_BINARY_SHA256:?missing release candidate binary digest}"
 : "${AIBOX_BIN:?missing aibox binary path}"
 : "${AIBOX_ADDONS_DIR:?missing addon directory}"
+
+[[ "${AIBOX_M7C_COMMIT}" =~ ^[0-9a-f]{40}$ ]] \
+  || { echo "invalid release candidate commit" >&2; exit 2; }
+[[ "${AIBOX_M7C_BINARY_SHA256}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+  || { echo "invalid release candidate binary digest" >&2; exit 2; }
+[[ -f "${AIBOX_BIN}" && -x "${AIBOX_BIN}" && ! -L "${AIBOX_BIN}" ]] \
+  || { echo "candidate binary must be an executable regular file" >&2; exit 2; }
+actual_binary_sha256="sha256:$(sha256sum "${AIBOX_BIN}" | awk '{print $1}')"
+[[ "${actual_binary_sha256}" == "${AIBOX_M7C_BINARY_SHA256}" ]] \
+  || { echo "deployed candidate binary digest does not match the release candidate" >&2; exit 2; }
 
 name="aibox-m7c-${RANDOM}-${RANDOM}"
 namespace="aibox-m7c"
@@ -151,11 +162,10 @@ scenarios+=("foreign-destroy-refusal")
 ! kubectl --context "${context}" --namespace "${namespace}" get service/web >/dev/null 2>&1
 ! kubectl --context "${context}" --namespace "${namespace}" get ingress -o name | grep -q .
 
-binary_sha256="sha256:$(sha256sum "${AIBOX_BIN}" | awk '{print $1}')"
 scenarios_json="$(printf '%s\n' "${scenarios[@]}" | jq -R . | jq -s '[.[] | {id: ., status: "passed"}]')"
 jq -n \
   --arg candidateCommit "${AIBOX_M7C_COMMIT}" \
-  --arg binarySha256 "${binary_sha256}" \
+  --arg binarySha256 "${actual_binary_sha256}" \
   --arg cluster "${name}" \
   --arg command 'cargo test --features e2e --test e2e kubernetes_kind -- --ignored --nocapture --test-threads=1' \
   --arg recordedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -168,7 +178,7 @@ jq -n \
 mkdir -p .aibox/release-evidence
 cp "${attestation}" .aibox/release-evidence/m7c-live.json
 RELEASE_CANDIDATE_SHA="${AIBOX_M7C_COMMIT}" \
-  AIBOX_RELEASE_BINARY_SHA256="${binary_sha256}" \
+  AIBOX_RELEASE_BINARY_SHA256="${actual_binary_sha256}" \
   "$AIBOX_BIN" config release-readiness --output json > readiness.json
 jq -e '.ready == true and (.gates[] | select(.id == "m7c-live-disposable-cluster-evidence").status == "passed")' readiness.json >/dev/null
 


### PR DESCRIPTION
## Summary
Promote the tested M7c companion readiness, candidate evidence binding, and nested-repository supply-chain scan fixes from v1.x-dev.

## Release status
The live M7c gate remains intentionally blocked until the host rebuilds the Tier 2 companion. No alpha publication is authorized by this promotion.

Refs #236
Refs #179