### PR TITLE
chore(v1): track host-blocked M7c evidence

### DIFF
--- a/context/logs/2026/07/LOG-20260728_1118-RapidSun-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260728_1118-RapidSun-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_1118-RapidSun-workitem-transitioned
+  created: '2026-07-28T11:18:47+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-28T11:18:47+00:00'
+  summary: Transitioned WorkItem 'BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence
+  subject_kind: WorkItem
+  actor: BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence
+---

--- a/context/workitems/2026/07/BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence.md
+++ b/context/workitems/2026/07/BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence.md
@@ -9,9 +9,10 @@ metadata:
     epic: '179'
     release_line: v1
     gate: m7c-live
+  updated: '2026-07-28T11:18:47+00:00'
 spec:
   title: Rebuild companion and produce candidate-bound live M7c evidence
-  state: backlog
+  state: in-progress
   type: task
   priority: critical
   description: Rebuild the aibox E2E companion with kind, systemd PID 1, delegated
@@ -19,4 +20,9 @@ spec:
     through the disposable Kubernetes lifecycle; retain schema-valid candidateCommit/binarySha256-bound
     evidence; rerun release readiness. Do not publish alpha unless this and every
     other mandatory gate pass.
+  started_at: '2026-07-28T11:18:47+00:00'
 ---
+
+## Transition note (2026-07-28T11:18:47+00:00)
+
+Implementation merged via PR #241 to v1.x-dev and promoted via PR #242 to v1.x-pre-release. Companion readiness is now fail-closed, M7c evidence is bound to the exact candidate binary digest, and nested repositories are excluded from owning supply-chain scans. Live evidence remains pending because the external Tier 2 companion is stale (kind absent). Host must run: docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.override.yml up -d --build --force-recreate aibox-e2e-testrunner


### PR DESCRIPTION
Record the completed M7c hardening and the remaining host-only companion rebuild needed before live evidence can be produced.

Refs #179
Refs #236