### PR TITLE
chore(v1): complete port reconciliation

### DIFF
--- a/context/logs/2026/07/LOG-20260728_1148-FocusedAsh-workitem-transitioned.md
+++ b/context/logs/2026/07/LOG-20260728_1148-FocusedAsh-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_1148-FocusedAsh-workitem-transitioned
+  created: '2026-07-28T11:48:04+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-07-28T11:48:04+00:00'
+  summary: Transitioned WorkItem 'BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations'
+    from 'review' to 'done'
+  subject: BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations
+  subject_kind: WorkItem
+  actor: BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations
+---

--- a/context/logs/2026/07/LOG-20260728_1148-SnappyDew-workitem-archive-moved.md
+++ b/context/logs/2026/07/LOG-20260728_1148-SnappyDew-workitem-archive-moved.md
@@ -1,0 +1,18 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260728_1148-SnappyDew-workitem-archive-moved
+  created: '2026-07-28T11:48:04+00:00'
+  updated: '2026-07-28T11:48:05+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-07-28T11:48:04+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations'
+    to /workspace/context/workitems/done/2026/07/BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations.md
+  subject: BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations
+  subject_kind: WorkItem
+  actor: BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations
+  details:
+    path: /workspace/context/workitems/done/2026/07/BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations.md
+---

--- a/context/workitems/done/2026/07/BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations.md
+++ b/context/workitems/done/2026/07/BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations.md
@@ -4,10 +4,10 @@ kind: WorkItem
 metadata:
   id: BACK-20260728_1132-WildAtlas-reconcile-v0-v1-release-port-obligations
   created: '2026-07-28T11:32:35+00:00'
-  updated: '2026-07-28T11:37:47+00:00'
+  updated: '2026-07-28T11:48:04+00:00'
 spec:
   title: Reconcile v0-to-v1 release port obligations
-  state: review
+  state: done
   type: task
   priority: critical
   description: 'Release-check-state blocks the v1 alpha because seven v0 commits lack
@@ -17,6 +17,7 @@ spec:
     check v1 pass without weakening the gate.'
   scope: v1-alpha
   started_at: '2026-07-28T11:37:29+00:00'
+  completed_at: '2026-07-28T11:48:04+00:00'
 ---
 
 ## Transition note (2026-07-28T11:37:29+00:00)
@@ -27,3 +28,8 @@ Port implementation integrated on fix/v1-unbound-m7c-evidence as commit 6aa00f71
 ## Transition note (2026-07-28T11:37:47+00:00)
 
 Implementation and focused validation complete; ready for final repository integration review.
+
+
+## Transition note (2026-07-28T11:48:04+00:00)
+
+PR #245 merged the port to v1.x-dev and PR #246 promoted it to v1.x-pre-release. Version-line port gate and full validation passed.


### PR DESCRIPTION
Archive the completed version-line port WorkItem after PR #245 merged and PR #246 promoted the implementation.

Refs #236