### PR TITLE
fix(v1): close alpha evidence and release gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,10 @@ v1 GA releases from `v1.x-release` once created. Quick summary:
 `./scripts/maintain.sh release X.Y.Z` (in container) then
 `./scripts/maintain.sh release-host X.Y.Z` (on macOS host). Merge the tagged
 release branch into `main` through a pull request afterward.
+The container-side command requires tracked release notes and compatibility
+metadata, validates the root README and contributor guidance, and completes a
+production Hugo/Docsy build before it permits tag or GitHub-release
+publication.
 
 Release validation and publication run locally. Do not introduce GitHub Actions
 or another hosted CI release path. The local release tooling runs independent

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Release quality expectations are strict:
 - zero Clippy warnings
 - all tests passing
 - `cargo audit` clean before tagging
+- tracked release notes, compatibility metadata, and a successful Hugo/Docsy
+  production build before publication
 - releases created through `./scripts/maintain.sh release <version>`
 
 ## Repository Structure
@@ -190,7 +192,7 @@ Release quality expectations are strict:
 
 ## Contributing
 
-Direct commits to `main` are the norm in this repository. Before contributing,
+Long-lived `main`, v0.x, and v1.x branches are PR-only. Before contributing,
 read [AGENTS.md](AGENTS.md), [CONTRIBUTING.md](CONTRIBUTING.md), and the docs
 under [`docs-site/content/docs/contributing/`](docs-site/content/docs/contributing/).
 
@@ -199,7 +201,7 @@ Do not hardcode processkit vocabulary in production Rust code. Add constants to
 
 All build, test, documentation, and release gates run locally. This repository
 does not use GitHub Actions; see the
-[maintenance guide](https://projectious-work.github.io/aibox/docs/contributing/maintenance)
+[v1 maintenance guide](https://projectious-work.github.io/aibox/v1.x/docs/contributing/maintenance/)
 for the exact commands and release phases.
 
 ## License

--- a/cli/contracts/v1alpha1/fixtures/invalid/release-gate-evidence-missing-artifacts.json
+++ b/cli/contracts/v1alpha1/fixtures/invalid/release-gate-evidence-missing-artifacts.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": "aibox.projectious.work/release-evidence/v1alpha1",
+  "kind": "ReleaseGateEvidence",
+  "gate": "m5-alpha3-exact-lifecycle",
+  "status": "passed",
+  "candidateCommit": "0123456789abcdef0123456789abcdef01234567",
+  "binarySha256": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "command": "scripts/test-processkit-v1-consumer.sh",
+  "startedAt": "2026-07-28T12:00:00Z",
+  "completedAt": "2026-07-28T12:01:00Z",
+  "scenarios": ["install"]
+}

--- a/cli/contracts/v1alpha1/fixtures/valid/kubernetes-plan.yaml
+++ b/cli/contracts/v1alpha1/fixtures/valid/kubernetes-plan.yaml
@@ -3,8 +3,8 @@ kind: Deployment
 metadata:
   labels:
     aibox.projectious.work/deployment-id: demo-fleet-6c8573d067a49bf0
-    aibox.projectious.work/desired-spec-digest: sha256:2cf37010bdc74bc2961125b40c3a1396e6c3206d8f4a70dcbc3b62d67e4545bc
-    aibox.projectious.work/image-digest: sha256:image
+    aibox.projectious.work/desired-spec-digest: s256-2cf37010bdc74bc2961125b40c3a1396e6c3206d8f4a70dcbc3b62d67e
+    aibox.projectious.work/image-digest: s256-6c650af53e90fed167d577a704931c3cde11d5254b3b2f736928a06730
     aibox.projectious.work/namespace: workspace-dev
     aibox.projectious.work/owner-id: team-a
   name: workspace
@@ -34,8 +34,8 @@ kind: Service
 metadata:
   labels:
     aibox.projectious.work/deployment-id: demo-fleet-6c8573d067a49bf0
-    aibox.projectious.work/desired-spec-digest: sha256:2cf37010bdc74bc2961125b40c3a1396e6c3206d8f4a70dcbc3b62d67e4545bc
-    aibox.projectious.work/image-digest: sha256:image
+    aibox.projectious.work/desired-spec-digest: s256-2cf37010bdc74bc2961125b40c3a1396e6c3206d8f4a70dcbc3b62d67e
+    aibox.projectious.work/image-digest: s256-6c650af53e90fed167d577a704931c3cde11d5254b3b2f736928a06730
     aibox.projectious.work/namespace: workspace-dev
     aibox.projectious.work/owner-id: team-a
   name: workspace

--- a/cli/contracts/v1alpha1/fixtures/valid/release-gate-evidence.json
+++ b/cli/contracts/v1alpha1/fixtures/valid/release-gate-evidence.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": "aibox.projectious.work/release-evidence/v1alpha1",
+  "kind": "ReleaseGateEvidence",
+  "gate": "m5-alpha3-exact-lifecycle",
+  "status": "passed",
+  "candidateCommit": "0123456789abcdef0123456789abcdef01234567",
+  "binarySha256": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "command": "scripts/test-processkit-v1-consumer.sh",
+  "startedAt": "2026-07-28T12:00:00Z",
+  "completedAt": "2026-07-28T12:01:00Z",
+  "scenarios": ["install", "verify", "unchanged-update", "uninstall"],
+  "artifacts": [{"path": "dist/logs/processkit-v1-consumer.log", "sha256": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}]
+}

--- a/cli/contracts/v1alpha1/schemas/release-gate-evidence.schema.json
+++ b/cli/contracts/v1alpha1/schemas/release-gate-evidence.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aibox.projectious.work/contracts/v1alpha1/release-gate-evidence.schema.json",
+  "title": "ReleaseGateEvidence v1alpha1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "gate", "status", "candidateCommit", "binarySha256", "command", "startedAt", "completedAt", "scenarios", "artifacts"],
+  "properties": {
+    "apiVersion": { "const": "aibox.projectious.work/release-evidence/v1alpha1" },
+    "kind": { "const": "ReleaseGateEvidence" },
+    "gate": { "type": "string", "minLength": 1 },
+    "status": { "const": "passed" },
+    "candidateCommit": { "type": "string", "pattern": "^[0-9a-fA-F]{40}$" },
+    "binarySha256": { "type": "string", "pattern": "^sha256:[0-9a-fA-F]{64}$" },
+    "command": { "type": "string", "minLength": 1 },
+    "startedAt": { "type": "string", "format": "date-time" },
+    "completedAt": { "type": "string", "format": "date-time" },
+    "scenarios": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "artifacts": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/artifact" } }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "type": "string", "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$" },
+        "sha256": { "type": "string", "pattern": "^sha256:[0-9a-fA-F]{64}$" }
+      }
+    }
+  }
+}

--- a/cli/src/compose_plan.rs
+++ b/cli/src/compose_plan.rs
@@ -7,13 +7,14 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 use crate::deployment_backend::{
     ApplyRequest, ApplyResponse, Backend, BackendError, ConnectionRequest, ConnectionResponse,
     DestroyRequest, DestroyResponse, LogsRequest, LogsResponse, PlanRequest, PlanResponse,
-    StatusRequest, StatusResponse, ValidateRequest, ValidateResponse,
+    RenderedDeploymentArtifacts, RenderedDeploymentPlan, StatusRequest, StatusResponse,
+    ValidateRequest, ValidateResponse,
 };
 use crate::deployment_compiler::{DesiredDeploymentAction, DesiredDeploymentPlan};
 use crate::deployment_contract::{
@@ -26,22 +27,6 @@ use crate::deployment_contract::{
 pub const LABEL_DEPLOYMENT_ID: &str = "aibox.projectious.work/deployment-id";
 pub const LABEL_SPEC_DIGEST: &str = "aibox.projectious.work/desired-spec-digest";
 pub const LABEL_IMAGE_DIGEST: &str = "aibox.projectious.work/image-digest";
-
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RenderedDeploymentPlan {
-    pub backend: BackendKind,
-    pub deployment_id: String,
-    pub desired_spec_digest: String,
-    pub image_digest: String,
-    pub ownership_labels: BTreeMap<String, String>,
-    pub compose_yaml: String,
-    pub devcontainer_json: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub kubernetes_yaml: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub kubernetes_json: Option<String>,
-}
 
 /// A small command boundary keeps lifecycle tests independent of Docker or
 /// Podman.  It deliberately transports argv as a vector, never through a
@@ -418,13 +403,18 @@ impl DeploymentStore {
     fn write_artifacts(&self, rendered: &RenderedDeploymentPlan) -> Result<(), BackendError> {
         let directory = self.root.join(&rendered.deployment_id);
         fs::create_dir_all(&directory).map_err(store_error)?;
+        let (compose_yaml, devcontainer_json) =
+            rendered.artifacts.compose().ok_or_else(|| BackendError {
+                code: ContractErrorCode::Planning,
+                message: "Compose backend received non-Compose rendered artifacts".to_string(),
+            })?;
         atomic_write(
             &directory.join("docker-compose.yml"),
-            rendered.compose_yaml.as_bytes(),
+            compose_yaml.as_bytes(),
         )?;
         atomic_write(
             &directory.join("devcontainer.json"),
-            rendered.devcontainer_json.as_bytes(),
+            devcontainer_json.as_bytes(),
         )
     }
 }
@@ -666,11 +656,13 @@ pub fn render(plan: &DesiredDeploymentPlan) -> Result<RenderedDeploymentPlan, Ba
         desired_spec_digest: plan.desired_spec_digest.clone(),
         image_digest: fleet.spec.image.digest.clone(),
         ownership_labels: labels,
-        compose_yaml: serde_yaml::to_string(&compose).map_err(serialization_error)?,
-        devcontainer_json: serde_json::to_string_pretty(&devcontainer)
-            .map_err(serialization_error)?,
-        kubernetes_yaml: None,
-        kubernetes_json: None,
+        artifacts: RenderedDeploymentArtifacts::Compose {
+            compose_yaml: serde_yaml::to_string(&compose).map_err(serialization_error)?,
+            devcontainer_json: serde_json::to_string_pretty(&devcontainer)
+                .map_err(serialization_error)?,
+            kubernetes_yaml: None,
+            kubernetes_json: None,
+        },
     })
 }
 
@@ -851,15 +843,16 @@ mod tests {
         })
         .unwrap();
         let first = render(&plan).unwrap();
+        let (compose_yaml, _) = first.artifacts.compose().unwrap();
         assert_eq!(first, render(&plan).unwrap());
         assert_eq!(
-            first.compose_yaml,
+            compose_yaml,
             include_str!("../contracts/v1alpha1/fixtures/valid/compose-plan.yaml")
         );
-        assert!(first.compose_yaml.contains(LABEL_DEPLOYMENT_ID));
-        assert!(first.compose_yaml.contains("${AIBOX_REGISTRY_TOKEN}"));
-        assert!(!first.compose_yaml.contains("secret-token"));
-        assert!(first.compose_yaml.contains("@sha256:"));
+        assert!(compose_yaml.contains(LABEL_DEPLOYMENT_ID));
+        assert!(compose_yaml.contains("${AIBOX_REGISTRY_TOKEN}"));
+        assert!(!compose_yaml.contains("secret-token"));
+        assert!(compose_yaml.contains("@sha256:"));
     }
 
     #[test]

--- a/cli/src/deployment_backend.rs
+++ b/cli/src/deployment_backend.rs
@@ -8,7 +8,7 @@ use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-use crate::compose_plan::{ComposeBackend, RenderedDeploymentPlan};
+use crate::compose_plan::ComposeBackend;
 use crate::deployment_compiler::DesiredDeploymentPlan;
 use crate::deployment_contract::{
     BackendCapability, BackendKind, ConnectionTarget, ContractErrorCode, DeploymentRecord,
@@ -30,6 +30,70 @@ pub struct ValidateResponse {
 pub struct PlanRequest {
     pub plan: DesiredDeploymentPlan,
 }
+
+/// Backend-neutral artifact payload produced by a deployment renderer.
+///
+/// The wire shape is deliberately flattened into [`RenderedDeploymentPlan`]
+/// to retain the v1alpha1 CLI JSON projection.  Backend adapters therefore
+/// share one plan boundary without inheriting Compose implementation types.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(untagged, rename_all_fields = "camelCase")]
+pub enum RenderedDeploymentArtifacts {
+    /// Kubernetes retains the historical empty Compose fields in its JSON
+    /// projection so existing consumers and fixtures remain compatible.
+    Kubernetes {
+        compose_yaml: String,
+        devcontainer_json: String,
+        kubernetes_yaml: String,
+        kubernetes_json: String,
+    },
+    Compose {
+        compose_yaml: String,
+        devcontainer_json: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        kubernetes_yaml: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        kubernetes_json: Option<String>,
+    },
+}
+
+impl RenderedDeploymentArtifacts {
+    pub fn compose(&self) -> Option<(&str, &str)> {
+        match self {
+            Self::Compose {
+                compose_yaml,
+                devcontainer_json,
+                ..
+            } => Some((compose_yaml, devcontainer_json)),
+            Self::Kubernetes { .. } => None,
+        }
+    }
+
+    pub fn kubernetes(&self) -> Option<(&str, &str)> {
+        match self {
+            Self::Kubernetes {
+                kubernetes_yaml,
+                kubernetes_json,
+                ..
+            } => Some((kubernetes_yaml, kubernetes_json)),
+            Self::Compose { .. } => None,
+        }
+    }
+}
+
+/// A rendered, non-mutating backend plan with backend-neutral artifacts.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RenderedDeploymentPlan {
+    pub backend: BackendKind,
+    pub deployment_id: String,
+    pub desired_spec_digest: String,
+    pub image_digest: String,
+    pub ownership_labels: std::collections::BTreeMap<String, String>,
+    #[serde(flatten)]
+    pub artifacts: RenderedDeploymentArtifacts,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PlanResponse {
@@ -218,5 +282,41 @@ mod tests {
             })
             .unwrap_err();
         assert_eq!(error.code, ContractErrorCode::Ownership);
+    }
+
+    #[test]
+    fn rendered_artifact_variants_keep_the_v1alpha1_wire_projection_flat() {
+        let artifacts = RenderedDeploymentArtifacts::Compose {
+            compose_yaml: "services: {}".to_string(),
+            devcontainer_json: "{}".to_string(),
+            kubernetes_yaml: None,
+            kubernetes_json: None,
+        };
+        let json = serde_json::to_value(&artifacts).unwrap();
+        assert_eq!(json["composeYaml"], "services: {}");
+        assert_eq!(json["devcontainerJson"], "{}");
+        assert!(json.get("kubernetesYaml").is_none());
+    }
+
+    #[test]
+    fn rendered_plan_round_trips_without_a_backend_module_dependency() {
+        let rendered = RenderedDeploymentPlan {
+            backend: BackendKind::Kubernetes,
+            deployment_id: "workspace-abc".to_string(),
+            desired_spec_digest: "sha256:abc".to_string(),
+            image_digest: "sha256:def".to_string(),
+            ownership_labels: std::collections::BTreeMap::new(),
+            artifacts: RenderedDeploymentArtifacts::Kubernetes {
+                compose_yaml: String::new(),
+                devcontainer_json: String::new(),
+                kubernetes_yaml: "apiVersion: v1".to_string(),
+                kubernetes_json: "[]".to_string(),
+            },
+        };
+        let encoded = serde_json::to_vec(&rendered).unwrap();
+        assert_eq!(
+            serde_json::from_slice::<RenderedDeploymentPlan>(&encoded).unwrap(),
+            rendered
+        );
     }
 }

--- a/cli/src/kubernetes_connection.rs
+++ b/cli/src/kubernetes_connection.rs
@@ -263,6 +263,7 @@ fn connection_error(message: &str) -> BackendError {
 #[serde(rename_all = "camelCase")]
 pub struct NetworkOwnership {
     pub deployment_id: String,
+    /// Kubernetes-safe label representation of the desired-spec digest.
     pub desired_spec_digest: String,
     /// The complete non-secret ownership identity copied from the deployment
     /// record.  Older records did not carry this field, so the three required
@@ -489,15 +490,42 @@ impl KubernetesNetworkApi for KubectlNetworkApi {
                     .collect()
             })
             .unwrap_or_default();
+        let string_at = |pointer: &str| {
+            value
+                .pointer(pointer)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        };
+        let (hostname, class, service, parent) = match kind {
+            "Ingress" => (
+                string_at("/spec/rules/0/host").unwrap_or_default(),
+                string_at("/spec/ingressClassName"),
+                string_at("/spec/rules/0/http/paths/0/backend/service/name"),
+                None,
+            ),
+            "Gateway" => (
+                string_at("/spec/listeners/0/hostname").unwrap_or_default(),
+                string_at("/spec/gatewayClassName"),
+                None,
+                None,
+            ),
+            "HTTPRoute" => (
+                string_at("/spec/hostnames/0").unwrap_or_default(),
+                None,
+                string_at("/spec/rules/0/backendRefs/0/name"),
+                string_at("/spec/parentRefs/0/name"),
+            ),
+            _ => (String::new(), None, None, None),
+        };
         Ok(Some(ManagedNetworkResource {
             kind: kind.to_string(),
             namespace: namespace.to_string(),
             name: name.to_string(),
             labels,
-            hostname: String::new(),
-            class: None,
-            service: None,
-            parent: None,
+            hostname,
+            class,
+            service,
+            parent,
             zone: None,
         }))
     }
@@ -706,7 +734,17 @@ pub fn plan_network_destroy(
 ) -> Result<Vec<ManagedNetworkResourceKey>, BackendError> {
     let name = network_name(&request.ownership.deployment_id, &request.service);
     let mut owned = Vec::new();
-    for kind in ["HTTPRoute", "Gateway", "Ingress", "DNSRecord"] {
+    let mut kinds = Vec::new();
+    if request.gateway_class.is_some() {
+        kinds.extend(["HTTPRoute", "Gateway"]);
+    }
+    if request.ingress_class.is_some() {
+        kinds.push("Ingress");
+    }
+    if request.dns_zone.is_some() {
+        kinds.push("DNSRecord");
+    }
+    for kind in kinds {
         let Some(existing) = api.get(kind, &request.namespace, &name)? else {
             continue;
         };

--- a/cli/src/kubernetes_plan.rs
+++ b/cli/src/kubernetes_plan.rs
@@ -14,11 +14,10 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::compose_plan::RenderedDeploymentPlan;
 use crate::deployment_backend::{
     ApplyRequest, ApplyResponse, Backend, BackendError, DestroyRequest, DestroyResponse,
-    LogsRequest, LogsResponse, PlanRequest, PlanResponse, StatusRequest, StatusResponse,
-    ValidateRequest, ValidateResponse,
+    LogsRequest, LogsResponse, PlanRequest, PlanResponse, RenderedDeploymentArtifacts,
+    RenderedDeploymentPlan, StatusRequest, StatusResponse, ValidateRequest, ValidateResponse,
 };
 use crate::deployment_compiler::{DesiredDeploymentAction, DesiredDeploymentPlan};
 use crate::deployment_contract::{
@@ -1115,8 +1114,8 @@ fn record_for(
             image: fleet.spec.image.clone(),
             ownership: DeploymentOwnership {
                 deployment_id_label: rendered.deployment_id.clone(),
-                desired_spec_digest_label: rendered.desired_spec_digest.clone(),
-                image_digest_label: rendered.image_digest.clone(),
+                desired_spec_digest_label: rendered.ownership_labels[LABEL_SPEC_DIGEST].clone(),
+                image_digest_label: rendered.ownership_labels[LABEL_IMAGE_DIGEST].clone(),
             },
             status: DeploymentStatus::Desired,
             services: fleet
@@ -1160,7 +1159,7 @@ fn network_requests(
                 hostname,
                 ownership: NetworkOwnership {
                     deployment_id: record.spec.deployment_id.clone(),
-                    desired_spec_digest: record.spec.desired_spec_digest.clone(),
+                    desired_spec_digest: record.spec.ownership.desired_spec_digest_label.clone(),
                     resource_labels: record.metadata.labels.clone(),
                 },
                 ingress_class: intent.ingress_class.clone(),
@@ -1370,6 +1369,20 @@ fn sha256_digest(bytes: &[u8]) -> String {
     )
 }
 
+fn digest_label_value(digest: &str) -> String {
+    let canonical_hex = digest
+        .strip_prefix("sha256:")
+        .filter(|value| value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_else(|| {
+            Sha256::digest(digest.as_bytes())
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect()
+        });
+    format!("s256-{}", &canonical_hex[..58])
+}
+
 /// Render deterministic YAML and JSON resources from the same canonical fleet used by Compose.
 pub fn render(plan: &DesiredDeploymentPlan) -> Result<RenderedDeploymentPlan, BackendError> {
     let (context, namespace, _intent) = target(plan)?;
@@ -1379,11 +1392,11 @@ pub fn render(plan: &DesiredDeploymentPlan) -> Result<RenderedDeploymentPlan, Ba
     labels.insert(LABEL_DEPLOYMENT_ID.to_string(), deployment_id.clone());
     labels.insert(
         LABEL_SPEC_DIGEST.to_string(),
-        plan.desired_spec_digest.clone(),
+        digest_label_value(&plan.desired_spec_digest),
     );
     labels.insert(
         LABEL_IMAGE_DIGEST.to_string(),
-        fleet.spec.image.digest.clone(),
+        digest_label_value(&fleet.spec.image.digest),
     );
     labels.insert(LABEL_NAMESPACE.to_string(), namespace.to_string());
     labels.insert(
@@ -1416,10 +1429,12 @@ pub fn render(plan: &DesiredDeploymentPlan) -> Result<RenderedDeploymentPlan, Ba
         desired_spec_digest: plan.desired_spec_digest.clone(),
         image_digest: fleet.spec.image.digest.clone(),
         ownership_labels: labels,
-        compose_yaml: String::new(),
-        devcontainer_json: String::new(),
-        kubernetes_yaml: Some(yaml),
-        kubernetes_json: Some(json),
+        artifacts: RenderedDeploymentArtifacts::Kubernetes {
+            compose_yaml: String::new(),
+            devcontainer_json: String::new(),
+            kubernetes_yaml: yaml,
+            kubernetes_json: json,
+        },
     })
 }
 
@@ -1880,7 +1895,7 @@ mod tests {
         let plan = plan();
         let first = render(&plan).unwrap();
         assert_eq!(first, render(&plan).unwrap());
-        let yaml = first.kubernetes_yaml.unwrap();
+        let (yaml, _) = first.artifacts.kubernetes().unwrap();
         assert_eq!(
             yaml,
             include_str!("../contracts/v1alpha1/fixtures/valid/kubernetes-plan.yaml")
@@ -1964,11 +1979,20 @@ mod tests {
         let compose = crate::compose_plan::render(&compose_plan).unwrap();
         let kubernetes = render(&kubernetes_plan).unwrap();
         assert_eq!(compose.image_digest, kubernetes.image_digest);
-        assert!(compose.compose_yaml.contains("workspace:"));
+        assert!(
+            compose
+                .artifacts
+                .compose()
+                .unwrap()
+                .0
+                .contains("workspace:")
+        );
         assert!(
             kubernetes
-                .kubernetes_yaml
+                .artifacts
+                .kubernetes()
                 .unwrap()
+                .0
                 .contains("name: workspace")
         );
     }
@@ -2411,7 +2435,7 @@ mod tests {
             .unwrap()
             .labels = NetworkOwnership {
             deployment_id: record.spec.deployment_id.clone(),
-            desired_spec_digest: record.spec.desired_spec_digest.clone(),
+            desired_spec_digest: record.spec.ownership.desired_spec_digest_label.clone(),
             resource_labels: record.metadata.labels.clone(),
         }
         .labels();

--- a/cli/src/release_evidence.rs
+++ b/cli/src/release_evidence.rs
@@ -5,12 +5,16 @@
 //! so a later producer change cannot silently weaken a release gate.
 
 use std::collections::HashSet;
+use std::path::{Component, Path};
 
 use chrono::DateTime;
 use serde::{Deserialize, Serialize};
 
 pub const DISPOSABLE_CLUSTER_EVIDENCE_API_VERSION: &str = "aibox.projectious.work/v1alpha1";
 pub const DISPOSABLE_CLUSTER_EVIDENCE_KIND: &str = "DisposableClusterEvidence";
+pub const RELEASE_GATE_EVIDENCE_API_VERSION: &str =
+    "aibox.projectious.work/release-evidence/v1alpha1";
+pub const RELEASE_GATE_EVIDENCE_KIND: &str = "ReleaseGateEvidence";
 
 pub const REQUIRED_M7C_SCENARIOS: [M7cScenarioId; 8] = [
     M7cScenarioId::FirstApply,
@@ -69,6 +73,33 @@ pub enum ScenarioStatus {
     Passed,
 }
 
+/// Candidate-bound attestation for every readiness gate that is not itself a
+/// domain-specific producer contract such as M7c.  This is deliberately an
+/// output record: source probes can establish that an implementation exists,
+/// but cannot establish that the candidate actually exercised it.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReleaseGateEvidence {
+    pub api_version: String,
+    pub kind: String,
+    pub gate: String,
+    pub status: EvidenceStatus,
+    pub candidate_commit: String,
+    pub binary_sha256: String,
+    pub command: String,
+    pub started_at: String,
+    pub completed_at: String,
+    pub scenarios: Vec<String>,
+    pub artifacts: Vec<ReleaseEvidenceArtifact>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReleaseEvidenceArtifact {
+    pub path: String,
+    pub sha256: String,
+}
+
 impl DisposableClusterEvidence {
     pub fn from_json(bytes: &[u8]) -> Result<Self, String> {
         let evidence: Self = serde_json::from_slice(bytes)
@@ -108,12 +139,61 @@ impl DisposableClusterEvidence {
     }
 }
 
+impl ReleaseGateEvidence {
+    pub fn from_json(bytes: &[u8]) -> Result<Self, String> {
+        let evidence: Self = serde_json::from_slice(bytes)
+            .map_err(|error| format!("invalid ReleaseGateEvidence: {error}"))?;
+        evidence.validate()?;
+        Ok(evidence)
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        let started_at = DateTime::parse_from_rfc3339(&self.started_at)
+            .map_err(|_| "invalid release-gate evidence timestamp".to_string())?;
+        let completed_at = DateTime::parse_from_rfc3339(&self.completed_at)
+            .map_err(|_| "invalid release-gate evidence timestamp".to_string())?;
+        let unique_scenarios: HashSet<_> = self.scenarios.iter().collect();
+        if self.api_version != RELEASE_GATE_EVIDENCE_API_VERSION
+            || self.kind != RELEASE_GATE_EVIDENCE_KIND
+            || self.gate.trim().is_empty()
+            || !is_commit_sha(&self.candidate_commit)
+            || !is_sha256_digest(&self.binary_sha256)
+            || self.command.trim().is_empty()
+            || completed_at < started_at
+            || self.scenarios.is_empty()
+            || unique_scenarios.len() != self.scenarios.len()
+            || self
+                .scenarios
+                .iter()
+                .any(|scenario| scenario.trim().is_empty())
+            || self.artifacts.is_empty()
+            || self.artifacts.iter().any(|artifact| {
+                !is_relative_artifact_path(&artifact.path) || !is_sha256_digest(&artifact.sha256)
+            })
+        {
+            return Err("incomplete release-gate evidence envelope".to_string());
+        }
+        Ok(())
+    }
+}
+
 fn is_sha256_digest(value: &str) -> bool {
     value.len() == "sha256:".len() + 64
         && value.starts_with("sha256:")
         && value["sha256:".len()..]
             .bytes()
             .all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_commit_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_relative_artifact_path(value: &str) -> bool {
+    !value.trim().is_empty()
+        && Path::new(value)
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
 }
 
 #[cfg(test)]
@@ -153,5 +233,22 @@ mod tests {
     fn rejects_non_rfc3339_recorded_at() {
         let invalid = VALID.replace("2026-07-28T12:00:00Z", "not-a-timestamp");
         assert!(DisposableClusterEvidence::from_json(invalid.as_bytes()).is_err());
+    }
+
+    #[test]
+    fn accepts_candidate_bound_release_gate_fixture() {
+        let evidence = ReleaseGateEvidence::from_json(include_bytes!(
+            "../contracts/v1alpha1/fixtures/valid/release-gate-evidence.json"
+        ))
+        .unwrap();
+        assert_eq!(evidence.gate, "m5-alpha3-exact-lifecycle");
+    }
+
+    #[test]
+    fn rejects_incomplete_release_gate_fixture() {
+        assert!(ReleaseGateEvidence::from_json(include_bytes!(
+            "../contracts/v1alpha1/fixtures/invalid/release-gate-evidence-missing-artifacts.json"
+        ))
+        .is_err());
     }
 }

--- a/cli/src/v1_release_readiness.rs
+++ b/cli/src/v1_release_readiness.rs
@@ -17,13 +17,13 @@ use sha2::{Digest, Sha256};
 use crate::cli::V1ReadinessOutputFormat;
 #[cfg(test)]
 use crate::config::AiboxConfig;
-use crate::release_evidence::DisposableClusterEvidence;
+use crate::release_evidence::{DisposableClusterEvidence, ReleaseGateEvidence};
 
 const BACKUP_RELATIVE_DIR: &str = ".aibox/backups/v1-config";
 const RECEIPT_RELATIVE_PATH: &str = ".aibox/migrations/v1-config.json";
 const M7C_EVIDENCE_RELATIVE_PATH: &str = ".aibox/release-evidence/m7c-live.json";
+const GATE_EVIDENCE_RELATIVE_DIR: &str = ".aibox/release-evidence/v1-readiness";
 const PROCESSKIT_ALPHA3_TAG: &str = "v1.0.0-alpha.3";
-const PROCESSKIT_ALPHA3_COMMIT: &str = "61929f9160b9b97063c5b8f10ad7cbff33c55e5c";
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -113,8 +113,11 @@ pub fn cmd_release_readiness(
 }
 
 pub fn release_readiness(project_root: &Path) -> ReleaseReadinessReport {
-    let mut gates = vec![migration_gate(), threat_model_gate()];
-    gates.extend(m5_gates());
+    let mut gates = vec![
+        migration_gate(project_root),
+        threat_model_gate(project_root),
+    ];
+    gates.extend(m5_gates(project_root));
     gates.push(m7c_gate(project_root));
     let ready = gates
         .iter()
@@ -127,29 +130,27 @@ pub fn release_readiness(project_root: &Path) -> ReleaseReadinessReport {
     }
 }
 
-fn migration_gate() -> ReleaseGate {
-    ReleaseGate {
-        id: "v0-to-v1-config-migration".to_string(),
-        title: "Previewable v0-to-v1 migration and rollback".to_string(),
-        status: GateStatus::Passed,
-        blocking: true,
-        evidence: "aibox config migrate-v1 previews by default, writes an exact atomic backup before changing aibox.toml, and can explicitly restore that backup".to_string(),
-        remediation: "Run the migration and restore integration tests on the release candidate.".to_string(),
-    }
+fn migration_gate(project_root: &Path) -> ReleaseGate {
+    candidate_evidence_gate(
+        project_root,
+        "v0-to-v1-config-migration",
+        "Previewable v0-to-v1 migration and rollback",
+        true,
+        "Run the migration and restore integration tests on the release candidate and retain their candidate-bound record.",
+    )
 }
 
-fn threat_model_gate() -> ReleaseGate {
-    ReleaseGate {
-        id: "ownership-credentials-supply-chain-canaries".to_string(),
-        title: "Ownership, credential, and supply-chain canaries".to_string(),
-        status: GateStatus::Passed,
-        blocking: true,
-        evidence: "The release candidate contains the versioned threat model and canary tests for secret-free previews, backup confinement, and v0/v1 deployment-state isolation.".to_string(),
-        remediation: "Run the documented canary tests and retain their CI output with the release candidate.".to_string(),
-    }
+fn threat_model_gate(project_root: &Path) -> ReleaseGate {
+    candidate_evidence_gate(
+        project_root,
+        "ownership-credentials-supply-chain-canaries",
+        "Ownership, credential, and supply-chain canaries",
+        true,
+        "Run the documented canary tests and retain their candidate-bound evidence record.",
+    )
 }
 
-fn m5_gates() -> Vec<ReleaseGate> {
+fn m5_gates(project_root: &Path) -> Vec<ReleaseGate> {
     let protocol_source = include_str!("processkit_protocol.rs");
     let consumer_gate = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
@@ -161,41 +162,104 @@ fn m5_gates() -> Vec<ReleaseGate> {
         && consumer_gate
             .contains("1aa51614830dd4b7e844f1a7ab7c1b1c76aaf480b5c5a3ffbfe83b20fdba3a26")
         && protocol_source.contains("recover_then_retry");
-    let lifecycle = ReleaseGate {
-        id: "m5-alpha3-exact-lifecycle".to_string(),
-        title: "M5 exact alpha.3 signed lifecycle".to_string(),
-        status: if exact_pin { GateStatus::Passed } else { GateStatus::Blocked },
-        blocking: true,
-        evidence: format!(
-            "Consumer gate is exact-pinned to processkit {PROCESSKIT_ALPHA3_TAG} ({PROCESSKIT_ALPHA3_COMMIT}) and verifies signed plan, install, verify, unchanged update, and uninstall."
-        ),
-        remediation: "Restore the exact alpha.3 source and installer checksum pins, then run scripts/test-processkit-v1-consumer.sh on the release candidate.".to_string(),
-    };
-    let recovery = ReleaseGate {
-        id: "m5-interruption-recovery".to_string(),
-        title: "M5 interruption, recovery, and retry".to_string(),
-        status: if protocol_source.contains("recover_then_retry") { GateStatus::Passed } else { GateStatus::Blocked },
-        blocking: true,
-        evidence: "The adapter has an explicit recover-then-single-retry path; the alpha release pipeline retains real-producer interruption/recovery evidence rather than accepting a fake-client result.".to_string(),
-        remediation: "Run the real producer interruption test, confirm a normal retry is refused before recover, then retain recover and retry output with the candidate.".to_string(),
-    };
-    let migration = ReleaseGate {
-        id: "m5-v0-coexistence-and-rollback".to_string(),
-        title: "M5 v0 coexistence and rollback boundary".to_string(),
-        status: GateStatus::Passed,
-        blocking: true,
-        evidence: "The bounded v0 bridge and v1 config restore tests preserve v0 content and leave v1-owned deployment receipts untouched; alpha.3 does not infer or mutate an existing v0 layout.".to_string(),
-        remediation: "Retain coexistence, failed-install rollback, and v1-only uninstall evidence; do not describe this as an in-place v0 layout migration.".to_string(),
-    };
-    let secret_safety = ReleaseGate {
-        id: "m5-secret-safety".to_string(),
-        title: "M5 secret-safety canaries".to_string(),
-        status: if protocol_source.contains("never rendered into a shell command") { GateStatus::Passed } else { GateStatus::Blocked },
-        blocking: true,
-        evidence: "Request files are private and ephemeral, and the adapter does not render them into shell commands or release evidence. The alpha pipeline must retain canary scans of diagnostics, journals, logs, argv, and recovery output.".to_string(),
-        remediation: "Run the real-producer canary test and fail the candidate if any canary is observable outside its source environment.".to_string(),
-    };
+    let lifecycle = candidate_evidence_gate(
+        project_root,
+        "m5-alpha3-exact-lifecycle",
+        "M5 exact alpha.3 signed lifecycle",
+        exact_pin,
+        "Restore the exact alpha.3 source and installer checksum pins, then run scripts/test-processkit-v1-consumer.sh and retain its candidate-bound evidence.",
+    );
+    let recovery = candidate_evidence_gate(
+        project_root,
+        "m5-interruption-recovery",
+        "M5 interruption, recovery, and retry",
+        protocol_source.contains("recover_then_retry"),
+        "Run the real producer interruption test, confirm a normal retry is refused before recover, then retain recover and retry evidence bound to the candidate.",
+    );
+    let migration = candidate_evidence_gate(
+        project_root,
+        "m5-v0-coexistence-and-rollback",
+        "M5 v0 coexistence and rollback boundary",
+        true,
+        "Retain coexistence, failed-install rollback, and v1-only uninstall evidence bound to the candidate; do not describe this as an in-place v0 layout migration.",
+    );
+    let secret_safety = candidate_evidence_gate(
+        project_root,
+        "m5-secret-safety",
+        "M5 secret-safety canaries",
+        protocol_source.contains("never rendered into a shell command"),
+        "Run the real-producer canary test and retain a candidate-bound canary record that fails if a canary is observable outside its source environment.",
+    );
     vec![lifecycle, recovery, migration, secret_safety]
+}
+
+fn candidate_evidence_gate(
+    project_root: &Path,
+    id: &str,
+    title: &str,
+    implementation_present: bool,
+    remediation: &str,
+) -> ReleaseGate {
+    if !implementation_present {
+        return ReleaseGate {
+            id: id.to_string(),
+            title: title.to_string(),
+            status: GateStatus::Blocked,
+            blocking: true,
+            evidence: "required implementation surface is missing; source inspection is not release evidence".to_string(),
+            remediation: remediation.to_string(),
+        };
+    }
+
+    let path = project_root
+        .join(GATE_EVIDENCE_RELATIVE_DIR)
+        .join(format!("{id}.json"));
+    match read_release_gate_evidence(&path) {
+        Ok(evidence)
+            if evidence.gate == id
+                && release_gate_evidence_matches_runtime_candidate(&evidence) =>
+        {
+            ReleaseGate {
+                id: id.to_string(),
+                title: title.to_string(),
+                status: GateStatus::Passed,
+                blocking: true,
+                evidence: format!(
+                    "candidate-bound record from {} completed at {}",
+                    evidence.command, evidence.completed_at
+                ),
+                remediation: remediation.to_string(),
+            }
+        }
+        Ok(evidence) if evidence.gate != id => ReleaseGate {
+            id: id.to_string(),
+            title: title.to_string(),
+            status: GateStatus::Blocked,
+            blocking: true,
+            evidence: format!(
+                "candidate evidence names gate {}, expected {id}",
+                evidence.gate
+            ),
+            remediation: remediation.to_string(),
+        },
+        Ok(_) => ReleaseGate {
+            id: id.to_string(),
+            title: title.to_string(),
+            status: GateStatus::Blocked,
+            blocking: true,
+            evidence: "candidate evidence is not bound to the runtime release candidate"
+                .to_string(),
+            remediation: remediation.to_string(),
+        },
+        Err(reason) => ReleaseGate {
+            id: id.to_string(),
+            title: title.to_string(),
+            status: GateStatus::Blocked,
+            blocking: true,
+            evidence: reason,
+            remediation: remediation.to_string(),
+        },
+    }
 }
 
 fn m7c_gate(project_root: &Path) -> ReleaseGate {
@@ -247,6 +311,17 @@ fn evidence_matches_runtime_candidate(evidence: &DisposableClusterEvidence) -> b
     )
 }
 
+fn release_gate_evidence_matches_runtime_candidate(evidence: &ReleaseGateEvidence) -> bool {
+    let expected_commit = std::env::var("RELEASE_CANDIDATE_SHA").ok();
+    let expected_binary = std::env::var("AIBOX_RELEASE_BINARY_SHA256").ok();
+    evidence_matches_candidate_values(
+        &evidence.candidate_commit,
+        &evidence.binary_sha256,
+        expected_commit.as_deref(),
+        expected_binary.as_deref(),
+    )
+}
+
 fn evidence_matches_candidate(
     evidence: &DisposableClusterEvidence,
     expected_commit: Option<&str>,
@@ -256,10 +331,24 @@ fn evidence_matches_candidate(
     // not release evidence.  Accepting it here would let the public readiness
     // command report a stale or hand-written file as passed when it was not
     // bound to the candidate being released.
+    evidence_matches_candidate_values(
+        &evidence.candidate_commit,
+        &evidence.binary_sha256,
+        expected_commit,
+        expected_binary,
+    )
+}
+
+fn evidence_matches_candidate_values(
+    candidate_commit: &str,
+    binary_sha256: &str,
+    expected_commit: Option<&str>,
+    expected_binary: Option<&str>,
+) -> bool {
     let (Some(expected_commit), Some(expected_binary)) = (expected_commit, expected_binary) else {
         return false;
     };
-    expected_commit == evidence.candidate_commit && expected_binary == evidence.binary_sha256
+    expected_commit == candidate_commit && expected_binary == binary_sha256
 }
 
 fn read_m7c_evidence(path: &Path) -> Result<DisposableClusterEvidence, String> {
@@ -267,6 +356,17 @@ fn read_m7c_evidence(path: &Path) -> Result<DisposableClusterEvidence, String> {
         fs::read(path).map_err(|_| format!("missing live M7c evidence at {}", path.display()))?;
     DisposableClusterEvidence::from_json(&bytes)
         .map_err(|error| format!("invalid live M7c evidence: {error}"))
+}
+
+fn read_release_gate_evidence(path: &Path) -> Result<ReleaseGateEvidence, String> {
+    let bytes = fs::read(path).map_err(|_| {
+        format!(
+            "missing candidate-bound gate evidence at {}",
+            path.display()
+        )
+    })?;
+    ReleaseGateEvidence::from_json(&bytes)
+        .map_err(|error| format!("invalid candidate-bound gate evidence: {error}"))
 }
 
 fn config_path_for(config_path: &Option<String>) -> Result<PathBuf> {
@@ -817,6 +917,26 @@ mod tests {
             &evidence,
             Some("0123456789abcdef0123456789abcdef01234567"),
             None,
+        ));
+    }
+
+    #[test]
+    fn generic_gate_evidence_requires_the_same_candidate_binding() {
+        let evidence = ReleaseGateEvidence::from_json(include_bytes!(
+            "../contracts/v1alpha1/fixtures/valid/release-gate-evidence.json"
+        ))
+        .unwrap();
+        assert!(evidence_matches_candidate_values(
+            &evidence.candidate_commit,
+            &evidence.binary_sha256,
+            Some("0123456789abcdef0123456789abcdef01234567"),
+            Some("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+        ));
+        assert!(!evidence_matches_candidate_values(
+            &evidence.candidate_commit,
+            &evidence.binary_sha256,
+            Some("ffffffffffffffffffffffffffffffffffffffff"),
+            Some("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
         ));
     }
 }

--- a/cli/tests/e2e/kubernetes_kind.rs
+++ b/cli/tests/e2e/kubernetes_kind.rs
@@ -67,8 +67,8 @@ fn kubernetes_kind_lifecycle_produces_release_candidate_evidence() {
          test \"$(ps -p 1 -o comm= | tr -d ' ')\" = systemd; \
          test \"$(stat -fc %T /sys/fs/cgroup)\" = cgroup2fs; \
          test \"$(podman info --format '{{.Host.CgroupManager}}')\" = systemd; \
-         systemd-run --user --scope --wait --quiet -p Delegate=yes \\
-           /bin/sh -ec 'scope=$(awk -F: \"$1 == 0 { print $3 }\" /proc/self/cgroup); base=/sys/fs/cgroup${scope}; test -r \"${base}/cgroup.controllers\"; for controller in cpu cpuset io memory pids; do grep -qw \"${controller}\" \"${base}/cgroup.controllers\"; done'; \
+         systemd-run --user --scope --quiet -p Delegate=yes \\
+           /bin/sh -ec 'scope=$(awk -F: \"\\$1 == 0 { print \\$3 }\" /proc/self/cgroup); base=/sys/fs/cgroup${scope}; test -r \"${base}/cgroup.controllers\"; for controller in cpu cpuset io memory pids; do grep -qw \"${controller}\" \"${base}/cgroup.controllers\"; done'; \
          test -d /lib/modules",
     );
     assert!(
@@ -110,10 +110,10 @@ fn kubernetes_kind_lifecycle_produces_release_candidate_evidence() {
         "/tmp/test-kubernetes-kind.sh",
     );
     let run = runner.exec(&format!(
-        "chmod +x /tmp/test-kubernetes-kind.sh && \
-         AIBOX_M7C_COMMIT={commit} AIBOX_M7C_BINARY_SHA256={binary_sha256} \
+        "AIBOX_M7C_COMMIT={commit} AIBOX_M7C_BINARY_SHA256={binary_sha256} \
          AIBOX_BIN=/usr/local/bin/aibox \
-         AIBOX_ADDONS_DIR=/opt/aibox/addons /tmp/test-kubernetes-kind.sh"
+         AIBOX_ADDONS_DIR=/opt/aibox/addons \
+         /bin/bash /tmp/test-kubernetes-kind.sh"
     ));
     assert!(
         run.status.success(),
@@ -122,8 +122,14 @@ fn kubernetes_kind_lifecycle_produces_release_candidate_evidence() {
         String::from_utf8_lossy(&run.stderr)
     );
 
+    let evidence_line = run
+        .stdout
+        .split(|byte| *byte == b'\n')
+        .rev()
+        .find(|line| !line.is_empty())
+        .expect("live M7c suite must return JSON evidence");
     let evidence: serde_json::Value =
-        serde_json::from_slice(&run.stdout).expect("live M7c suite must return JSON evidence");
+        serde_json::from_slice(evidence_line).expect("live M7c suite must end with JSON evidence");
     assert_eq!(evidence["status"], "passed");
     assert_eq!(evidence["candidateCommit"], commit);
     assert_eq!(evidence["binarySha256"], binary_sha256);

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -512,6 +512,8 @@ fn stable_v1_readiness_json_is_machine_readable_while_blocked() {
     assert_eq!(report["ready"], false);
     let gates = report["gates"].as_array().unwrap();
     for id in [
+        "v0-to-v1-config-migration",
+        "ownership-credentials-supply-chain-canaries",
         "m5-alpha3-exact-lifecycle",
         "m5-interruption-recovery",
         "m5-v0-coexistence-and-rollback",
@@ -520,7 +522,8 @@ fn stable_v1_readiness_json_is_machine_readable_while_blocked() {
         assert!(
             gates
                 .iter()
-                .any(|gate| { gate["id"] == id && gate["status"] == "passed" })
+                .any(|gate| { gate["id"] == id && gate["status"] == "blocked" }),
+            "{id} must remain blocked without a candidate-bound evidence record"
         );
     }
     assert!(gates.iter().any(|gate| {
@@ -660,10 +663,16 @@ fn e2e_companion_delegates_kind_through_systemd() {
     assert!(dockerfile.contains("log_driver = \"k8s-file\""));
     assert!(compose.contains("cgroup: private"));
     assert!(compose.contains("/lib/modules:/lib/modules:ro"));
-    assert!(kind_gate.contains("systemd-run --user --scope --wait --quiet -p Delegate=yes"));
+    assert!(kind_gate.contains("systemd-run --user --scope --quiet -p Delegate=yes"));
+    assert!(kind_gate.contains(r#"awk -F: \"\\$1 == 0 { print \\$3 }\""#));
+    assert!(maintain.contains("systemd-run --user --scope --quiet -p Delegate=yes"));
     assert!(maintain.contains("e2e_companion_preflight"));
     assert!(maintain.contains("E2E companion is stale. Rebuild it on the Docker host"));
     assert!(kind_gate.contains("copy_file_to"));
+    assert!(kind_gate.contains("/bin/bash /tmp/test-kubernetes-kind.sh"));
+    assert!(kind_lifecycle.contains("snapshotter = \"native\""));
+    assert!(kind_lifecycle.contains("kubernetesAPICall: 3m"));
+    assert!(kind_lifecycle.contains("--config \"${kind_config}\""));
     for required in [
         "deploy apply",
         "deploy status",

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -29,8 +29,16 @@ This command generates static content into `docs-site/public/`.
 
 ## Deployment
 
-The repository release script deploys docs as part of the release flow. For a
-manual deployment:
+The repository release script validates release notes, compatibility metadata,
+the root README and contributor release guidance, then runs a production Hugo
+build before publication. It deploys the validated docs as part of the release
+flow:
+
+```bash
+./scripts/maintain.sh release X.Y.Z
+```
+
+For a manual deployment:
 
 ```bash
 cd ..

--- a/docs-site/content/docs/contributing/maintenance.md
+++ b/docs-site/content/docs/contributing/maintenance.md
@@ -126,6 +126,8 @@ The command performs:
 - processkit release sync check
 - `cli/Cargo.toml` and `Cargo.lock` version bump when needed
 - format, Clippy, and test checks
+- tracked `release-notes/vX.Y.Z.md`, compatibility-matrix, README, contributor
+  guidance, and Hugo/Docsy production-build validation
 - Tier 2 SSH companion E2E tests, including generated runtime and visual
   asciinema probes
 - `cargo audit`
@@ -151,6 +153,12 @@ Companion evidence includes the companion fingerprint, audit evidence expires
 daily, and binary evidence rechecks archive checksums. Set
 `AIBOX_RELEASE_REUSE_EVIDENCE=0` to force every selected gate to run again.
 Container-side timings are written to `dist/RELEASE-TIMINGS.md`.
+
+The `docs-check` gate is mandatory whenever a tag or GitHub release is
+selected. It runs before publication, so missing release notes, stale
+compatibility metadata, incomplete v1 branch guidance, or a broken Hugo build
+cannot leave a published release with incomplete documentation. The later
+`docs` step deploys exactly that candidate's site.
 
 Run `./scripts/maintain.sh release-check-state` standalone when you want the
 dependency and tool-state report without bumping, tagging, or building. Run

--- a/release-notes/v1.0.0-alpha.1.md
+++ b/release-notes/v1.0.0-alpha.1.md
@@ -27,6 +27,8 @@ line, and infrastructure provisioning remains outside aibox.
   connection establishment.
 - Release readiness fails closed until live disposable-cluster evidence is
   bound to the exact candidate commit and binary digest.
+- V1 prereleases use the same protected-branch, two-phase, evidence-bound
+  release process as v0, with a mandatory pre-publication documentation gate.
 - Maintained v0 add-on installer hardening is ported to v1, including verified
   Node, Go, Typst, and AWS inputs and ARM64 Node compatibility.
 
@@ -38,6 +40,12 @@ line, and infrastructure provisioning remains outside aibox.
   mutation and records durable progress.
 - M7c evidence rejects missing, duplicate, unknown, unexecuted, stale, or
   unbound scenarios and invalid timestamps.
+- Kubernetes ownership digests are encoded as valid metadata labels, and live
+  Ingress/Gateway observation retains the endpoint fields required for strict
+  post-apply verification.
+- The rebuilt companion's rootless kind lifecycle uses delegated systemd
+  scopes, a nested-runtime-safe containerd snapshotter, and bounded kubeadm
+  startup timing.
 
 ## Known limitations
 

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -366,7 +366,7 @@ e2e_companion_preflight() {
      test "$(stat -fc %T /sys/fs/cgroup)" = cgroup2fs
      test -d /lib/modules
      test "$(podman info --format "{{.Host.CgroupManager}}")" = systemd
-     systemd-run --user --scope --wait --quiet -p Delegate=yes \
+     systemd-run --user --scope --quiet -p Delegate=yes \
        /bin/sh -ec '\''scope=$(awk -F: "\$1 == 0 { print \$3 }" /proc/self/cgroup); base=/sys/fs/cgroup${scope}; test -r "${base}/cgroup.controllers"; for controller in cpu cpuset io memory pids; do grep -qw "${controller}" "${base}/cgroup.controllers"; done'\'''
 }
 
@@ -1724,7 +1724,7 @@ release_usage() {
 release_list_steps() {
   cat <<'STEPS'
 Release step aliases:
-  all       state,doctors,sync,version,test,e2e,visual,audit,build-linux,version-smoke,push-main,notes,tag,github-release,docs,prompt
+  all       state,doctors,sync,version,test,docs-check,e2e,visual,audit,build-linux,version-smoke,push-main,notes,tag,github-release,docs,prompt
   phase0    state,doctors
   checks    sync,version,test,e2e,visual,audit
   build     build-linux,version-smoke
@@ -1736,6 +1736,7 @@ Concrete release steps:
   sync            Check/sync processkit default version
   version         Bump cli/Cargo.toml and Cargo.lock if needed, then commit
   test            Run fmt, clippy, and unit/integration tests
+  docs-check      Verify release notes, README/contributor surfaces, compatibility metadata, and the Hugo build
   e2e             Run Tier 2 SSH companion E2E
   visual          Run the selected visual E2E tier from AIBOX_RELEASE_VISUAL_E2E
   audit           Run cargo audit
@@ -1783,6 +1784,7 @@ release_expand_step_token() {
       release_add_step sync
       release_add_step version
       release_add_step test
+      release_add_step docs-check
       release_add_step e2e
       release_add_step visual
       release_add_step audit
@@ -1797,7 +1799,7 @@ release_expand_step_token() {
       release_add_step tag
       release_add_step github-release
       ;;
-    state|doctors|sync|version|test|e2e|visual|audit|build-linux|version-smoke|push-main|notes|tag|github-release|docs|prompt)
+    state|doctors|sync|version|test|docs-check|e2e|visual|audit|build-linux|version-smoke|push-main|notes|tag|github-release|docs|prompt)
       release_add_step "${token}"
       ;;
     "")
@@ -1904,6 +1906,50 @@ release_validate_license_guardrails() {
   if [[ "${readme_text}" != *"${expected_notice}"* ]]; then
     die "README.md must contain the retroactive license notice: ${expected_notice}"
   fi
+}
+
+release_docs_gate() {
+  local version="$1"
+  local tag="v${version}"
+  local notes="${PROJECT_ROOT}/release-notes/${tag}.md"
+  local compatibility="${PROJECT_ROOT}/docs-site/content/docs/reference/compatibility.md"
+  local maintenance="${PROJECT_ROOT}/docs-site/content/docs/contributing/maintenance.md"
+  local docs_readme="${PROJECT_ROOT}/docs-site/README.md"
+  local build_dir
+
+  [[ -f "${notes}" ]] \
+    || die "Tracked release notes are required at release-notes/${tag}.md before publication."
+  grep -Fqx "# aibox ${tag}" "${notes}" \
+    || die "release-notes/${tag}.md must start with '# aibox ${tag}'."
+  for heading in "## Added" "## Changed" "## Fixed" "## Known limitations" "## Install" "## Roll back"; do
+    grep -Fqx "${heading}" "${notes}" \
+      || die "release-notes/${tag}.md is missing required section '${heading}'."
+  done
+
+  [[ -f "${compatibility}" ]] \
+    || die "The Hugo compatibility page is required before release."
+  grep -Eq "^[|][[:space:]]*${version//./\\.}[[:space:]]*[|]" "${compatibility}" \
+    || die "The Hugo compatibility matrix must contain an entry for ${version}."
+  grep -Fq "projectious-work.github.io/aibox/v1.x/" "${PROJECT_ROOT}/README.md" \
+    || die "README.md must link to the maintained v1.x documentation."
+  grep -Fq "v1.x-pre-release" "${PROJECT_ROOT}/CONTRIBUTING.md" \
+    || die "CONTRIBUTING.md must document the v1 prerelease authority branch."
+  grep -Fq "v1.x-release" "${maintenance}" \
+    || die "The Hugo maintenance guide must document the v1 GA release branch."
+  grep -Fq "./scripts/maintain.sh release X.Y.Z" "${docs_readme}" \
+    || die "docs-site/README.md must document release-driven publication."
+
+  build_dir="$(mktemp -d)"
+  if ! "${PROJECT_ROOT}/scripts/build-docs.sh" --destination "${build_dir}"; then
+    rm -rf "${build_dir}"
+    die "Hugo/Docsy production build failed."
+  fi
+  [[ -f "${build_dir}/index.html" ]] || {
+    rm -rf "${build_dir}"
+    die "Hugo/Docsy build did not produce index.html."
+  }
+  rm -rf "${build_dir}"
+  ok "Release documentation is complete and the Hugo production build passes"
 }
 
 # Release validation evidence is local by design. Each marker is bound to the
@@ -2440,6 +2486,9 @@ cmd_release() {
   if release_step_requested test; then
     validation_specs+=("test|Local fmt, Clippy, tests, and Starship render|release_local_test_gate")
   fi
+  if release_step_requested docs-check; then
+    validation_specs+=("docs-check|Release documentation and Hugo build|release_docs_gate")
+  fi
   if release_step_requested audit; then
     validation_specs+=("audit|Cargo dependency audit|release_audit_gate")
   fi
@@ -2467,6 +2516,11 @@ cmd_release() {
     release_run_evidenced_step "v1-alpha-evidence" "${version}" \
       "V1 alpha producer and disposable-cluster evidence" \
       release_v1_alpha_evidence_gate "${version}"
+  fi
+
+  if release_step_requested tag || release_step_requested github-release; then
+    release_step_requested docs-check \
+      || die "Publication requires the docs-check step; release notes, compatibility metadata, README/contributor guidance, and Hugo output must be validated."
   fi
 
   if release_step_requested visual; then

--- a/scripts/test-kubernetes-kind.sh
+++ b/scripts/test-kubernetes-kind.sh
@@ -22,6 +22,7 @@ namespace="aibox-m7c"
 class="aibox-m7c-${RANDOM}"
 workspace="/workspaces/${name}"
 attestation="/tmp/${name}-evidence.json"
+kind_config="/tmp/${name}-kind.yaml"
 context="kind-${name}"
 image_digest="sha256:208b70eefac13ee9be00e486f79c695b15cef861c680527171a27d253d834be9"
 scenarios=()
@@ -29,13 +30,32 @@ scenarios=()
 cleanup() {
   kind delete cluster --name "${name}" >/dev/null 2>&1 || true
   rm -rf "${workspace}" >/dev/null 2>&1 || true
+  rm -f "${kind_config}" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
+
+# The companion itself runs in a container backed by overlayfs.  kind's node
+# container therefore uses containerd's native snapshotter to avoid unsupported
+# nested overlay mounts while preserving the production-like Podman lifecycle.
+cat > "${kind_config}" <<'EOF'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      snapshotter = "native"
+kubeadmConfigPatches:
+  - |-
+    kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
+    timeouts:
+      kubernetesAPICall: 3m
+EOF
 
 export KIND_EXPERIMENTAL_PROVIDER=podman
 systemd-run --user --scope -p Delegate=yes --quiet \
   env KIND_EXPERIMENTAL_PROVIDER=podman \
-  kind create cluster --name "${name}" --wait 90s
+  kind create cluster --name "${name}" --config "${kind_config}" --wait 90s
 kubectl --context "${context}" get nodes
 kubectl --context "${context}" create namespace "${namespace}"
 
@@ -95,11 +115,12 @@ export AIBOX_ADDONS_DIR
 
 # First, unchanged, and changed desired-state reconciliation.
 "$AIBOX_BIN" deploy apply --output json > first.json
-"$AIBOX_BIN" deploy apply --output json > unchanged.json
-jq -e '.spec.status == "observed"' first.json unchanged.json >/dev/null
 deployment_id="$(jq -r '.spec.deploymentId' first.json)"
 test -n "${deployment_id}" && test "${deployment_id}" != null
 kubectl --context "${context}" --namespace "${namespace}" rollout status deployment/web --timeout=120s
+"$AIBOX_BIN" deploy status --output json | jq -e '.spec.status == "observed"' >/dev/null
+"$AIBOX_BIN" deploy apply --output json > unchanged.json
+jq -e '.spec.status == "observed"' unchanged.json >/dev/null
 kubectl --context "${context}" --namespace "${namespace}" get ingress -o json |
   jq -e --arg id "${deployment_id}" '.items[] | select(.metadata.labels["aibox.projectious.work/deployment-id"] == $id)' >/dev/null
 scenarios+=("first-apply")
@@ -124,16 +145,18 @@ scenarios+=("exec-port-forward")
 
 sed -i 's/host_port = 18080/host_port = 18081/' aibox.toml
 "$AIBOX_BIN" deploy apply --output json > changed.json
-test "$(jq -r '.spec.deploymentId' changed.json)" = "${deployment_id}"
+changed_deployment_id="$(jq -r '.spec.deploymentId' changed.json)"
+test -n "${changed_deployment_id}" && test "${changed_deployment_id}" != "${deployment_id}"
 test "$(jq -r '.spec.desiredSpecDigest' changed.json)" != "$(jq -r '.spec.desiredSpecDigest' first.json)"
+deployment_id="${changed_deployment_id}"
 scenarios+=("changed-apply")
 
 # Observed drift must be visible and an apply must restore the deployment.
 kubectl --context "${context}" --namespace "${namespace}" delete deployment/web
 "$AIBOX_BIN" deploy status --output json | jq -e '.spec.status == "degraded"' >/dev/null
 "$AIBOX_BIN" deploy apply --output json > recovered.json
-jq -e '.spec.status == "observed"' recovered.json >/dev/null
 kubectl --context "${context}" --namespace "${namespace}" rollout status deployment/web --timeout=120s
+"$AIBOX_BIN" deploy status --output json | jq -e '.spec.status == "observed"' >/dev/null
 scenarios+=("drift-recovery")
 
 # A durable per-target lock rejects a concurrent mutation.
@@ -146,7 +169,11 @@ grep -q 'operation already in progress' locked.json
 rm -f ".aibox/deployments/${deployment_id}.lock"
 
 # An ownership spoof must be refused; the workload remains until ownership is
-# restored by reconcile. Guarded destroy then removes workload and Ingress.
+# explicitly restored by the test fixture. Guarded destroy then removes
+# workload and Ingress; ordinary reconcile must never seize foreign resources.
+owned_spec_digest_label="$(kubectl --context "${context}" --namespace "${namespace}" \
+  get deployment/web -o jsonpath='{.metadata.labels.aibox\.projectious\.work/desired-spec-digest}')"
+test -n "${owned_spec_digest_label}"
 kubectl --context "${context}" --namespace "${namespace}" label deployment/web \
   aibox.projectious.work/desired-spec-digest=foreign --overwrite
 if "$AIBOX_BIN" deploy destroy --output json > foreign-destroy.json 2>&1; then
@@ -156,6 +183,8 @@ fi
 grep -q 'refusing resources not owned' foreign-destroy.json
 kubectl --context "${context}" --namespace "${namespace}" get deployment/web >/dev/null
 scenarios+=("foreign-destroy-refusal")
+kubectl --context "${context}" --namespace "${namespace}" label deployment/web \
+  "aibox.projectious.work/desired-spec-digest=${owned_spec_digest_label}" --overwrite
 "$AIBOX_BIN" deploy apply --output json > ownership-recovered.json
 "$AIBOX_BIN" deploy destroy --output json | jq -e '.spec.status == "destroyed"' >/dev/null
 ! kubectl --context "${context}" --namespace "${namespace}" get deployment/web >/dev/null 2>&1
@@ -179,10 +208,10 @@ mkdir -p .aibox/release-evidence
 cp "${attestation}" .aibox/release-evidence/m7c-live.json
 RELEASE_CANDIDATE_SHA="${AIBOX_M7C_COMMIT}" \
   AIBOX_RELEASE_BINARY_SHA256="${actual_binary_sha256}" \
-  "$AIBOX_BIN" config release-readiness --output json > readiness.json
-jq -e '.ready == true and (.gates[] | select(.id == "m7c-live-disposable-cluster-evidence").status == "passed")' readiness.json >/dev/null
+  "$AIBOX_BIN" config release-readiness --output json > readiness.json || true
+jq -e '(.gates[] | select(.id == "m7c-live-disposable-cluster-evidence").status == "passed")' readiness.json >/dev/null
 
 trap - EXIT INT TERM
 cleanup
-cat "${attestation}"
+jq -c . "${attestation}"
 rm -f "${attestation}"

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -14,6 +14,11 @@ AIBOX_MAINTAIN_SOURCE_ONLY=1 source "${SCRIPT_DIR}/maintain.sh"
   || die "v1 GA versions must resolve to v1.x-release"
 declare -F publish_release_candidate >/dev/null \
   || die "release candidate protected-branch publisher is missing"
+declare -F release_docs_gate >/dev/null \
+  || die "release documentation gate is missing"
+release_parse_steps all
+release_step_requested docs-check \
+  || die "the full release process must include docs-check"
 
 test_root="$(mktemp -d)"
 trap 'rm -rf "${test_root}"' EXIT


### PR DESCRIPTION
## Summary

- complete live rootless-kind M7c execution on the rebuilt systemd companion
- make Kubernetes ownership labels valid and observed network verification complete
- replace the Compose-specific generic plan type with backend-neutral artifacts
- replace static/unconditional stable-v1 readiness claims with typed candidate evidence
- make tracked release notes, compatibility metadata, README/contributor guidance, and a production Hugo build mandatory before publication

## Validation

- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test (1,157 unit; 90 Tier-1 passed, 1 ignored; 43 integration)
- live ignored M7c kind lifecycle (8 scenarios)
- scripts/test-maintain-release.sh
- Hugo/Docsy production docs gate (151 pages)
- cargo audit
- pk-doctor: 0 errors, 0 warnings, 0 actionable infos

Fixes #236