### PR TITLE
feat(v1): produce stable readiness evidence

### DIFF
--- a/cli/src/v1_release_readiness.rs
+++ b/cli/src/v1_release_readiness.rs
@@ -217,7 +217,8 @@ fn candidate_evidence_gate(
     match read_release_gate_evidence(&path) {
         Ok(evidence)
             if evidence.gate == id
-                && release_gate_evidence_matches_runtime_candidate(&evidence) =>
+                && release_gate_evidence_matches_runtime_candidate(&evidence)
+                && release_gate_artifacts_match(project_root, &evidence) =>
         {
             ReleaseGate {
                 id: id.to_string(),
@@ -320,6 +321,15 @@ fn release_gate_evidence_matches_runtime_candidate(evidence: &ReleaseGateEvidenc
         expected_commit.as_deref(),
         expected_binary.as_deref(),
     )
+}
+
+fn release_gate_artifacts_match(project_root: &Path, evidence: &ReleaseGateEvidence) -> bool {
+    evidence.artifacts.iter().all(|artifact| {
+        let path = project_root.join(&artifact.path);
+        fs::read(path)
+            .map(|bytes| sha256(&bytes) == artifact.sha256)
+            .unwrap_or(false)
+    })
 }
 
 fn evidence_matches_candidate(
@@ -938,5 +948,23 @@ mod tests {
             Some("ffffffffffffffffffffffffffffffffffffffff"),
             Some("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
         ));
+    }
+
+    #[test]
+    fn generic_gate_evidence_requires_untampered_artifacts() {
+        let dir = TempDir::new().unwrap();
+        let mut evidence = ReleaseGateEvidence::from_json(include_bytes!(
+            "../contracts/v1alpha1/fixtures/valid/release-gate-evidence.json"
+        ))
+        .unwrap();
+        let artifact = dir.path().join("logs/gate.log");
+        fs::create_dir_all(artifact.parent().unwrap()).unwrap();
+        fs::write(&artifact, b"producer passed\n").unwrap();
+        evidence.artifacts[0].path = "logs/gate.log".to_string();
+        evidence.artifacts[0].sha256 = sha256(b"producer passed\n");
+        assert!(release_gate_artifacts_match(dir.path(), &evidence));
+
+        fs::write(&artifact, b"tampered\n").unwrap();
+        assert!(!release_gate_artifacts_match(dir.path(), &evidence));
     }
 }

--- a/docs-site/content/docs/reference/v1-deployment-boundaries.md
+++ b/docs-site/content/docs/reference/v1-deployment-boundaries.md
@@ -35,9 +35,18 @@ aibox config release-readiness --output json
 ```
 
 It exits non-zero while a blocking gate is incomplete, but JSON is still printed
-for CI ingestion. In particular it blocks until the exact processkit alpha.3
-lifecycle, interruption/recovery, coexistence/rollback, and secret-safety
-gates are met, and M7c has complete live disposable-cluster evidence at
+for automation ingestion. Stable publication runs
+`scripts/test-v1-stable-readiness.sh` first. That harness executes the real
+migration/restore, ownership and secret canaries, dependency audit, and exact
+processkit alpha.3 producer tests. It writes one typed, candidate-bound
+`ReleaseGateEvidence` record per gate under
+`.aibox/release-evidence/v1-readiness/`. A record is retained only after its
+producer succeeds.
+
+The readiness parser verifies the candidate commit, tested-binary digest, gate
+identity, and SHA-256 digest of every referenced producer log. Missing,
+candidate-mismatched, or modified logs block the release. M7c separately
+requires complete live disposable-cluster evidence at
 `.aibox/release-evidence/m7c-live.json`.
 
 M7c passes only when the release workflow supplies both the exact candidate

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -2142,6 +2142,23 @@ release_v1_alpha_evidence_gate() {
   "${PROJECT_ROOT}/scripts/test-processkit-v1-consumer.sh"
 }
 
+release_v1_stable_evidence_gate() {
+  local version="$1" candidate_binary_sha256
+  [[ "${version}" == 1.* && "${version}" != *-* ]] || return 0
+  [[ -f "${CLI_DIR}/target/debug/aibox" && -x "${CLI_DIR}/target/debug/aibox" && ! -L "${CLI_DIR}/target/debug/aibox" ]] \
+    || die "stable-v1 candidate binary is missing; run the local release test gate first"
+  candidate_binary_sha256="sha256:$(sha256_file "${CLI_DIR}/target/debug/aibox")"
+  RELEASE_CANDIDATE_SHA="${RELEASE_CANDIDATE_SHA}" \
+  AIBOX_RELEASE_BINARY_SHA256="${candidate_binary_sha256}" \
+    "${PROJECT_ROOT}/scripts/test-v1-stable-readiness.sh"
+  (cd "${PROJECT_ROOT}" && \
+    RELEASE_CANDIDATE_SHA="${RELEASE_CANDIDATE_SHA}" \
+    AIBOX_RELEASE_BINARY_SHA256="${candidate_binary_sha256}" \
+      cargo run --quiet --manifest-path "${CLI_DIR}/Cargo.toml" -- \
+        config release-readiness --output json) \
+    || die "stable-v1 release readiness evidence is incomplete"
+}
+
 release_visual_gate() {
   case "${AIBOX_RELEASE_VISUAL_E2E:-skip}" in
     status) cmd_test_e2e_visual_status ;;
@@ -2513,6 +2530,18 @@ cmd_release() {
     release_run_evidenced_step "v1-alpha-evidence" "${version}" \
       "V1 alpha producer and disposable-cluster evidence" \
       release_v1_alpha_evidence_gate "${version}"
+  fi
+  if [[ "${version}" == 1.* && "${version}" != *-* ]] && \
+     { release_step_requested tag || release_step_requested github-release; }; then
+    release_step_requested test \
+      || die "stable-v1 publication requires the local test step"
+    release_step_requested audit \
+      || die "stable-v1 publication requires the dependency audit step"
+    release_step_requested e2e \
+      || die "stable-v1 publication requires the e2e step so M7c evidence is generated"
+    release_run_evidenced_step "v1-stable-evidence" "${version}" \
+      "Stable-v1 migration, security, M5, and M7c evidence" \
+      release_v1_stable_evidence_gate "${version}"
   fi
 
   if release_step_requested tag || release_step_requested github-release; then

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -16,6 +16,8 @@ declare -F publish_release_candidate >/dev/null \
   || die "release candidate protected-branch publisher is missing"
 declare -F release_docs_gate >/dev/null \
   || die "release documentation gate is missing"
+declare -F release_v1_stable_evidence_gate >/dev/null \
+  || die "stable-v1 producer evidence gate is missing"
 if declare -f release_v1_alpha_evidence_gate | grep -Fq 'config release-readiness'; then
   die "v1 alpha publication must not require stable-v1 readiness"
 fi

--- a/scripts/test-v1-stable-readiness.sh
+++ b/scripts/test-v1-stable-readiness.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLI_MANIFEST="${PROJECT_ROOT}/cli/Cargo.toml"
+EVIDENCE_DIR="${PROJECT_ROOT}/.aibox/release-evidence/v1-readiness"
+LOG_DIR="${EVIDENCE_DIR}/logs"
+
+: "${RELEASE_CANDIDATE_SHA:?set RELEASE_CANDIDATE_SHA to the exact 40-character candidate commit}"
+: "${AIBOX_RELEASE_BINARY_SHA256:?set AIBOX_RELEASE_BINARY_SHA256 to the tested sha256:<hex> binary digest}"
+
+[[ "${RELEASE_CANDIDATE_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "RELEASE_CANDIDATE_SHA must be a 40-character lowercase commit SHA" >&2
+  exit 2
+}
+[[ "${AIBOX_RELEASE_BINARY_SHA256}" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+  echo "AIBOX_RELEASE_BINARY_SHA256 must be a sha256:<64 lowercase hex> digest" >&2
+  exit 2
+}
+command -v jq >/dev/null || {
+  echo "jq is required to record typed stable-v1 release evidence" >&2
+  exit 2
+}
+
+mkdir -p "${LOG_DIR}"
+
+record_gate() {
+  local gate="$1" command_label="$2" started_at="$3" completed_at="$4" log_path="$5"
+  shift 5
+  local relative_log="${log_path#"${PROJECT_ROOT}/"}"
+  local log_sha256="sha256:$(sha256sum "${log_path}" | awk '{print $1}')"
+  local evidence_tmp="${EVIDENCE_DIR}/.${gate}.json.tmp"
+  local scenarios_json
+  scenarios_json="$(printf '%s\n' "$@" | jq -Rsc 'split("\n")[:-1]')"
+
+  jq -n \
+    --arg gate "${gate}" \
+    --arg candidate_commit "${RELEASE_CANDIDATE_SHA}" \
+    --arg binary_sha256 "${AIBOX_RELEASE_BINARY_SHA256}" \
+    --arg command "${command_label}" \
+    --arg started_at "${started_at}" \
+    --arg completed_at "${completed_at}" \
+    --arg artifact_path "${relative_log}" \
+    --arg artifact_sha256 "${log_sha256}" \
+    --argjson scenarios "${scenarios_json}" \
+    '{
+      apiVersion: "aibox.projectious.work/release-evidence/v1alpha1",
+      kind: "ReleaseGateEvidence",
+      gate: $gate,
+      status: "passed",
+      candidateCommit: $candidate_commit,
+      binarySha256: $binary_sha256,
+      command: $command,
+      startedAt: $started_at,
+      completedAt: $completed_at,
+      scenarios: $scenarios,
+      artifacts: [{path: $artifact_path, sha256: $artifact_sha256}]
+    }' > "${evidence_tmp}"
+  mv "${evidence_tmp}" "${EVIDENCE_DIR}/${gate}.json"
+}
+
+run_gate() {
+  local gate="$1" command_label="$2"
+  shift 2
+  local scenarios=()
+  while [[ "${1:-}" != "--" ]]; do
+    scenarios+=("$1")
+    shift
+  done
+  shift
+
+  local started_at completed_at
+  local log_tmp="${LOG_DIR}/.${gate}.log.tmp"
+  local log_path="${LOG_DIR}/${gate}.log"
+  started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if ! "$@" > "${log_tmp}" 2>&1; then
+    cat "${log_tmp}" >&2
+    rm -f "${log_tmp}" "${EVIDENCE_DIR}/${gate}.json"
+    return 1
+  fi
+  completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  cat "${log_tmp}"
+  mv "${log_tmp}" "${log_path}"
+  record_gate \
+    "${gate}" "${command_label}" "${started_at}" "${completed_at}" "${log_path}" \
+    "${scenarios[@]}"
+}
+
+run_migration_gate() {
+  cargo test --manifest-path "${CLI_MANIFEST}" \
+    v1_release_readiness::tests:: -- --nocapture
+  cargo test --manifest-path "${CLI_MANIFEST}" \
+    v1_config_migration_preview_apply_and_restore_are_explicit_and_isolated -- --nocapture
+}
+
+run_security_gate() {
+  local filter
+  for filter in \
+    deployment_target_serializes_credential_references_without_secret_values \
+    destroy_refuses_every_ownership_mismatch_and_is_idempotent_after_success \
+    connection_argv_never_receives_credential_references_or_secret_canaries \
+    reconciler_uses_existing_facilities_and_never_serializes_secret_canary
+  do
+    cargo test --manifest-path "${CLI_MANIFEST}" "${filter}" -- --nocapture
+  done
+  (cd "${PROJECT_ROOT}/cli" && cargo audit)
+}
+
+run_gate \
+  "v0-to-v1-config-migration" \
+  "scripts/test-v1-stable-readiness.sh migration" \
+  "preview-without-mutation" \
+  "exact-private-backup" \
+  "disabled-v1-boundary" \
+  "restore-v0-config" \
+  "preserve-v1-deployment-records" \
+  -- run_migration_gate
+
+run_gate \
+  "ownership-credentials-supply-chain-canaries" \
+  "scripts/test-v1-stable-readiness.sh security" \
+  "credential-reference-serialization" \
+  "secret-canary-absence" \
+  "complete-ownership-before-destroy" \
+  "dependency-advisory-audit" \
+  -- run_security_gate
+
+m5_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+m5_log_tmp="${LOG_DIR}/.m5-real-producer.log.tmp"
+m5_log_path="${LOG_DIR}/m5-real-producer.log"
+if ! "${PROJECT_ROOT}/scripts/test-processkit-v1-consumer.sh" \
+  > "${m5_log_tmp}" 2>&1
+then
+  cat "${m5_log_tmp}" >&2
+  rm -f "${m5_log_tmp}"
+  exit 1
+fi
+m5_completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cat "${m5_log_tmp}"
+mv "${m5_log_tmp}" "${m5_log_path}"
+
+for gate in \
+  m5-alpha3-exact-lifecycle \
+  m5-interruption-recovery \
+  m5-v0-coexistence-and-rollback \
+  m5-secret-safety
+do
+  case "${gate}" in
+    m5-alpha3-exact-lifecycle)
+      scenarios=(signed-install verify no-op-update changed-update uninstall)
+      ;;
+    m5-interruption-recovery)
+      scenarios=(interrupted-operation retry-refusal recover retry-success)
+      ;;
+    m5-v0-coexistence-and-rollback)
+      scenarios=(v0-coexistence failed-install-rollback v1-only-uninstall)
+      ;;
+    m5-secret-safety)
+      scenarios=(argv-canary-absence request-cleanup log-canary-absence error-canary-absence)
+      ;;
+  esac
+  record_gate \
+    "${gate}" \
+    "scripts/test-processkit-v1-consumer.sh" \
+    "${m5_started_at}" \
+    "${m5_completed_at}" \
+    "${m5_log_path}" \
+    "${scenarios[@]}"
+done
+
+echo "stable-v1 producer evidence written to ${EVIDENCE_DIR}"


### PR DESCRIPTION
## Outcome

Closes the first post-alpha gap from #236: stable-v1 readiness now consumes evidence emitted by real producers instead of requiring hand-created records.

## Changes

- add a stable-readiness producer harness for reversible migration, ownership/credential/supply-chain canaries, and exact processkit alpha.3 lifecycle/recovery/coexistence/secret-safety
- retain typed candidate- and binary-bound `ReleaseGateEvidence` only after producer success
- bind each record to a SHA-256-verified producer log and reject missing or modified artifacts
- require this harness plus local tests, audit, and live M7c before stable-v1 publication
- document the stable evidence flow

## Validation

- 1,158 unit tests
- 90 Tier-1 E2E passed; 1 ignored
- 43 integration tests
- Clippy with `-D warnings`
- Rust formatting and shell syntax
- cargo audit clean
- maintain release regression suite
- full producer-to-parser run: six non-M7c stable gates pass; M7c correctly remains candidate-bound
- Hugo production build: 151 pages
- pk-doctor: 0 errors, 0 warnings, 0 actionable findings

Refs #236
