### PR TITLE
feat(v1): apply reviewed migration intent

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -542,6 +542,14 @@ pub enum ConfigAction {
         /// Write the disabled v1 orchestration boundary after making an exact v0 backup.
         #[arg(long, conflicts_with = "restore")]
         apply: bool,
+        /// Reviewed TOML document containing one complete [orchestration] table.
+        #[arg(
+            long,
+            value_name = "FILE",
+            requires = "apply",
+            conflicts_with = "restore"
+        )]
+        intent_file: Option<String>,
         /// Restore an exact v0 backup created by `config migrate-v1 --apply`.
         #[arg(long, value_name = "BACKUP", conflicts_with = "apply")]
         restore: Option<String>,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -4644,13 +4644,7 @@ impl AiboxConfig {
     /// backend.  Backend discovery and rendering intentionally happen later.
     fn validate_orchestration(&self) -> Result<()> {
         let orchestration = &self.orchestration;
-        if !orchestration.enabled {
-            if orchestration.has_intent() {
-                bail!(
-                    "orchestration intent requires orchestration.enabled = true; \
-                     aibox never deploys from an implicit v1 configuration"
-                );
-            }
+        if !orchestration.enabled && !orchestration.has_intent() {
             return Ok(());
         }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -222,11 +222,13 @@ fn dispatch(cli: cli::Cli) -> anyhow::Result<()> {
             }
             cli::ConfigAction::MigrateV1 {
                 apply,
+                intent_file,
                 restore,
                 format,
             } => v1_release_readiness::cmd_config_migrate_v1(
                 config_path,
                 apply,
+                intent_file.as_deref(),
                 restore.as_deref(),
                 format,
             ),

--- a/cli/src/v1_release_readiness.rs
+++ b/cli/src/v1_release_readiness.rs
@@ -101,13 +101,14 @@ struct MigrationReceipt {
 pub fn cmd_config_migrate_v1(
     config_path: &Option<String>,
     apply: bool,
+    intent_file: Option<&str>,
     restore: Option<&str>,
     format: V1ReadinessOutputFormat,
 ) -> Result<()> {
     let path = config_path_for(config_path)?;
     let report = match restore {
         Some(backup) => restore_v0_config(&path, Path::new(backup))?,
-        None if apply => apply_v1_config_migration(&path)?,
+        None if apply => apply_v1_config_migration(&path, intent_file.map(Path::new))?,
         None => preview_v1_config_migration(&path)?,
     };
     print_migration_report(&report, format);
@@ -459,11 +460,18 @@ fn preview_v1_config_migration(path: &Path) -> Result<ConfigMigrationReport> {
     })
 }
 
-fn apply_v1_config_migration(path: &Path) -> Result<ConfigMigrationReport> {
+fn apply_v1_config_migration(
+    path: &Path,
+    intent_file: Option<&Path>,
+) -> Result<ConfigMigrationReport> {
     let original = read_v0_config(path)?;
     let original_digest = sha256(&original);
-    let (mapped_fields, unresolved_decisions) = migration_analysis(&original)?;
-    let Some(migrated) = migrated_config(&original)? else {
+    let (mapped_fields, mut unresolved_decisions) = migration_analysis(&original)?;
+    let intent = intent_file.map(read_migration_intent).transpose()?;
+    if intent.is_some() {
+        unresolved_decisions.clear();
+    }
+    let Some(migrated) = migrated_config_with_intent(&original, intent.as_deref())? else {
         return Ok(ConfigMigrationReport {
             operation: "apply".to_string(),
             changed: false,
@@ -508,7 +516,7 @@ fn apply_v1_config_migration(path: &Path) -> Result<ConfigMigrationReport> {
                 .to_string(),
         ),
         mapped_fields,
-        ready_to_enable: unresolved_decisions.is_empty(),
+        ready_to_enable: intent.is_some() && unresolved_decisions.is_empty(),
         unresolved_decisions,
     })
 }
@@ -664,6 +672,10 @@ fn read_v0_config(path: &Path) -> Result<Vec<u8>> {
 }
 
 fn migrated_config(original: &[u8]) -> Result<Option<Vec<u8>>> {
+    migrated_config_with_intent(original, None)
+}
+
+fn migrated_config_with_intent(original: &[u8], intent: Option<&[u8]>) -> Result<Option<Vec<u8>>> {
     if contains_orchestration(original)? {
         return Ok(None);
     }
@@ -672,9 +684,52 @@ fn migrated_config(original: &[u8]) -> Result<Option<Vec<u8>>> {
         result.push(b'\n');
     }
     result.extend_from_slice(
-        b"\n# aibox v1 migration boundary: explicit opt-in keeps v0 lifecycle behavior unchanged.\n# Fill the nested orchestration sections and set enabled = true only after reviewing the v1 guide.\n[orchestration]\nenabled = false\n",
+        b"\n# aibox v1 migration boundary: disabled until explicit activation after plan review.\n",
     );
+    match intent {
+        Some(intent) => result.extend_from_slice(intent),
+        None => result.extend_from_slice(
+            b"# Fill the nested orchestration sections and set enabled = true only after reviewing the v1 guide.\n[orchestration]\nenabled = false\n",
+        ),
+    }
     Ok(Some(result))
+}
+
+fn read_migration_intent(path: &Path) -> Result<Vec<u8>> {
+    if fs::symlink_metadata(path)?.file_type().is_symlink() || !path.is_file() {
+        bail!("refusing non-regular migration intent: {}", path.display());
+    }
+    let bytes =
+        fs::read(path).with_context(|| format!("read migration intent {}", path.display()))?;
+    let text = std::str::from_utf8(&bytes)
+        .map_err(|_| anyhow::anyhow!("migration intent must be UTF-8 TOML"))?;
+    let mut value: toml::Value =
+        toml::from_str(text).map_err(|_| anyhow::anyhow!("migration intent must be valid TOML"))?;
+    let root = value
+        .as_table_mut()
+        .context("migration intent must be a TOML document")?;
+    if root.len() != 1 || !root.contains_key("orchestration") {
+        bail!("migration intent may contain only one [orchestration] document");
+    }
+    let orchestration = root
+        .get_mut("orchestration")
+        .and_then(toml::Value::as_table_mut)
+        .context("migration intent requires an [orchestration] table")?;
+    orchestration.insert("enabled".to_string(), toml::Value::Boolean(false));
+
+    let rendered = toml::to_string(&value)?;
+    let mut validation_document = value;
+    validation_document
+        .get_mut("orchestration")
+        .and_then(toml::Value::as_table_mut)
+        .expect("validated orchestration table")
+        .insert("enabled".to_string(), toml::Value::Boolean(true));
+    let validation_toml = toml::to_string(&validation_document)?;
+    let validation = format!("[container]\nname = \"migration-validation\"\n\n{validation_toml}");
+    crate::config::AiboxConfig::from_str(&validation).map_err(|_| {
+        anyhow::anyhow!("migration intent is not a complete valid v1 orchestration configuration")
+    })?;
+    Ok(rendered.into_bytes())
 }
 
 fn contains_orchestration(bytes: &[u8]) -> Result<bool> {
@@ -958,7 +1013,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = config(&dir);
         let original = fs::read(&path).unwrap();
-        let report = apply_v1_config_migration(&path).unwrap();
+        let report = apply_v1_config_migration(&path, None).unwrap();
         let backup = PathBuf::from(report.backup_path.unwrap());
         assert_eq!(fs::read(&backup).unwrap(), original);
         assert_eq!(
@@ -981,7 +1036,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = config(&dir);
         let original = fs::read(&path).unwrap();
-        let applied = apply_v1_config_migration(&path).unwrap();
+        let applied = apply_v1_config_migration(&path, None).unwrap();
         let deployment = dir.path().join(".aibox/deployments/v1-owned.json");
         fs::create_dir_all(deployment.parent().unwrap()).unwrap();
         fs::write(&deployment, "v1 deployment receipt").unwrap();
@@ -1013,7 +1068,9 @@ mod tests {
         let path = config(&dir);
         let outside = TempDir::new().unwrap();
         symlink(outside.path(), dir.path().join(".aibox")).unwrap();
-        let error = apply_v1_config_migration(&path).unwrap_err().to_string();
+        let error = apply_v1_config_migration(&path, None)
+            .unwrap_err()
+            .to_string();
         assert!(error.contains("unsafe backup directory component"));
     }
 

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -511,6 +511,112 @@ fn v1_config_migration_preview_apply_and_restore_are_explicit_and_isolated() {
 }
 
 #[test]
+fn v1_config_migration_applies_a_reviewed_complete_intent_but_keeps_it_disabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("aibox.toml");
+    std::fs::write(&config, "[container]\nname = \"legacy\"\n").unwrap();
+    let intent = dir.path().join("v1-intent.toml");
+    std::fs::write(
+        &intent,
+        r#"[orchestration]
+enabled = true
+
+[orchestration.image]
+reference = "ghcr.io/acme/workspace"
+digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+platform = "linux-amd64"
+
+[orchestration.fleet]
+name = "legacy"
+services = [{ name = "legacy" }]
+
+[orchestration.target]
+backend = "compose"
+reference = "docker-context:default"
+scope = "legacy"
+
+[orchestration.deployment]
+name = "legacy"
+owner_id = "team-a"
+
+[[orchestration.connections]]
+name = "shell"
+service = "legacy"
+transport = "compose-exec"
+interactive = true
+"#,
+    )
+    .unwrap();
+
+    let applied = run_in_dir(
+        dir.path(),
+        &[
+            "config",
+            "migrate-v1",
+            "--apply",
+            "--intent-file",
+            "v1-intent.toml",
+            "--output",
+            "json",
+        ],
+    );
+    let report = parse_json(&applied);
+    assert_eq!(report["readyToEnable"], true);
+    assert!(report["unresolvedDecisions"].as_array().unwrap().is_empty());
+    let migrated = std::fs::read_to_string(&config).unwrap();
+    assert!(migrated.contains("[orchestration.image]"));
+    assert!(migrated.contains("enabled = false"));
+
+    let compile = run_in_dir(dir.path(), &["config", "compile", "--output", "json"]);
+    assert!(
+        !compile.status.success(),
+        "disabled intent must not compile or deploy"
+    );
+    assert!(String::from_utf8_lossy(&compile.stderr).contains("not enabled"));
+}
+
+#[test]
+fn v1_config_migration_rejects_incomplete_or_secret_bearing_intent_before_backup() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("aibox.toml");
+    let original = "[container]\nname = \"legacy\"\n";
+    std::fs::write(&config, original).unwrap();
+    std::fs::write(
+        dir.path().join("invalid-intent.toml"),
+        r#"[orchestration]
+enabled = true
+
+[orchestration.image]
+reference = "ghcr.io/acme/workspace"
+digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+platform = "linux-amd64"
+
+[orchestration.fleet]
+name = "legacy"
+services = [{ name = "legacy", environment = [{ name = "TOKEN", value = "must-not-copy" }] }]
+"#,
+    )
+    .unwrap();
+
+    let output = run_in_dir(
+        dir.path(),
+        &[
+            "config",
+            "migrate-v1",
+            "--apply",
+            "--intent-file",
+            "invalid-intent.toml",
+            "--output",
+            "json",
+        ],
+    );
+    assert!(!output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("must-not-copy"));
+    assert_eq!(std::fs::read_to_string(&config).unwrap(), original);
+    assert!(!dir.path().join(".aibox").exists());
+}
+
+#[test]
 fn stable_v1_readiness_json_is_machine_readable_while_blocked() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(

--- a/docs-site/content/docs/migrations/v0-to-v1-deployments.md
+++ b/docs-site/content/docs/migrations/v0-to-v1-deployments.md
@@ -32,6 +32,22 @@ until these operator decisions have explicit v1 values. This makes the command
 a migration planner, rather than a textual marker that implies the v0
 configuration was fully converted.
 
+Create a reviewed TOML document containing only one complete
+`[orchestration]` tree, then apply it with the migration:
+
+```sh
+aibox config migrate-v1 --apply --intent-file v1-intent.toml --output json
+```
+
+The intent file may say `enabled = true` for validation, but the migration
+always writes it as `enabled = false`. Aibox validates the complete image,
+fleet, target, deployment, connection, and credential-reference contract
+offline before it creates the backup or changes `aibox.toml`. Extra top-level
+tables, incomplete intent, symlinked files, and raw credential values are
+rejected. The result reports `readyToEnable: true`; activation remains a
+separate reviewed edit followed by `aibox config compile` and
+`aibox deploy plan`.
+
 Apply the narrow migration only after reviewing the preview:
 
 ```sh


### PR DESCRIPTION
## Outcome

Completes the actionable configuration-conversion half of the practical migration gap in #236.

- add `config migrate-v1 --apply --intent-file <file>`
- accept only a single complete `[orchestration]` document
- validate the full v1 contract offline before any backup or config mutation
- force the stored intent to `enabled = false`, even when the reviewed input says true
- reject incomplete, extra-top-level, symlinked, or secret-bearing intent before mutation
- preserve exact private backup, atomic replacement, configuration-only restore, and v1 deployment-record coexistence
- allow complete disabled intent to load while compile/deploy remain fail-closed until explicit activation

## Validation

- 1,158 unit tests
- 90 Tier-1 E2E passed; 1 ignored
- 45 integration tests
- zero-warning Clippy and formatting
- cargo audit clean
- Hugo production build: 151 pages
- pk-doctor: 0 errors, 0 warnings, 0 actionable findings

Refs #236
