### PR TITLE
feat(v1): gate stable on adoption pilots

### DIFF
--- a/cli/src/v1_release_readiness.rs
+++ b/cli/src/v1_release_readiness.rs
@@ -140,6 +140,13 @@ pub fn release_readiness(project_root: &Path) -> ReleaseReadinessReport {
     ];
     gates.extend(m5_gates(project_root));
     gates.push(m7c_gate(project_root));
+    gates.push(candidate_evidence_gate(
+        project_root,
+        "adoption-pilots",
+        "Representative v1 adoption pilots",
+        true,
+        "Run scripts/test-v1-adoption-pilots.sh against the exact candidate after M5 and M7c evidence exists.",
+    ));
     let ready = gates
         .iter()
         .all(|gate| !gate.blocking || gate.status == GateStatus::Passed);

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -643,6 +643,7 @@ fn stable_v1_readiness_json_is_machine_readable_while_blocked() {
         "m5-interruption-recovery",
         "m5-v0-coexistence-and-rollback",
         "m5-secret-safety",
+        "adoption-pilots",
     ] {
         assert!(
             gates

--- a/docs-site/content/docs/contributing/v1-adoption-pilots.md
+++ b/docs-site/content/docs/contributing/v1-adoption-pilots.md
@@ -1,0 +1,36 @@
+---
+title: "V1 adoption pilots"
+weight: 35
+---
+
+# V1 adoption pilots
+
+Stable-v1 readiness requires four repeatable journeys against the exact
+candidate and binary:
+
+1. a new Compose workspace can compile and render a deterministic plan;
+2. a representative v0 project can preview, apply, and roll back a reviewed
+   v1 intent without exposing secrets or touching v1 deployment records;
+3. an existing Kubernetes target passes the complete live M7c lifecycle;
+4. exact-pinned processkit install, verify, unchanged update, recovery, and
+   uninstall pass through the direct opaque boundary.
+
+After the live M7c and M5 producer evidence has been generated, run:
+
+```sh
+RELEASE_CANDIDATE_SHA="$(git rev-parse HEAD)" \
+AIBOX_RELEASE_BINARY_SHA256="sha256:<tested-binary-digest>" \
+  ./scripts/test-v1-adoption-pilots.sh
+```
+
+The harness refuses missing or candidate-mismatched prerequisites. It executes
+the local Compose and migration journeys, verifies the live Kubernetes and
+direct-processkit scenario sets, and writes
+`.aibox/release-evidence/v1-readiness/adoption-pilots.json`. Stable publication
+reruns this automatically and verifies the retained log digest.
+
+This automated evidence establishes repeatability, not user sentiment. Record
+configuration friction, plan comprehension, recovery steps, terminology
+confusion, and documentation gaps from external pilots in their tracking
+issues. Do not convert an unrun or unsuccessful external pilot into a passing
+release marker.

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -2151,6 +2151,9 @@ release_v1_stable_evidence_gate() {
   RELEASE_CANDIDATE_SHA="${RELEASE_CANDIDATE_SHA}" \
   AIBOX_RELEASE_BINARY_SHA256="${candidate_binary_sha256}" \
     "${PROJECT_ROOT}/scripts/test-v1-stable-readiness.sh"
+  RELEASE_CANDIDATE_SHA="${RELEASE_CANDIDATE_SHA}" \
+  AIBOX_RELEASE_BINARY_SHA256="${candidate_binary_sha256}" \
+    "${PROJECT_ROOT}/scripts/test-v1-adoption-pilots.sh"
   (cd "${PROJECT_ROOT}" && \
     RELEASE_CANDIDATE_SHA="${RELEASE_CANDIDATE_SHA}" \
     AIBOX_RELEASE_BINARY_SHA256="${candidate_binary_sha256}" \

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -18,6 +18,8 @@ declare -F release_docs_gate >/dev/null \
   || die "release documentation gate is missing"
 declare -F release_v1_stable_evidence_gate >/dev/null \
   || die "stable-v1 producer evidence gate is missing"
+[[ -x "${SCRIPT_DIR}/test-v1-adoption-pilots.sh" ]] \
+  || die "v1 adoption-pilot evidence harness is missing or not executable"
 if declare -f release_v1_alpha_evidence_gate | grep -Fq 'config release-readiness'; then
   die "v1 alpha publication must not require stable-v1 readiness"
 fi

--- a/scripts/test-v1-adoption-pilots.sh
+++ b/scripts/test-v1-adoption-pilots.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLI_MANIFEST="${PROJECT_ROOT}/cli/Cargo.toml"
+EVIDENCE_DIR="${PROJECT_ROOT}/.aibox/release-evidence/v1-readiness"
+LOG_DIR="${EVIDENCE_DIR}/logs"
+M7C_EVIDENCE="${PROJECT_ROOT}/.aibox/release-evidence/m7c-live.json"
+M5_EVIDENCE="${EVIDENCE_DIR}/m5-alpha3-exact-lifecycle.json"
+
+: "${RELEASE_CANDIDATE_SHA:?set RELEASE_CANDIDATE_SHA to the exact candidate commit}"
+: "${AIBOX_RELEASE_BINARY_SHA256:?set AIBOX_RELEASE_BINARY_SHA256 to the tested binary digest}"
+[[ "${RELEASE_CANDIDATE_SHA}" =~ ^[0-9a-f]{40}$ ]] || exit 2
+[[ "${AIBOX_RELEASE_BINARY_SHA256}" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 2
+command -v jq >/dev/null || {
+  echo "jq is required for adoption-pilot evidence" >&2
+  exit 2
+}
+
+for evidence in "${M7C_EVIDENCE}" "${M5_EVIDENCE}"; do
+  [[ -f "${evidence}" ]] || {
+    echo "missing prerequisite pilot evidence: ${evidence}" >&2
+    exit 1
+  }
+  jq -e \
+    --arg commit "${RELEASE_CANDIDATE_SHA}" \
+    --arg digest "${AIBOX_RELEASE_BINARY_SHA256}" \
+    '.candidateCommit == $commit and .binarySha256 == $digest and .status == "passed"' \
+    "${evidence}" >/dev/null || {
+      echo "pilot prerequisite is not bound to the exact candidate: ${evidence}" >&2
+      exit 1
+    }
+done
+
+mkdir -p "${LOG_DIR}"
+log_tmp="${LOG_DIR}/.adoption-pilots.log.tmp"
+log_path="${LOG_DIR}/adoption-pilots.log"
+evidence_tmp="${EVIDENCE_DIR}/.adoption-pilots.json.tmp"
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+run_pilots() {
+  echo "journey=new-compose"
+  cargo test --manifest-path "${CLI_MANIFEST}" \
+    deploy_plan_renders_compose_artifacts_without_writing_project_files -- --nocapture
+  cargo test --manifest-path "${CLI_MANIFEST}" \
+    compose_plan::tests:: -- --nocapture
+
+  echo "journey=migrated-v0"
+  cargo test --manifest-path "${CLI_MANIFEST}" \
+    v1_config_migration -- --nocapture
+
+  echo "journey=existing-kubernetes-target"
+  jq -e '
+    [.scenarios[].id] as $ids
+    | ["first-apply","unchanged-apply","changed-apply","drift-recovery",
+       "status-logs","exec-port-forward","ingress","foreign-destroy-refusal"]
+      | all(. as $required | $ids | index($required))
+  ' "${M7C_EVIDENCE}" >/dev/null
+
+  echo "journey=direct-processkit"
+  jq -e '
+    .gate == "m5-alpha3-exact-lifecycle"
+    and (.scenarios | index("signed-install"))
+    and (.scenarios | index("verify"))
+    and (.scenarios | index("no-op-update"))
+    and (.scenarios | index("uninstall"))
+  ' "${M5_EVIDENCE}" >/dev/null
+}
+
+if ! run_pilots > "${log_tmp}" 2>&1; then
+  cat "${log_tmp}" >&2
+  rm -f "${log_tmp}" "${EVIDENCE_DIR}/adoption-pilots.json"
+  exit 1
+fi
+completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cat "${log_tmp}"
+mv "${log_tmp}" "${log_path}"
+log_sha256="sha256:$(sha256sum "${log_path}" | awk '{print $1}')"
+
+jq -n \
+  --arg commit "${RELEASE_CANDIDATE_SHA}" \
+  --arg digest "${AIBOX_RELEASE_BINARY_SHA256}" \
+  --arg started "${started_at}" \
+  --arg completed "${completed_at}" \
+  --arg log_sha256 "${log_sha256}" \
+  '{
+    apiVersion: "aibox.projectious.work/release-evidence/v1alpha1",
+    kind: "ReleaseGateEvidence",
+    gate: "adoption-pilots",
+    status: "passed",
+    candidateCommit: $commit,
+    binarySha256: $digest,
+    command: "scripts/test-v1-adoption-pilots.sh",
+    startedAt: $started,
+    completedAt: $completed,
+    scenarios: [
+      "new-compose",
+      "migrated-v0",
+      "existing-kubernetes-target",
+      "direct-processkit"
+    ],
+    artifacts: [{
+      path: ".aibox/release-evidence/v1-readiness/logs/adoption-pilots.log",
+      sha256: $log_sha256
+    }]
+  }' > "${evidence_tmp}"
+mv "${evidence_tmp}" "${EVIDENCE_DIR}/adoption-pilots.json"
+echo "adoption pilot evidence written to ${EVIDENCE_DIR}/adoption-pilots.json"


### PR DESCRIPTION
## Outcome

Implements repeatable adoption-pilot evidence for #236.

- require new Compose, migrated v0, existing Kubernetes, and direct processkit journeys
- run local Compose lifecycle and migration suites
- require exact candidate-bound M7c and M5 prerequisites
- emit artifact-verified `adoption-pilots` release evidence
- run the pilot gate automatically before stable-v1 readiness
- distinguish automated repeatability evidence from external user sentiment and feedback

## Validation

- four-journey pilot harness passed against existing exact candidate evidence
- 1,161 unit tests
- 90 Tier-1 E2E passed; 1 ignored
- 45 integration tests
- formatting and zero-warning Clippy
- cargo audit clean
- Hugo production build: 153 pages
- pk-doctor: 0 errors, 0 warnings, 0 actionable findings

Refs #236
