### PR TITLE
feat(v1): gate stable operations on rehearsed evidence

### DIFF
--- a/cli/src/v1_release_readiness.rs
+++ b/cli/src/v1_release_readiness.rs
@@ -147,6 +147,27 @@ pub fn release_readiness(project_root: &Path) -> ReleaseReadinessReport {
         true,
         "Run scripts/test-v1-adoption-pilots.sh against the exact candidate after M5 and M7c evidence exists.",
     ));
+    gates.push(candidate_evidence_gate(
+        project_root,
+        "support-deprecation-retirement-policy",
+        "Support, deprecation, coexistence, and v0 retirement policy",
+        true,
+        "Run scripts/test-v1-operational-readiness.sh and retain its candidate-bound support-policy evidence.",
+    ));
+    gates.push(candidate_evidence_gate(
+        project_root,
+        "portfolio-boundary-audit",
+        "Ainfra, aibox, and processkit portfolio boundary",
+        true,
+        "Run scripts/test-v1-operational-readiness.sh and retain its candidate-bound portfolio audit.",
+    ));
+    gates.push(candidate_evidence_gate(
+        project_root,
+        "four-platform-release-rollback-rehearsal",
+        "Four-platform release and rollback rehearsal",
+        true,
+        "Run both release phases and the rollback rehearsal from the final candidate, then record the retained artifacts with scripts/record-v1-platform-rehearsal.sh.",
+    ));
     let ready = gates
         .iter()
         .all(|gate| !gate.blocking || gate.status == GateStatus::Passed);

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -644,6 +644,9 @@ fn stable_v1_readiness_json_is_machine_readable_while_blocked() {
         "m5-v0-coexistence-and-rollback",
         "m5-secret-safety",
         "adoption-pilots",
+        "support-deprecation-retirement-policy",
+        "portfolio-boundary-audit",
+        "four-platform-release-rollback-rehearsal",
     ] {
         assert!(
             gates

--- a/docs-site/content/docs/contributing/maintenance.md
+++ b/docs-site/content/docs/contributing/maintenance.md
@@ -200,6 +200,34 @@ By default, this smoke runs with `AIBOX_RELEASE_SMOKE_TIER=addons`, so `git-ui`
 It is host-side because macOS binaries and host runtime access are not
 available from the Linux devcontainer.
 
+For a final v1 release candidate, retain the two Linux archives, two macOS
+archives, their checksum sidecars, the container- and host-release logs, and an
+exact-version rollback/reinstall log under one project-relative rehearsal
+directory. Record the completed rehearsal against the exact candidate and
+tested binary:
+
+The final line of each retained log is the corresponding completion marker:
+
+```text
+release phase=container status=passed candidate=<40-character-commit>
+release phase=host status=passed candidate=<40-character-commit>
+rollback status=passed candidate=<40-character-commit> version=<version>
+```
+
+Append a marker only after its command succeeds. The recorder also opens every
+archive, verifies the expected target-named binary, validates every checksum,
+and refuses symlinked inputs.
+
+```bash
+RELEASE_CANDIDATE_SHA=<40-character-commit> \
+AIBOX_RELEASE_BINARY_SHA256=sha256:<tested-binary-digest> \
+  ./scripts/record-v1-platform-rehearsal.sh \
+    dist/v1-platform-rehearsal/1.0.0 1.0.0
+```
+
+Stable readiness remains blocked if this evidence is missing, stale, bound to a
+different candidate, or references a missing or modified artifact.
+
 The two macOS targets build concurrently. The host release also overlaps that
 build lane with source-hash-aware image reuse or publication, then joins both
 lanes before uploading binaries and starting the runtime smoke. Healthy tmux

--- a/docs-site/content/docs/reference/v1-deployment-boundaries.md
+++ b/docs-site/content/docs/reference/v1-deployment-boundaries.md
@@ -57,6 +57,13 @@ processkit alpha.3 producer tests. It writes one typed, candidate-bound
 `.aibox/release-evidence/v1-readiness/`. A record is retained only after its
 producer succeeds.
 
+Stable readiness also runs `scripts/test-v1-operational-readiness.sh` for the
+support/deprecation/retirement policy and the ainfra/aibox/processkit portfolio
+boundary. The four-platform release and rollback gate is deliberately not
+manufactured inside the Linux container: after both native release phases and
+an exact-version rollback rehearsal, retain their artifacts with
+`scripts/record-v1-platform-rehearsal.sh`.
+
 The readiness parser verifies the candidate commit, tested-binary digest, gate
 identity, and SHA-256 digest of every referenced producer log. Missing,
 candidate-mismatched, or modified logs block the release. M7c separately

--- a/docs-site/content/docs/reference/v1-support-and-retirement.md
+++ b/docs-site/content/docs/reference/v1-support-and-retirement.md
@@ -1,0 +1,66 @@
+---
+weight: 9
+title: V1 support, deprecation, and retirement
+---
+
+# V1 support, deprecation, and retirement
+
+V1 prereleases are evaluation releases. Until a stable v1 release satisfies
+every candidate-bound readiness gate, v0 remains supported as the stable line.
+V1 and v0 may coexist while projects evaluate migration; neither line may
+manage or destroy the other line's deployment records or resources.
+
+## Product boundaries
+
+- **ainfra provisions** accounts, hosts, networks, clusters, identities, DNS
+  zones, and other infrastructure, then exposes non-secret target references.
+- **aibox deploys** immutable AI workspace images onto existing Compose or
+  Kubernetes targets. It does not provision infrastructure.
+- **processkit owns** process distribution, installation, migrations, MCP,
+  skills, schemas, and harness projections. Aibox's v1 integration is disabled
+  or delegates one opaque request to the processkit CLI.
+
+These boundaries are release requirements. The portfolio audit fails if the v1
+production path begins interpreting processkit policy or provisioning
+infrastructure.
+
+## Support and deprecation
+
+- Alpha and beta users should pin the exact prerelease and retain a known-good
+  v0 installer version.
+- Corrective contract changes require compatibility review and an updated
+  contract-freeze manifest. Incompatible changes require a new API version.
+- A deprecated v0 compatibility surface must identify its replacement and
+  removal criteria. A date alone is not sufficient retirement authority.
+- Security reporting and response follow the repository `SECURITY.md`.
+
+## Rollback and coexistence
+
+Binary rollback does not delete v1 deployments. Before reinstalling v0, use the
+matching v1 CLI to inspect and, when intended, destroy v1 resources through its
+ownership-guarded lifecycle. Restoring a v0 configuration changes only the
+configuration backup boundary; it does not delete v1 deployments or receipts.
+
+Stable release rehearsal must retain checksummed archives for both Linux and
+both macOS targets, container- and host-release logs, and an exact-version
+rollback/reinstall log. `scripts/record-v1-platform-rehearsal.sh` validates and
+records those artifacts against the exact candidate.
+
+## V0 retirement criteria
+
+Retirement is evidence-based. V0 remains available until all of these are true:
+
+1. representative new, migrated, Kubernetes, and direct-processkit journeys
+   pass on candidate-bound technical evidence;
+2. external pilots have recorded migration friction, failures, recovery steps,
+   terminology problems, and documentation gaps;
+3. migration and coexistence documentation covers unresolved decisions and
+   manual v1 cleanup;
+4. supported projects have a reviewed migration outcome with no known data
+   loss or destructive ownership defect;
+5. all four native artifacts, release phases, and rollback have been rehearsed
+   from the final candidate;
+6. the ainfra/aibox/processkit portfolio-boundary audit passes.
+
+Retirement requires a reviewed decision after this evidence exists. Automated
+journeys cannot stand in for external operator feedback.

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -2154,6 +2154,9 @@ release_v1_stable_evidence_gate() {
   RELEASE_CANDIDATE_SHA="${RELEASE_CANDIDATE_SHA}" \
   AIBOX_RELEASE_BINARY_SHA256="${candidate_binary_sha256}" \
     "${PROJECT_ROOT}/scripts/test-v1-adoption-pilots.sh"
+  RELEASE_CANDIDATE_SHA="${RELEASE_CANDIDATE_SHA}" \
+  AIBOX_RELEASE_BINARY_SHA256="${candidate_binary_sha256}" \
+    "${PROJECT_ROOT}/scripts/test-v1-operational-readiness.sh"
   (cd "${PROJECT_ROOT}" && \
     RELEASE_CANDIDATE_SHA="${RELEASE_CANDIDATE_SHA}" \
     AIBOX_RELEASE_BINARY_SHA256="${candidate_binary_sha256}" \

--- a/scripts/record-v1-platform-rehearsal.sh
+++ b/scripts/record-v1-platform-rehearsal.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EVIDENCE_DIR="${PROJECT_ROOT}/.aibox/release-evidence/v1-readiness"
+REHEARSAL_ROOT="${1:-}"
+VERSION="${2:-}"
+
+: "${RELEASE_CANDIDATE_SHA:?set RELEASE_CANDIDATE_SHA to the exact candidate commit}"
+: "${AIBOX_RELEASE_BINARY_SHA256:?set AIBOX_RELEASE_BINARY_SHA256 to the tested binary digest}"
+[[ "${RELEASE_CANDIDATE_SHA}" =~ ^[0-9a-f]{40}$ ]] || exit 2
+[[ "${AIBOX_RELEASE_BINARY_SHA256}" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 2
+[[ -n "${REHEARSAL_ROOT}" && -n "${VERSION}" ]] || {
+  echo "usage: scripts/record-v1-platform-rehearsal.sh <project-relative-directory> <version>" >&2
+  exit 2
+}
+[[ "${REHEARSAL_ROOT}" != /* && "${REHEARSAL_ROOT}" != *..* ]] || {
+  echo "rehearsal directory must be a confined project-relative path" >&2
+  exit 2
+}
+[[ -d "${PROJECT_ROOT}/${REHEARSAL_ROOT}" && ! -L "${PROJECT_ROOT}/${REHEARSAL_ROOT}" ]] || {
+  echo "rehearsal directory must be a real directory inside the project" >&2
+  exit 2
+}
+[[ "${VERSION}" =~ ^1\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+  echo "platform rehearsal requires a v1 version" >&2
+  exit 2
+}
+command -v jq >/dev/null || exit 2
+
+targets=(
+  aarch64-unknown-linux-gnu
+  x86_64-unknown-linux-gnu
+  aarch64-apple-darwin
+  x86_64-apple-darwin
+)
+logs=(
+  container-release.log
+  host-release.log
+  rollback.log
+)
+artifacts=()
+
+for target in "${targets[@]}"; do
+  archive="${PROJECT_ROOT}/${REHEARSAL_ROOT}/aibox-v${VERSION}-${target}.tar.gz"
+  checksum="${archive}.sha256"
+  [[ -f "${archive}" && ! -L "${archive}" && -f "${checksum}" && ! -L "${checksum}" ]] || {
+    echo "missing ${target} archive or checksum in ${REHEARSAL_ROOT}" >&2
+    exit 1
+  }
+  expected="$(awk 'NR == 1 { print $1 }' "${checksum}")"
+  actual="$(sha256sum "${archive}" | awk '{print $1}')"
+  [[ "${expected}" =~ ^[0-9a-f]{64}$ && "${actual}" == "${expected}" ]] || {
+    echo "checksum mismatch for ${target} archive" >&2
+    exit 1
+  }
+  tar -tzf "${archive}" |
+    grep -Fqx "aibox-v${VERSION}-${target}" || {
+      echo "${target} archive does not contain its expected binary" >&2
+      exit 1
+    }
+  artifacts+=(
+    "${REHEARSAL_ROOT}/$(basename "${archive}")"
+    "${REHEARSAL_ROOT}/$(basename "${checksum}")"
+  )
+done
+
+for log in "${logs[@]}"; do
+  path="${PROJECT_ROOT}/${REHEARSAL_ROOT}/${log}"
+  [[ -s "${path}" && ! -L "${path}" ]] || {
+    echo "missing non-empty rehearsal log ${REHEARSAL_ROOT}/${log}" >&2
+    exit 1
+  }
+  artifacts+=("${REHEARSAL_ROOT}/${log}")
+done
+grep -Fqx "release phase=container status=passed candidate=${RELEASE_CANDIDATE_SHA}" \
+  "${PROJECT_ROOT}/${REHEARSAL_ROOT}/container-release.log" || {
+    echo "container release log lacks the exact-candidate completion marker" >&2
+    exit 1
+  }
+grep -Fqx "release phase=host status=passed candidate=${RELEASE_CANDIDATE_SHA}" \
+  "${PROJECT_ROOT}/${REHEARSAL_ROOT}/host-release.log" || {
+    echo "host release log lacks the exact-candidate completion marker" >&2
+    exit 1
+  }
+grep -Fqx "rollback status=passed candidate=${RELEASE_CANDIDATE_SHA} version=${VERSION}" \
+  "${PROJECT_ROOT}/${REHEARSAL_ROOT}/rollback.log" || {
+    echo "rollback log lacks the exact-candidate and exact-version completion marker" >&2
+    exit 1
+  }
+
+mkdir -p "${EVIDENCE_DIR}"
+evidence_tmp="${EVIDENCE_DIR}/.four-platform-release-rollback-rehearsal.json.tmp"
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+artifacts_json="$(
+  printf '%s\n' "${artifacts[@]}" |
+    jq -Rsc 'split("\n")[:-1] | map({path: ., sha256: ""})'
+)"
+for index in $(seq 0 $((${#artifacts[@]} - 1))); do
+  artifact_digest="sha256:$(sha256sum "${PROJECT_ROOT}/${artifacts[${index}]}" | awk '{print $1}')"
+  artifacts_json="$(jq --argjson index "${index}" --arg digest "${artifact_digest}" \
+    '.[$index].sha256 = $digest' <<< "${artifacts_json}")"
+done
+completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+jq -n \
+  --arg commit "${RELEASE_CANDIDATE_SHA}" \
+  --arg digest "${AIBOX_RELEASE_BINARY_SHA256}" \
+  --arg version "${VERSION}" \
+  --arg started "${started_at}" \
+  --arg completed "${completed_at}" \
+  --argjson artifacts "${artifacts_json}" \
+  '{
+    apiVersion: "aibox.projectious.work/release-evidence/v1alpha1",
+    kind: "ReleaseGateEvidence",
+    gate: "four-platform-release-rollback-rehearsal",
+    status: "passed",
+    candidateCommit: $commit,
+    binarySha256: $digest,
+    command: ("scripts/record-v1-platform-rehearsal.sh " + $version),
+    startedAt: $started,
+    completedAt: $completed,
+    scenarios: [
+      "linux-aarch64-artifact",
+      "linux-x86_64-artifact",
+      "macos-aarch64-artifact",
+      "macos-x86_64-artifact",
+      "checksum-verification",
+      "container-release-rehearsal",
+      "host-release-rehearsal",
+      "rollback-reinstall-rehearsal"
+    ],
+    artifacts: $artifacts
+  }' > "${evidence_tmp}"
+mv "${evidence_tmp}" "${EVIDENCE_DIR}/four-platform-release-rollback-rehearsal.json"
+echo "four-platform release and rollback rehearsal evidence recorded for ${RELEASE_CANDIDATE_SHA}"

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -20,6 +20,21 @@ declare -F release_v1_stable_evidence_gate >/dev/null \
   || die "stable-v1 producer evidence gate is missing"
 [[ -x "${SCRIPT_DIR}/test-v1-adoption-pilots.sh" ]] \
   || die "v1 adoption-pilot evidence harness is missing or not executable"
+[[ -x "${SCRIPT_DIR}/test-v1-operational-readiness.sh" ]] \
+  || die "v1 operational-readiness evidence harness is missing or not executable"
+[[ -x "${SCRIPT_DIR}/record-v1-platform-rehearsal.sh" ]] \
+  || die "v1 platform-rehearsal recorder is missing or not executable"
+grep -Fq 'tar -tzf "${archive}"' "${SCRIPT_DIR}/record-v1-platform-rehearsal.sh" \
+  || die "platform rehearsal does not inspect archive contents"
+grep -Fq 'release phase=host status=passed candidate=' \
+  "${SCRIPT_DIR}/record-v1-platform-rehearsal.sh" \
+  || die "platform rehearsal does not require exact-candidate host evidence"
+grep -Fq 'rollback status=passed candidate=' \
+  "${SCRIPT_DIR}/record-v1-platform-rehearsal.sh" \
+  || die "platform rehearsal does not require exact-candidate rollback evidence"
+declare -f release_v1_stable_evidence_gate |
+  grep -Fq 'test-v1-operational-readiness.sh' \
+  || die "stable-v1 release does not run the operational evidence producer"
 if declare -f release_v1_alpha_evidence_gate | grep -Fq 'config release-readiness'; then
   die "v1 alpha publication must not require stable-v1 readiness"
 fi

--- a/scripts/test-v1-operational-readiness.sh
+++ b/scripts/test-v1-operational-readiness.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLI_MANIFEST="${PROJECT_ROOT}/cli/Cargo.toml"
+EVIDENCE_DIR="${PROJECT_ROOT}/.aibox/release-evidence/v1-readiness"
+LOG_DIR="${EVIDENCE_DIR}/logs"
+
+: "${RELEASE_CANDIDATE_SHA:?set RELEASE_CANDIDATE_SHA to the exact candidate commit}"
+: "${AIBOX_RELEASE_BINARY_SHA256:?set AIBOX_RELEASE_BINARY_SHA256 to the tested binary digest}"
+[[ "${RELEASE_CANDIDATE_SHA}" =~ ^[0-9a-f]{40}$ ]] || exit 2
+[[ "${AIBOX_RELEASE_BINARY_SHA256}" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 2
+command -v jq >/dev/null || {
+  echo "jq is required for operational-readiness evidence" >&2
+  exit 2
+}
+
+mkdir -p "${LOG_DIR}"
+
+record_gate() {
+  local gate="$1" started_at="$2" completed_at="$3" log_path="$4"
+  shift 4
+  local relative_log="${log_path#"${PROJECT_ROOT}/"}"
+  local log_sha256="sha256:$(sha256sum "${log_path}" | awk '{print $1}')"
+  local evidence_tmp="${EVIDENCE_DIR}/.${gate}.json.tmp"
+  local scenarios_json
+  scenarios_json="$(printf '%s\n' "$@" | jq -Rsc 'split("\n")[:-1]')"
+
+  jq -n \
+    --arg gate "${gate}" \
+    --arg commit "${RELEASE_CANDIDATE_SHA}" \
+    --arg digest "${AIBOX_RELEASE_BINARY_SHA256}" \
+    --arg started "${started_at}" \
+    --arg completed "${completed_at}" \
+    --arg path "${relative_log}" \
+    --arg artifact_digest "${log_sha256}" \
+    --argjson scenarios "${scenarios_json}" \
+    '{
+      apiVersion: "aibox.projectious.work/release-evidence/v1alpha1",
+      kind: "ReleaseGateEvidence",
+      gate: $gate,
+      status: "passed",
+      candidateCommit: $commit,
+      binarySha256: $digest,
+      command: "scripts/test-v1-operational-readiness.sh",
+      startedAt: $started,
+      completedAt: $completed,
+      scenarios: $scenarios,
+      artifacts: [{path: $path, sha256: $artifact_digest}]
+    }' > "${evidence_tmp}"
+  mv "${evidence_tmp}" "${EVIDENCE_DIR}/${gate}.json"
+}
+
+run_gate() {
+  local gate="$1"
+  shift
+  local scenarios=()
+  while [[ "${1:-}" != "--" ]]; do
+    scenarios+=("$1")
+    shift
+  done
+  shift
+
+  local started_at completed_at
+  local log_tmp="${LOG_DIR}/.${gate}.log.tmp"
+  local log_path="${LOG_DIR}/${gate}.log"
+  started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if ! "$@" > "${log_tmp}" 2>&1; then
+    cat "${log_tmp}" >&2
+    rm -f "${log_tmp}" "${EVIDENCE_DIR}/${gate}.json"
+    return 1
+  fi
+  completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  cat "${log_tmp}"
+  mv "${log_tmp}" "${log_path}"
+  record_gate "${gate}" "${started_at}" "${completed_at}" "${log_path}" "${scenarios[@]}"
+}
+
+support_policy_gate() {
+  grep -Fq "v0 remains supported" \
+    "${PROJECT_ROOT}/docs-site/content/docs/reference/v1-support-and-retirement.md"
+  grep -Fq "Retirement is evidence-based" \
+    "${PROJECT_ROOT}/docs-site/content/docs/reference/v1-support-and-retirement.md"
+  grep -Fq "does not delete v1 deployments" \
+    "${PROJECT_ROOT}/docs-site/content/docs/reference/v1-support-and-retirement.md"
+  grep -Fq "v1.x-release" \
+    "${PROJECT_ROOT}/docs-site/content/docs/contributing/maintenance.md"
+  grep -Fq "evaluation release: v0 remains the supported stable line" \
+    "${PROJECT_ROOT}/release-notes/v1.0.0-alpha.1.md"
+  echo "support, deprecation, coexistence, rollback, and retirement policy checks passed"
+}
+
+portfolio_boundary_gate() {
+  cargo test --manifest-path "${CLI_MANIFEST}" \
+    processkit_protocol::tests::disabled_boundary_performs_no_discovery_or_process_invocation \
+    -- --nocapture
+  cargo test --manifest-path "${CLI_MANIFEST}" \
+    processkit_protocol::tests::direct_boundary_matches_the_opaque_protocol_outcome \
+    -- --nocapture
+  cargo test --manifest-path "${CLI_MANIFEST}" \
+    processkit_protocol::tests::v1_boundary_contains_no_legacy_distribution_or_layout_policy \
+    -- --nocapture
+  grep -Fq "Infrastructure supplied by the operator" \
+    "${PROJECT_ROOT}/docs-site/content/docs/reference/v1-deployment-boundaries.md"
+  grep -Fq "does not provision infrastructure" \
+    "${PROJECT_ROOT}/docs-site/content/docs/reference/v1-support-and-retirement.md"
+  grep -Fq "processkit owns" \
+    "${PROJECT_ROOT}/docs-site/content/docs/reference/v1-support-and-retirement.md"
+  echo "ainfra, aibox, and processkit portfolio boundaries passed"
+}
+
+run_gate \
+  support-deprecation-retirement-policy \
+  support-window \
+  deprecation-notice \
+  v0-coexistence \
+  rollback-safety \
+  evidence-based-retirement \
+  -- support_policy_gate
+
+run_gate \
+  portfolio-boundary-audit \
+  ainfra-provisions \
+  aibox-deploys \
+  processkit-owns-process-policy \
+  disabled-processkit \
+  direct-opaque-processkit \
+  -- portfolio_boundary_gate
+
+echo "stable-v1 operational evidence written to ${EVIDENCE_DIR}"


### PR DESCRIPTION
## What changed\n- add candidate-bound support/deprecation/v0-retirement and portfolio-boundary producers\n- add a four-platform release/rollback rehearsal recorder that verifies archive contents, checksums, exact-candidate phase markers, and artifact immutability\n- make all three operational gates blocking for stable v1 publication\n- document support, coexistence, retirement criteria, and the host/container rehearsal handoff\n\n## Validation\n- cargo test: 1162 unit, 90 Tier-1 E2E, 45 integration (1 intentionally ignored)\n- cargo clippy --all-targets -- -D warnings\n- cargo audit\n- scripts/test-maintain-release.sh\n- operational producers and platform-recorder synthetic artifact test\n- Hugo production build: 155 pages\n- pk-doctor: 0 ERROR / 0 WARN / 0 actionable INFO\n\nRefs #236