### PR TITLE
feat(v1): require external pilot feedback

### DIFF
--- a/cli/src/v1_release_readiness.rs
+++ b/cli/src/v1_release_readiness.rs
@@ -168,6 +168,13 @@ pub fn release_readiness(project_root: &Path) -> ReleaseReadinessReport {
         true,
         "Run both release phases and the rollback rehearsal from the final candidate, then record the retained artifacts with scripts/record-v1-platform-rehearsal.sh.",
     ));
+    gates.push(candidate_evidence_gate(
+        project_root,
+        "external-pilot-feedback",
+        "External operator adoption feedback",
+        true,
+        "Run all five documented real-project pilots and retain their structured feedback with scripts/record-v1-external-pilot-feedback.sh.",
+    ));
     let ready = gates
         .iter()
         .all(|gate| !gate.blocking || gate.status == GateStatus::Passed);

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -647,6 +647,7 @@ fn stable_v1_readiness_json_is_machine_readable_while_blocked() {
         "support-deprecation-retirement-policy",
         "portfolio-boundary-audit",
         "four-platform-release-rollback-rehearsal",
+        "external-pilot-feedback",
     ] {
         assert!(
             gates

--- a/docs-site/content/docs/reference/v1-deployment-boundaries.md
+++ b/docs-site/content/docs/reference/v1-deployment-boundaries.md
@@ -64,6 +64,11 @@ manufactured inside the Linux container: after both native release phases and
 an exact-version rollback rehearsal, retain their artifacts with
 `scripts/record-v1-platform-rehearsal.sh`.
 
+Automated adoption journeys are necessary but not sufficient. Stable readiness
+also requires all five external pilot feedback documents described in the
+[support and retirement policy](../v1-support-and-retirement/), recorded by
+`scripts/record-v1-external-pilot-feedback.sh` against the same candidate.
+
 The readiness parser verifies the candidate commit, tested-binary digest, gate
 identity, and SHA-256 digest of every referenced producer log. Missing,
 candidate-mismatched, or modified logs block the release. M7c separately

--- a/docs-site/content/docs/reference/v1-support-and-retirement.md
+++ b/docs-site/content/docs/reference/v1-support-and-retirement.md
@@ -64,3 +64,39 @@ Retirement is evidence-based. V0 remains available until all of these are true:
 
 Retirement requires a reviewed decision after this evidence exists. Automated
 journeys cannot stand in for external operator feedback.
+
+## External pilot evidence
+
+Stable readiness requires structured feedback for all five representative
+journeys: aibox self-hosting, an existing v0 migration, a clean Compose project
+without processkit, an existing Kubernetes target, and direct processkit use.
+Each `<journey>.json` uses this shape:
+
+```json
+{
+  "apiVersion": "aibox.projectious.work/pilot-feedback/v1alpha1",
+  "kind": "ExternalPilotFeedback",
+  "journey": "aibox-self-host",
+  "candidateCommit": "<40-character-commit>",
+  "status": "completed",
+  "operatorFeedback": "What the operator experienced",
+  "configurationFriction": [],
+  "recoverySteps": [],
+  "migrationDecisions": [],
+  "runtimeErrors": [],
+  "documentationGaps": [],
+  "terminologyConfusion": []
+}
+```
+
+After review, retain the five files against the exact candidate:
+
+```bash
+RELEASE_CANDIDATE_SHA=<40-character-commit> \
+AIBOX_RELEASE_BINARY_SHA256=sha256:<tested-binary-digest> \
+  ./scripts/record-v1-external-pilot-feedback.sh \
+    dist/v1-pilot-feedback/<40-character-commit>
+```
+
+Empty finding arrays are honest; empty operator feedback, missing journeys, or
+candidate-mismatched feedback block stable publication.

--- a/scripts/record-v1-external-pilot-feedback.sh
+++ b/scripts/record-v1-external-pilot-feedback.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EVIDENCE_DIR="${PROJECT_ROOT}/.aibox/release-evidence/v1-readiness"
+FEEDBACK_ROOT="${1:-}"
+
+: "${RELEASE_CANDIDATE_SHA:?set RELEASE_CANDIDATE_SHA to the exact candidate commit}"
+: "${AIBOX_RELEASE_BINARY_SHA256:?set AIBOX_RELEASE_BINARY_SHA256 to the tested binary digest}"
+[[ "${RELEASE_CANDIDATE_SHA}" =~ ^[0-9a-f]{40}$ ]] || exit 2
+[[ "${AIBOX_RELEASE_BINARY_SHA256}" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 2
+[[ -n "${FEEDBACK_ROOT}" && "${FEEDBACK_ROOT}" != /* && "${FEEDBACK_ROOT}" != *..* ]] || {
+  echo "usage: scripts/record-v1-external-pilot-feedback.sh <project-relative-directory>" >&2
+  exit 2
+}
+[[ -d "${PROJECT_ROOT}/${FEEDBACK_ROOT}" && ! -L "${PROJECT_ROOT}/${FEEDBACK_ROOT}" ]] || {
+  echo "feedback directory must be a real directory inside the project" >&2
+  exit 2
+}
+command -v jq >/dev/null || exit 2
+
+journeys=(
+  aibox-self-host
+  migrated-v0
+  new-compose-without-processkit
+  existing-kubernetes
+  direct-processkit
+)
+artifacts_json='[]'
+
+for journey in "${journeys[@]}"; do
+  relative_path="${FEEDBACK_ROOT}/${journey}.json"
+  path="${PROJECT_ROOT}/${relative_path}"
+  [[ -f "${path}" && ! -L "${path}" ]] || {
+    echo "missing external pilot feedback for ${journey}" >&2
+    exit 1
+  }
+  jq -e \
+    --arg journey "${journey}" \
+    --arg candidate "${RELEASE_CANDIDATE_SHA}" \
+    '
+      .apiVersion == "aibox.projectious.work/pilot-feedback/v1alpha1"
+      and .kind == "ExternalPilotFeedback"
+      and .journey == $journey
+      and .candidateCommit == $candidate
+      and .status == "completed"
+      and (.operatorFeedback | type == "string" and length > 0)
+      and (.configurationFriction | type == "array")
+      and (.recoverySteps | type == "array")
+      and (.migrationDecisions | type == "array")
+      and (.runtimeErrors | type == "array")
+      and (.documentationGaps | type == "array")
+      and (.terminologyConfusion | type == "array")
+    ' "${path}" >/dev/null || {
+      echo "invalid or candidate-mismatched external pilot feedback for ${journey}" >&2
+      exit 1
+    }
+  artifact_digest="sha256:$(sha256sum "${path}" | awk '{print $1}')"
+  artifacts_json="$(
+    jq \
+      --arg path "${relative_path}" \
+      --arg digest "${artifact_digest}" \
+      '. + [{path: $path, sha256: $digest}]' <<< "${artifacts_json}"
+  )"
+done
+
+mkdir -p "${EVIDENCE_DIR}"
+evidence_tmp="${EVIDENCE_DIR}/.external-pilot-feedback.json.tmp"
+recorded_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+scenarios_json="$(printf '%s\n' "${journeys[@]}" | jq -Rsc 'split("\n")[:-1]')"
+
+jq -n \
+  --arg commit "${RELEASE_CANDIDATE_SHA}" \
+  --arg digest "${AIBOX_RELEASE_BINARY_SHA256}" \
+  --arg recorded "${recorded_at}" \
+  --argjson scenarios "${scenarios_json}" \
+  --argjson artifacts "${artifacts_json}" \
+  '{
+    apiVersion: "aibox.projectious.work/release-evidence/v1alpha1",
+    kind: "ReleaseGateEvidence",
+    gate: "external-pilot-feedback",
+    status: "passed",
+    candidateCommit: $commit,
+    binarySha256: $digest,
+    command: "scripts/record-v1-external-pilot-feedback.sh",
+    startedAt: $recorded,
+    completedAt: $recorded,
+    scenarios: $scenarios,
+    artifacts: $artifacts
+  }' > "${evidence_tmp}"
+mv "${evidence_tmp}" "${EVIDENCE_DIR}/external-pilot-feedback.json"
+echo "external pilot feedback evidence recorded for ${RELEASE_CANDIDATE_SHA}"

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -24,6 +24,14 @@ declare -F release_v1_stable_evidence_gate >/dev/null \
   || die "v1 operational-readiness evidence harness is missing or not executable"
 [[ -x "${SCRIPT_DIR}/record-v1-platform-rehearsal.sh" ]] \
   || die "v1 platform-rehearsal recorder is missing or not executable"
+[[ -x "${SCRIPT_DIR}/record-v1-external-pilot-feedback.sh" ]] \
+  || die "v1 external-pilot feedback recorder is missing or not executable"
+grep -Fq 'new-compose-without-processkit' \
+  "${SCRIPT_DIR}/record-v1-external-pilot-feedback.sh" \
+  || die "external-pilot evidence does not require the processkit-disabled journey"
+grep -Fq '.operatorFeedback' \
+  "${SCRIPT_DIR}/record-v1-external-pilot-feedback.sh" \
+  || die "external-pilot evidence does not require operator feedback"
 grep -Fq 'tar -tzf "${archive}"' "${SCRIPT_DIR}/record-v1-platform-rehearsal.sh" \
   || die "platform rehearsal does not inspect archive contents"
 grep -Fq 'release phase=host status=passed candidate=' \


### PR DESCRIPTION
## What changed\n- add a stable-v1 gate for external operator feedback\n- require five candidate-bound journeys: aibox self-host, migrated v0, clean Compose without processkit, existing Kubernetes, and direct processkit\n- validate structured friction, recovery, migration, runtime, docs, terminology, and operator-feedback fields\n- retain each reviewed input by SHA-256 so missing or modified feedback fails closed\n\n## Validation\n- cargo test: 1162 unit, 90 Tier-1 E2E, 45 integration (1 intentionally ignored)\n- cargo clippy --all-targets -- -D warnings\n- structured-feedback recorder synthetic test\n- scripts/test-maintain-release.sh\n- Hugo production build: 155 pages\n- pk-doctor: 0 ERROR / 0 WARN / 0 actionable INFO\n\nRefs #236