### PR TITLE
docs(v1): add release selector and processkit tutorial

### DIFF
--- a/docs-site/assets/scss/_styles_project.scss
+++ b/docs-site/assets/scss/_styles_project.scss
@@ -46,6 +46,20 @@ pre {
   font-variant-ligatures: none;
 }
 
+.td-release-menu {
+  min-width: 13rem;
+}
+
+.td-release-menu .dropdown-header:not(:first-child) {
+  border-top: 1px solid var(--bs-border-color);
+  margin-top: 0.35rem;
+  padding-top: 0.65rem;
+}
+
+.td-release-menu__alias {
+  font-weight: 600;
+}
+
 .theme-gallery-filters {
   border: 1px solid var(--bs-border-color);
   border-radius: $border-radius-lg;

--- a/docs-site/content/docs/tutorials/_index.md
+++ b/docs-site/content/docs/tutorials/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Tutorials"
+description: "End-to-end aibox v1 project walkthroughs."
+weight: 25
+---
+
+# Tutorials
+
+These tutorials start with an empty directory and finish with a working result.
+Use them when you want the complete sequence rather than a command reference.

--- a/docs-site/content/docs/tutorials/local-project-processkit.md
+++ b/docs-site/content/docs/tutorials/local-project-processkit.md
@@ -1,0 +1,160 @@
+---
+title: "Create a local project with processkit"
+description: "Build and deploy a new project locally with aibox v1, then install the processkit process base."
+weight: 1
+---
+
+# Create a local project with processkit
+
+This tutorial starts with an empty directory, deploys a workspace through the
+v1 Compose backend, and installs the processkit v1 process base into the
+project. Both products are prereleases, so the example uses exact versions.
+
+## Before you begin
+
+Install a Docker- or Podman-compatible Compose runtime, `curl`, `tar`, and
+`sha256sum`. Then install the exact aibox v1 release shown on the
+[releases page](https://github.com/projectious-work/aibox/releases):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/projectious-work/aibox/main/scripts/install.sh |
+  VERSION=1.0.0-alpha.1 bash
+aibox --version
+```
+
+If that release is not published yet, use the latest v1 prerelease shown on the
+releases page and substitute its version below.
+
+## Scaffold the project
+
+```sh
+mkdir hello-aibox
+cd hello-aibox
+aibox init hello-aibox --context-mode harness-only --harness codex --no-container
+```
+
+`harness-only` keeps aibox's legacy processkit installer out of the project.
+The process base is installed later by the processkit v1 CLI, through its own
+native boundary.
+
+Add an application and image source:
+
+```dockerfile
+# image-source/Containerfile
+FROM docker.io/library/alpine:3.22
+CMD ["sh", "-c", "while true; do date; sleep 30; done"]
+```
+
+Create `image-source/` and save the file there. Build and push the image to a
+registry you can access:
+
+```sh
+aibox image build --push --output json
+```
+
+Before running that command, add a complete `[orchestration]` contract to
+`aibox.toml`. Replace the image reference, digest, and owner with your values:
+
+```toml
+[orchestration]
+enabled = true
+
+[orchestration.image]
+reference = "ghcr.io/YOUR-ACCOUNT/hello-aibox:dev"
+digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+platform = "linux-amd64"
+
+[orchestration.image.build]
+context = "image-source"
+dockerfile = "Containerfile"
+
+[orchestration.fleet]
+name = "hello-aibox"
+services = [{ name = "workspace" }]
+
+[orchestration.target]
+backend = "compose"
+reference = "docker-context:default"
+scope = "hello-aibox"
+
+[orchestration.deployment]
+name = "hello-aibox-local"
+owner_id = "YOUR-STABLE-OWNER-ID"
+
+[[orchestration.connections]]
+name = "shell"
+service = "workspace"
+transport = "compose-exec"
+command = ["sh"]
+```
+
+The first build uses that syntactically valid, all-zero placeholder digest.
+After the push,
+copy the returned registry manifest digest into `orchestration.image.digest`.
+The deployment never consumes a mutable tag by itself.
+
+## Plan and deploy locally
+
+```sh
+aibox config compile --output json
+aibox deploy plan --output json
+aibox deploy apply --output json
+aibox deploy status
+aibox connect shell
+```
+
+The plan is read-only. Apply creates only the Compose resources carrying this
+deployment's ownership labels and writes its local deployment record.
+
+## Install the processkit process base
+
+Download one exact processkit v1 release, verify both release assets, and run
+the native installer. The filenames and checksums are published with every
+[processkit release](https://github.com/projectious-work/processkit/releases).
+
+```sh
+PROCESSKIT_VERSION=v1.0.0-alpha.4
+PROCESSKIT_TARGET=aarch64-unknown-linux-gnu
+PROCESSKIT_DIR=.aibox/processkit-release
+mkdir -p "${PROCESSKIT_DIR}"
+
+curl -fL -o "${PROCESSKIT_DIR}/processkit.tar.gz" \
+  "https://github.com/projectious-work/processkit/releases/download/${PROCESSKIT_VERSION}/processkit-${PROCESSKIT_VERSION}.tar.gz"
+curl -fL -o "${PROCESSKIT_DIR}/processkit.tar.gz.sha256" \
+  "https://github.com/projectious-work/processkit/releases/download/${PROCESSKIT_VERSION}/processkit-${PROCESSKIT_VERSION}.tar.gz.sha256"
+curl -fL -o "${PROCESSKIT_DIR}/processkit" \
+  "https://github.com/projectious-work/processkit/releases/download/${PROCESSKIT_VERSION}/processkit-${PROCESSKIT_VERSION}-${PROCESSKIT_TARGET}"
+curl -fL -o "${PROCESSKIT_DIR}/processkit.sha256" \
+  "https://github.com/projectious-work/processkit/releases/download/${PROCESSKIT_VERSION}/processkit-${PROCESSKIT_VERSION}-${PROCESSKIT_TARGET}.sha256"
+
+(cd "${PROCESSKIT_DIR}" && sed 's/  .*/  processkit.tar.gz/' processkit.tar.gz.sha256 | sha256sum --check)
+(cd "${PROCESSKIT_DIR}" && sed 's/  .*/  processkit/' processkit.sha256 | sha256sum --check)
+chmod +x "${PROCESSKIT_DIR}/processkit"
+tar -xzf "${PROCESSKIT_DIR}/processkit.tar.gz" -C "${PROCESSKIT_DIR}"
+
+"${PROCESSKIT_DIR}/processkit" install \
+  --root . \
+  --distribution "${PROCESSKIT_DIR}/processkit-${PROCESSKIT_VERSION}" \
+  --profile managed \
+  --harness codex \
+  --yes
+"${PROCESSKIT_DIR}/processkit" verify --root . --json
+```
+
+Choose the target matching your host (`aarch64-unknown-linux-gnu` is the
+current v1 alpha target). The `managed` profile installs the shared process
+base, canonical `AGENTS.md`, and runtime policy. `verify` checks installed
+provenance and managed-path drift without changing the project.
+
+Commit `aibox.toml`, `aibox.lock`, `AGENTS.md`, and the installed `context/`
+tree. Do not commit `.aibox/processkit-release/`; it is only a download staging
+directory.
+
+## Clean up
+
+```sh
+aibox deploy destroy --output json
+```
+
+Destroy refuses resources that do not match the recorded identity and ownership
+labels.

--- a/docs-site/hugo.yaml
+++ b/docs-site/hugo.yaml
@@ -30,7 +30,19 @@ params:
   offlineSearch: true
   offlineSearchSummaryLength: 200
   offlineSearchMaxResults: 25
-  version: "v1.x"
+  version: "v1.x preview"
+  version_menu: "Releases"
+  version_menu_pagelinks: true
+  # The deployment script replaces this fallback with the shared
+  # releases.json manifest. Keeping both line aliases here makes the selector
+  # useful in local previews and when the manifest cannot be fetched.
+  versions:
+    - name: "v0.x current"
+      version: "v0.x"
+      url: "https://projectious-work.github.io/aibox/"
+    - name: "v1.x preview"
+      version: "v1.x preview"
+      url: "https://projectious-work.github.io/aibox/v1.x/"
   github_repo: "https://github.com/projectious-work/aibox"
   github_branch: "v1.x-dev"
   path_base_for_github_subdir: "docs-site/content"

--- a/docs-site/layouts/_partials/hooks/body-end.html
+++ b/docs-site/layouts/_partials/hooks/body-end.html
@@ -1,0 +1,3 @@
+{{ if .Site.Params.versions -}}
+  <script src="{{ "js/release-menu.js" | relURL }}" defer></script>
+{{ end -}}

--- a/docs-site/layouts/_partials/navbar-version-selector.html
+++ b/docs-site/layouts/_partials/navbar-version-selector.html
@@ -1,0 +1,19 @@
+{{/* Release-aware override of Docsy's flat version selector. */ -}}
+{{ $menuName := .Site.Params.version_menu | default "Releases" -}}
+<div class="td-version-menu dropdown">
+  <a class="nav-link dropdown-toggle td-version-menu__title" href="#" role="button"
+    data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <span class="td-version-menu__title-text">{{ $menuName }}</span>
+  </a>
+  <ul class="dropdown-menu td-release-menu"
+    data-release-manifest="{{ printf "%sreleases.json" .Site.Params.productionURL }}"
+    data-current-base="{{ .Site.BaseURL }}"
+    data-current-version="{{ .Site.Params.version }}">
+    {{ range .Site.Params.versions -}}
+      <li>
+        <a class="dropdown-item{{ if eq .version $.Site.Params.version }} active{{ end }}"
+          href="{{ .url }}">{{ .name | default .version }}</a>
+      </li>
+    {{ end -}}
+  </ul>
+</div>

--- a/docs-site/static/js/release-menu.js
+++ b/docs-site/static/js/release-menu.js
@@ -1,0 +1,69 @@
+(function () {
+  "use strict";
+
+  var menu = document.querySelector(".td-release-menu");
+  if (!menu) return;
+
+  function pagePath(siteBase) {
+    var root = new URL(siteBase).pathname;
+    var path = window.location.pathname;
+    if (path.indexOf(root) === 0) path = path.slice(root.length);
+    path = path.replace(/^v[01]\.x\/v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\//, "");
+    path = path.replace(/^v1\.x\//, "");
+    return path;
+  }
+
+  function item(label, url, active, muted) {
+    var li = document.createElement("li");
+    var link = document.createElement("a");
+    link.className = "dropdown-item" + (active ? " active" : "");
+    link.href = new URL(pagePath(url.siteBase), url.base).href;
+    link.textContent = label;
+    if (muted) link.classList.add("td-release-menu__alias");
+    if (active) link.setAttribute("aria-current", "page");
+    li.appendChild(link);
+    return li;
+  }
+
+  fetch(menu.dataset.releaseManifest, { credentials: "omit" })
+    .then(function (response) {
+      if (!response.ok) throw new Error("release manifest unavailable");
+      return response.json();
+    })
+    .then(function (manifest) {
+      var fragment = document.createDocumentFragment();
+      var currentBase = menu.dataset.currentBase.replace(/\/$/, "");
+
+      manifest.lines.forEach(function (line) {
+        var headingItem = document.createElement("li");
+        var heading = document.createElement("h6");
+        heading.className = "dropdown-header";
+        heading.textContent = line.line;
+        headingItem.appendChild(heading);
+        fragment.appendChild(headingItem);
+
+        var currentActive = line.current.url.replace(/\/$/, "") === currentBase;
+        fragment.appendChild(item(
+          "Current (" + line.current.version + ")",
+          { base: line.current.url, siteBase: manifest.siteBase },
+          currentActive,
+          true
+        ));
+
+        line.releases.forEach(function (release) {
+          var active = release.url.replace(/\/$/, "") === currentBase;
+          fragment.appendChild(item(
+            release.version,
+            { base: release.url, siteBase: manifest.siteBase },
+            active,
+            false
+          ));
+        });
+      });
+
+      menu.replaceChildren(fragment);
+    })
+    .catch(function () {
+      // Hugo-rendered line aliases remain available as an offline fallback.
+    });
+})();

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SITE_BASE_URL="${SITE_BASE_URL:-https://projectious-work.github.io/aibox/}"
+PAGES_BRANCH="${PAGES_BRANCH:-gh-pages}"
+LINE=""
+VERSION=""
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --line) LINE="${2:?--line requires a value}"; shift 2 ;;
+    --version) VERSION="${2:?--version requires a value}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ "${LINE}" =~ ^v[01]\.x$ ]] || {
+  echo "--line must be v0.x or v1.x" >&2
+  exit 2
+}
+[[ -z "${VERSION}" || "${VERSION}" =~ ^v[01]\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || {
+  echo "--version must be a v-prefixed v0 or v1 semver" >&2
+  exit 2
+}
+
+if [[ "${LINE}" == "v0.x" ]]; then
+  CURRENT_URL="${SITE_BASE_URL}"
+  CURRENT_PATH=""
+else
+  CURRENT_URL="${SITE_BASE_URL}${LINE}/"
+  CURRENT_PATH="${LINE}"
+fi
+
+BUILD_DIR="$(mktemp -d)"
+PAGES_DIR="$(mktemp -d)"
+cleanup() {
+  git -C "${ROOT_DIR}" worktree remove --force "${PAGES_DIR}" >/dev/null 2>&1 || true
+  rm -rf -- "${BUILD_DIR}" "${PAGES_DIR}"
+}
+trap cleanup EXIT
+
+DOCS_BASE_URL="${CURRENT_URL}" "${ROOT_DIR}/scripts/build-docs.sh" \
+  --destination "${BUILD_DIR}/current"
+if [[ -n "${VERSION}" ]]; then
+  DOCS_BASE_URL="${SITE_BASE_URL}${LINE}/${VERSION}/" \
+    "${ROOT_DIR}/scripts/build-docs.sh" --destination "${BUILD_DIR}/archive"
+fi
+
+if git -C "${ROOT_DIR}" show-ref --verify --quiet "refs/heads/${PAGES_BRANCH}"; then
+  git -C "${ROOT_DIR}" worktree add "${PAGES_DIR}" "${PAGES_BRANCH}"
+else
+  git -C "${ROOT_DIR}" fetch origin "${PAGES_BRANCH}:${PAGES_BRANCH}"
+  git -C "${ROOT_DIR}" worktree add "${PAGES_DIR}" "${PAGES_BRANCH}"
+fi
+
+TARGET="${PAGES_DIR}/${CURRENT_PATH}"
+mkdir -p "${TARGET}"
+while IFS= read -r -d '' entry; do
+  name="$(basename "${entry}")"
+  [[ "${name}" == ".git" ]] && continue
+  [[ -z "${CURRENT_PATH}" && "${name}" =~ ^v[01]\.x$ ]] && continue
+  [[ -n "${CURRENT_PATH}" && "${name}" =~ ^v[01]\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] && continue
+  rm -rf -- "${entry}"
+done < <(find "${TARGET}" -mindepth 1 -maxdepth 1 -print0)
+cp -R "${BUILD_DIR}/current/." "${TARGET}/"
+
+if [[ -n "${VERSION}" ]]; then
+  ARCHIVE="${PAGES_DIR}/${LINE}/${VERSION}"
+  mkdir -p "${ARCHIVE}"
+  find "${ARCHIVE}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+  cp -R "${BUILD_DIR}/archive/." "${ARCHIVE}/"
+fi
+
+mkdir -p "${PAGES_DIR}/v0.x" "${PAGES_DIR}/v1.x"
+
+release_array() {
+  local line="$1"
+  find "${PAGES_DIR}/${line}" -mindepth 1 -maxdepth 1 -type d \
+    -printf '%f\n' 2>/dev/null |
+    sed -n -E '/^v[01]\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$/p' |
+    sort -Vr |
+    jq -R -s --arg base "${SITE_BASE_URL}${line}/" \
+      'split("\n") | map(select(length > 0) | {version: ., url: ($base + . + "/")})'
+}
+
+v0_releases="$(release_array v0.x)"
+v1_releases="$(release_array v1.x)"
+v0_current="$(jq -r '(.lines[]? | select(.line == "v0.x") | .current.version) // empty' \
+  "${PAGES_DIR}/releases.json" 2>/dev/null || true)"
+v1_current="$(jq -r '(.lines[]? | select(.line == "v1.x") | .current.version) // empty' \
+  "${PAGES_DIR}/releases.json" 2>/dev/null || true)"
+[[ "${LINE}" == "v0.x" && -n "${VERSION}" ]] && v0_current="${VERSION}"
+[[ "${LINE}" == "v1.x" && -n "${VERSION}" ]] && v1_current="${VERSION}"
+[[ -n "${v0_current}" ]] || v0_current="v0.x"
+[[ -n "${v1_current}" ]] || v1_current="preview"
+
+jq -n \
+  --arg siteBase "${SITE_BASE_URL}" \
+  --arg v0Current "${v0_current}" \
+  --arg v1Current "${v1_current}" \
+  --argjson v0Releases "${v0_releases}" \
+  --argjson v1Releases "${v1_releases}" \
+  '{
+    schemaVersion: 1,
+    siteBase: $siteBase,
+    lines: [
+      {line: "v0.x", current: {version: $v0Current, url: $siteBase}, releases: $v0Releases},
+      {line: "v1.x", current: {version: $v1Current, url: ($siteBase + "v1.x/")}, releases: $v1Releases}
+    ]
+  }' > "${PAGES_DIR}/releases.json"
+: > "${PAGES_DIR}/.nojekyll"
+
+git -C "${PAGES_DIR}" add -A
+if git -C "${PAGES_DIR}" diff --cached --quiet; then
+  echo "No documentation changes to deploy."
+  exit 0
+fi
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  git -C "${PAGES_DIR}" diff --cached --stat
+  exit 0
+fi
+
+git -C "${PAGES_DIR}" commit -m "docs: deploy ${LINE}${VERSION:+ ${VERSION}}"
+git -C "${PAGES_DIR}" push origin "${PAGES_BRANCH}"

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -192,7 +192,8 @@ ${bold}Development:${reset}
   release-runtime-smoke <version>
                            Run host-side generated-runtime smoke and write logs
   docs-serve               Serve Hugo/Docsy locally (http://localhost:1313/aibox/)
-  docs-deploy [--dry-run]  Build Hugo/Docsy and push to gh-pages branch
+  docs-deploy --line <v0.x|v1.x> [--version vX.Y.Z] [--dry-run]
+                           Build Hugo/Docsy, retain release snapshots, and push gh-pages
   test-visual              Run screencast smoke tests (~40s)
   record-docs              Regenerate all docs screencasts + README GIF
 
@@ -1350,6 +1351,12 @@ cmd_docs_serve() {
 }
 
 cmd_docs_deploy() {
+  "${PROJECT_ROOT}/scripts/deploy-docs.sh" "$@"
+}
+
+# Retained temporarily for line-history comparison while the versioned
+# deployment path rolls out. It is not called by the command dispatcher.
+cmd_docs_deploy_legacy() {
   local dry_run=false
   # Bug (b): declare tmpdir early so the EXIT trap below never sees an unbound
   # variable under set -u if the function exits before reaching mktemp -d.
@@ -2638,7 +2645,8 @@ cmd_release() {
 
   if release_step_requested docs; then
     info "Deploying documentation..."
-    cmd_docs_deploy
+    local docs_line="v${version%%.*}.x"
+    cmd_docs_deploy --line "${docs_line}" --version "v${version}"
     ok "Documentation deployed"
   fi
 


### PR DESCRIPTION
## Outcome
- adds a navbar **Releases** selector for v0.x and v1.x
- archives every future release under its version line and publishes a shared manifest so old pages discover new releases
- wires the release command to deploy both the mutable line alias and immutable release snapshot
- adds a v1 Tutorials section with a verified local Compose deployment and processkit v1 process-base installation walkthrough

## Validation
- Hugo/Docsy build: 161 pages
- versioned deploy dry-run: passed for v1.0.0-alpha.1
- processkit v1.0.0-alpha.4 checksums, install, and verify: passed against the published producer
- scripts/test-maintain-release.sh: passed
- cargo test: 1297 passed, 1 ignored
- bash syntax and git diff checks: passed

Refs #236