### PR TITLE
fix: restore Codex processkit gateway startup

### DIFF
--- a/cli/src/mcp_registration.rs
+++ b/cli/src/mcp_registration.rs
@@ -1509,14 +1509,24 @@ fn gateway_daemon_proxy_spec(
     specs: &[McpServerSpec],
 ) -> Option<McpServerSpec> {
     let gateway = gateway_spec(specs)?;
-    let script = gateway
+    let script_index = gateway
         .args
         .iter()
-        .find(|arg| arg.ends_with(".py") && arg.contains("processkit-gateway/mcp/server.py"))
-        .cloned()
+        .position(|arg| arg.ends_with(".py") && arg.contains("processkit-gateway/mcp/server.py"));
+    let mut args = script_index
+        .map(|index| gateway.args[..=index].to_vec())
         .unwrap_or_else(|| {
-            "context/skills/processkit/processkit-gateway/mcp/server.py".to_string()
+            vec![
+                "run".to_string(),
+                "--script".to_string(),
+                "context/skills/processkit/processkit-gateway/mcp/server.py".to_string(),
+            ]
         });
+    args.extend([
+        "stdio-proxy".to_string(),
+        "--url".to_string(),
+        config.mcp.gateway.url(),
+    ]);
     let mut env = processkit_mcp_env(BTreeMap::new());
     env.insert("PROCESSKIT_MCP_MODE".to_string(), "gateway".to_string());
     if config.mcp.gateway.lazy_catalog {
@@ -1529,13 +1539,7 @@ fn gateway_daemon_proxy_spec(
     Some(McpServerSpec {
         name: "processkit-gateway".to_string(),
         command: gateway.command,
-        args: vec![
-            "run".to_string(),
-            script,
-            "stdio-proxy".to_string(),
-            "--url".to_string(),
-            config.mcp.gateway.url(),
-        ],
+        args,
         env,
     })
 }
@@ -3648,7 +3652,7 @@ args = ["server.js"]
             version,
             "processkit",
             "processkit-gateway",
-            r#"{"mcpServers":{"processkit-gateway":{"command":"uv","args":["run","context/skills/processkit/processkit-gateway/mcp/server.py"]}}}"#,
+            r#"{"mcpServers":{"processkit-gateway":{"command":"uv","args":["run","--script","context/skills/processkit/processkit-gateway/mcp/server.py"]}}}"#,
         );
         fs::write(
             tmp.path().join(".mcp.json"),
@@ -3697,6 +3701,11 @@ args = ["server.js"]
         assert!(
             args.iter().any(|arg| arg == "stdio-proxy"),
             "auto mode should use the daemon stdio proxy when processkit-gateway is installed: {}",
+            body
+        );
+        assert!(
+            args.iter().any(|arg| arg == "--script"),
+            "auto mode must preserve uv's --script flag so inline gateway dependencies are installed: {}",
             body
         );
         assert!(

--- a/cli/src/processkit_vocab.rs
+++ b/cli/src/processkit_vocab.rs
@@ -161,7 +161,7 @@ pub const TIER_SPECIFIC_MCP_SKILLS: &[&str] = &[
 /// constant serves as the canonical reference for tests and documentation.
 // Used in #[cfg(test)] blocks across multiple modules and in documentation.
 #[allow(dead_code)]
-pub const PROCESSKIT_DEFAULT_VERSION: &str = "v0.28.3";
+pub const PROCESSKIT_DEFAULT_VERSION: &str = "v0.28.5";
 
 // ---------------------------------------------------------------------------
 // v0.26.0 — RoleSlot MCP tools (team-manager skill)


### PR DESCRIPTION
## Root cause

Codex correctly discovers the generated processkit-gateway registration, but aibox auto/daemon mode rebuilt the command without preserving `uv run --script`. Fresh environments therefore skipped PEP 723 dependency installation and the server crashed before exposing tools. At the same time, processkit servers allowed incompatible MCP SDK 2.x.

## Fix

- preserve the gateway command prefix through the script path, including `--script`
- fall back to a dependency-aware `uv run --script` command
- add regression coverage for the generated daemon proxy
- pin new projects to processkit v0.28.5, which constrains the SDK to compatible 1.x

Upstream processkit fix/release: projectious-work/processkit#159 and v0.28.5.

## Verification

- focused gateway regression test passes
- full cargo test: 1054 unit + 88 E2E + 30 integration passed
- direct processkit v0.28.5 gateway startup succeeds

`cargo clippy --all-targets -- -D warnings` currently reports pre-existing Rust 1.97 `useless_borrows_in_formatting` findings outside this change.