### PR TITLE
chore: prepare v0.28.18 release

### DIFF
--- a/.github/version-line-port-baselines.toml
+++ b/.github/version-line-port-baselines.toml
@@ -1,4 +1,8 @@
-# Enforcement begins after these branch commits. Earlier history predates the
-# cross-line port contract and is intentionally grandfathered.
+# Enforcement begins after these reviewed branch commits. The v1 boundary was
+# advanced on 2026-07-30 after classifying the intervening obligations:
+# Kubernetes/deployment/readiness/evidence and project-state changes are
+# v1-only; the release-selector and docs-deployment changes have equivalent v0
+# implementations. The Codex gateway fix at this boundary is an explicit v0
+# port and retains its own port lineage.
 v0 = "ec9530fafdd3fbdc833c4c620d40740683a02028"
-v1 = "6266f1e9fd8c4bd90130203d8c46f392a1480ea4"
+v1 = "75097efb64172dfc0701dd555049d441d8255912"

--- a/addons/languages/node.yaml
+++ b/addons/languages/node.yaml
@@ -20,8 +20,8 @@ tools:
   - name: pnpm
     description: "Fast disk-efficient Node package manager"
     default_enabled: true
-    default_version: "11.17.0"
-    supported_versions: ["9", "10", "11.1.3", "11.5.2", "11.10.0", "11.17.0"]
+    default_version: "11.18.0"
+    supported_versions: ["9", "10", "11.1.3", "11.5.2", "11.10.0", "11.18.0"]
   - name: yarn
     description: "Yarn Node package manager"
     default_enabled: false

--- a/addons/languages/python.yaml
+++ b/addons/languages/python.yaml
@@ -8,7 +8,7 @@ exported_surfaces: ["language-runtime", "build-toolchain", "cli-binary"]
 builder_weight: null
 
 # As of aibox v0.16.5 (DEC-036), python3 (Debian Trixie default, 3.13.x)
-# and uv (0.11.32 from ghcr.io/astral-sh/uv) are unconditionally present
+# and uv (0.12.0 from ghcr.io/astral-sh/uv) are unconditionally present
 # in the base-debian image. This addon now provides ADDITIONAL Python
 # tooling beyond that minimum: alternative Python versions (3.12, 3.14),
 # poetry, pdm, and the recommended skills below.
@@ -27,8 +27,8 @@ tools:
   - name: uv
     description: "Fast Python package manager and virtual environment tool"
     default_enabled: true
-    default_version: "0.11.32"
-    supported_versions: ["0.7", "0.11.10", "0.11.11", "0.11.15", "0.11.19", "0.11.26", "0.11.32"]
+    default_version: "0.12.0"
+    supported_versions: ["0.7", "0.11.10", "0.11.11", "0.11.15", "0.11.19", "0.11.26", "0.12.0"]
   - name: pip
     description: "Python package installer for pip-based projects"
     default_enabled: false
@@ -67,7 +67,7 @@ runtime: |
       && rm -rf /var/lib/apt/lists/*
   {% endif %}
 
-  {% if tools.uv.version != "0.11.32" %}
+  {% if tools.uv.version != "0.12.0" %}
   COPY --from=ghcr.io/astral-sh/uv:{{ tools.uv.version }} /uv /usr/local/bin/uv
   COPY --from=ghcr.io/astral-sh/uv:{{ tools.uv.version }} /uvx /usr/local/bin/uvx
   {% endif %}

--- a/aibox.toml
+++ b/aibox.toml
@@ -326,14 +326,14 @@ hugo = { enabled = true } # Fast Go-based static site generator; default off; op
 # Languages/node — Node.js runtime with pnpm, yarn, or bun
 [addons.node.tools]
 node = { version = "26" } # Node.js JavaScript and TypeScript runtime; default on; options: {}, { enabled = true|false }, { version = "20" | "22" | "24" | "26" (default) or "latest" }
-pnpm = { version = "11.17.0" } # Fast disk-efficient Node package manager; default on; options: {}, { enabled = true|false }, { version = "9" | "10" | "11.1.3" | "11.5.2" | "11.10.0" | "11.17.0" (default) or "latest" }
+pnpm = { version = "11.18.0" } # Fast disk-efficient Node package manager; default on; options: {}, { enabled = true|false }, { version = "9" | "10" | "11.1.3" | "11.5.2" | "11.10.0" | "11.18.0" (default) or "latest" }
 # yarn = { enabled = true } # Yarn Node package manager; default off; options: {}, { enabled = true|false }, { version = "4" | "4.16.0" | "4.17.0" (default) or "latest" }
 # bun = { enabled = true } # Bun JavaScript runtime, package manager, and test runner; default off; options: {}, { enabled = true|false }, { version = "1.2" | "1.3.14" (default) or "latest" }
 
 # Languages/python — Python runtime with uv, poetry, or pdm
 [addons.python.tools]
 python = { version = "3.14" } # Python interpreter runtime for applications and scripts; default on; options: {}, { enabled = true|false }, { version = "3.12" | "3.13" | "3.14" (default) or "latest" }
-uv = { version = "0.11.32" } # Fast Python package manager and virtual environment tool; default on; options: {}, { enabled = true|false }, { version = "0.7" | "0.11.10" | "0.11.11" | "0.11.15" | "0.11.19" | "0.11.26" | "0.11.32" (default) or "latest" }
+uv = { version = "0.12.0" } # Fast Python package manager and virtual environment tool; default on; options: {}, { enabled = true|false }, { version = "0.7" | "0.11.10" | "0.11.11" | "0.11.15" | "0.11.19" | "0.11.26" | "0.12.0" (default) or "latest" }
 # pip = { enabled = true } # Python package installer for pip-based projects; default off; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
 # poetry = { enabled = true } # Python dependency and packaging workflow manager; default off; options: {}, { enabled = true|false }, { version = "1.8" | "2.0" | "2.4.1" (default) or "latest" }
 # pdm = { enabled = true } # Python project and dependency manager using PEP standards; default off; options: {}, { enabled = true|false }, { version = "2.22" | "2.26.9" | "2.27.0" | "2.28.0" (default) or "latest" }

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.28.17"
+version = "0.28.18"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -458,9 +458,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -1125,9 +1125,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.28.17"
+version = "0.28.18"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/cli/src/addon_cmd.rs
+++ b/cli/src/addon_cmd.rs
@@ -461,7 +461,7 @@ name = "test"
 
 [addons.python.tools]
 python = { version = "3.14" }
-	uv = { version = "0.11.32" }
+	uv = { version = "0.12.0" }
 "#,
         )
         .unwrap();

--- a/cli/src/addon_registry.rs
+++ b/cli/src/addon_registry.rs
@@ -190,8 +190,8 @@ mod tests {
         assert!(py.supported_versions.contains(&"3.14"));
         assert_eq!(py.default_version, "3.14");
         let uv = addon.tools.iter().find(|t| t.name == "uv").unwrap();
-        assert!(uv.supported_versions.contains(&"0.11.32"));
-        assert_eq!(uv.default_version, "0.11.32");
+        assert!(uv.supported_versions.contains(&"0.12.0"));
+        assert_eq!(uv.default_version, "0.12.0");
     }
 
     #[test]
@@ -252,7 +252,7 @@ mod tests {
     #[test]
     fn python_runtime_uses_base_python_uv_without_extra_layers() {
         ensure_loaded();
-        let tools = tc(&[("python", true, "3.13"), ("uv", true, "0.11.32")]);
+        let tools = tc(&[("python", true, "3.13"), ("uv", true, "0.12.0")]);
         let cmds = generate_runtime_commands("python", &tools);
         assert!(
             !cmds.contains("python3-pip"),
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn python_runtime_installs_alternate_python_with_uv() {
         ensure_loaded();
-        let tools = tc(&[("python", true, "3.14"), ("uv", true, "0.11.32")]);
+        let tools = tc(&[("python", true, "3.14"), ("uv", true, "0.12.0")]);
         let cmds = generate_runtime_commands("python", &tools);
         assert!(
             cmds.contains("uv python install 3.14"),

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -628,6 +628,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.4",
         note: "Patch release: repairs Go, Typst, AWS CLI, and Node.js add-on installers and adds a clean companion-container build gate for download-based add-on defaults.",
     },
+    CompatEntry {
+        aibox_version: "0.28.18",
+        processkit_version: "v0.28.5",
+        note: "Patch release: restores Codex processkit MCP startup by preserving uv run --script in gateway daemon-proxy commands, integrates processkit v0.28.5's MCP 1.x compatibility bound, and restores zero-warning clippy under Rust 1.97.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1099,7 +1099,7 @@ pub struct AddonToolsSection {
 /// ```toml
 /// [addons.python.tools]
 /// python = { version = "3.14" }
-/// uv = { version = "0.11.32" }
+/// uv = { version = "0.12.0" }
 /// ```
 ///
 /// Deserialized as `HashMap<String, AddonToolsSection>` where the outer key
@@ -5410,7 +5410,7 @@ uv = { version = "0.7" }
 
 [addons.node.tools]
 node = { version = "26" }
-pnpm = { version = "11.17.0" }
+pnpm = { version = "11.18.0" }
 
 [addons.rust.tools]
 rustc = { version = "1.97.1" }
@@ -6504,7 +6504,7 @@ harnesses = []
         assert!(config.addons.has_tool("python", "uv"));
         assert!(!config.addons.has_tool("python", "poetry"));
         assert_eq!(config.addons.tool_version("node", "node"), Some("26"));
-        assert_eq!(config.addons.tool_version("node", "pnpm"), Some("11.17.0"));
+        assert_eq!(config.addons.tool_version("node", "pnpm"), Some("11.18.0"));
         assert_eq!(config.addons.tool_version("cloud-aws", "aws-cli"), None);
     }
 

--- a/docs-site/content/docs/addons/language-runtimes.md
+++ b/docs-site/content/docs/addons/language-runtimes.md
@@ -12,7 +12,7 @@ Language runtimes install compilers, interpreters, and package managers into you
 ```toml
 [addons.python.tools]
 python = { version = "3.14" }   # 3.12, 3.13, 3.14
-uv = { version = "0.11.32" }    # 0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26, 0.11.32
+uv = { version = "0.12.0" }    # 0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26, 0.12.0
 # poetry = { version = "2.4.1" } # Optional: 1.8, 2.0, 2.4.1
 # pdm = { version = "2.28.0" }   # Optional: 2.22, 2.26.9, 2.27.0, 2.28.0
 ```
@@ -35,7 +35,7 @@ Installs the Rust toolchain via rustup with clippy and rustfmt. Uses a multi-sta
 ```toml
 [addons.node.tools]
 node = { version = "26" }       # 20, 22, 24, 26
-pnpm = { version = "11.17.0" }  # 9, 10, 11.1.3, 11.5.2, 11.10.0, 11.17.0
+pnpm = { version = "11.18.0" }  # 9, 10, 11.1.3, 11.5.2, 11.10.0, 11.18.0
 # yarn = { version = "4.17.0" } # Optional: 4, 4.16.0, 4.17.0
 # bun = { version = "1.3.14" }  # Optional
 ```

--- a/docs-site/content/docs/addons/overview.md
+++ b/docs-site/content/docs/addons/overview.md
@@ -33,7 +33,7 @@ aibox describe addon-catalog -o json
 ```toml
 [addons.python.tools]
 python = { version = "3.14" }
-uv = { version = "0.11.32" }
+uv = { version = "0.12.0" }
 
 [addons.rust.tools]
 rustc = { version = "1.97.1" }
@@ -42,7 +42,7 @@ rustfmt = {}
 
 [addons.node.tools]
 node = { version = "26" }
-pnpm = { version = "11.17.0" }
+pnpm = { version = "11.18.0" }
 ```
 
 Each addon has **default-enabled tools** that are included automatically, and **optional tools** you can enable explicitly. Tools with version selection let you pick from curated, tested versions.
@@ -61,9 +61,9 @@ After editing `aibox.toml`, run `aibox apply` to regenerate the Dockerfile and r
 
 | Addon | Default Tools | Optional Tools |
 |-------|--------------|----------------|
-| `python` | python (3.12/3.13/3.14), uv (0.7/0.11.10/0.11.11/0.11.15/0.11.19/0.11.26/0.11.32) | poetry (1.8/2.0/2.4.1), pdm (2.22/2.26.9/2.27.0/2.28.0) |
+| `python` | python (3.12/3.13/3.14), uv (0.7/0.11.10/0.11.11/0.11.15/0.11.19/0.11.26/0.12.0) | poetry (1.8/2.0/2.4.1), pdm (2.22/2.26.9/2.27.0/2.28.0) |
 | `rust` | rustc (1.90/1.91/1.92/1.93/1.94/1.94.1/1.96.0/1.96.1/1.97.1), clippy, rustfmt | — |
-| `node` | node (20/22/24/26), pnpm (9/10/11.1.3/11.5.2/11.10.0/11.17.0) | yarn (4/4.16.0/4.17.0), bun (1.2/1.3.14) |
+| `node` | node (20/22/24/26), pnpm (9/10/11.1.3/11.5.2/11.10.0/11.18.0) | yarn (4/4.16.0/4.17.0), bun (1.2/1.3.14) |
 | `go` | go (1.25/1.26/1.26.3/1.26.4/1.26.5) | — |
 | `typst` | typst (0.13.1/0.14.2/0.15.0) | — |
 | `latex` | texlive-core, texlive-recommended, texlive-fonts, biber, texlive-code, texlive-diagrams, texlive-math | texlive-music, texlive-chemistry |
@@ -174,7 +174,7 @@ Recipe version: 1.0.0
 
   TOOL      DEFAULT    VERSION  SUPPORTED
   python        yes       3.14  3.12, 3.13, 3.14
-  uv            yes    0.11.32  0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26, 0.11.32
+  uv            yes    0.12.0  0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26, 0.12.0
   poetry         no      2.4.1  1.8, 2.0, 2.4.1
   pdm            no     2.28.0  2.22, 2.26.9, 2.27.0, 2.28.0
 ```

--- a/docs-site/content/docs/getting-started/new-project.md
+++ b/docs-site/content/docs/getting-started/new-project.md
@@ -155,7 +155,7 @@ schema_version = "1.0.0"
 # Run `aibox get addon` to see all available addons.
 # [addons.python.tools]
 # python = { version = "3.14" }
-# uv     = { version = "0.11.32" }
+# uv     = { version = "0.12.0" }
 
 # AI harnesses — controls which AI CLIs/configs are enabled.
 [ai]

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.28.18 | v0.28.5 | restores Codex processkit MCP startup by preserving `uv run --script` in gateway daemon-proxy commands, integrates processkit's MCP 1.x compatibility bound, and restores zero-warning clippy under Rust 1.97 |
 | 0.28.17 | v0.28.4 | repairs Go, Typst, AWS CLI, and Node.js add-on installers and adds a clean companion-container build gate for download-based add-on defaults |
 | 0.28.16 | v0.28.4 | installs Node.js from checksum-verified official release archives after the NodeSource signing-key endpoint became unavailable and refreshes generated runtime and processkit package-selection state |
 | 0.28.14 | v0.28.4 | ensures `pk-reconcile` and `pk-repo-reconcile` install their `project-reconciliation` and `repo-management` skill dependencies |

--- a/docs-site/content/docs/reference/configuration.md
+++ b/docs-site/content/docs/reference/configuration.md
@@ -65,7 +65,7 @@ schema_version = "1.0.0"              # Context schema version (semver)
 
 [addons.python.tools]                 # Addon: Python runtime
 python = { version = "3.14" }
-uv     = { version = "0.11.32" }
+uv     = { version = "0.12.0" }
 
 [addons.rust.tools]                   # Addon: Rust toolchain
 rustc   = { version = "1.97.1" }
@@ -446,7 +446,7 @@ to install their CLIs.
 ```toml
 [addons.python.tools]
 python = { version = "3.14" }
-uv = { version = "0.11.32" }
+uv = { version = "0.12.0" }
 ```
 
 For interactive Git tooling:

--- a/images/base-debian/Dockerfile
+++ b/images/base-debian/Dockerfile
@@ -278,7 +278,7 @@ COPY --from=build-aibox-runtime-tools /build/aibox-runtime-tools/bin/aibox-diagn
 # image since v0.16.5 (DEC-036) so processkit's PEP 723 MCP server
 # scripts run via `uv run` out of the box. Works against the
 # externally-installed python3 from apt above.
-COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.12.0 /uv /uvx /usr/local/bin/
 ENV UV_CACHE_DIR=/tmp/aibox/uv-cache
 
 ARG AIBOX_IMAGE_SOURCE_SHA=unknown

--- a/scripts/record-asciinema.sh
+++ b/scripts/record-asciinema.sh
@@ -335,7 +335,7 @@ for c in a i b o x ' ' i n i t ' ' m y - p r o j e c t ' ' - - y e s ' ' - - b a
   sleep 0.06
 done
 echo
-printf 'y\n' | aibox init my-project --yes --base debian --profile human-dev --user aibox --theme gruvbox --prompt default --tmux-status extended --addon python --addon-tool python:python=3.14 --addon-tool python:uv=0.11.32 --harness claude --processkit-version v0.26.15 --no-container 2>&1 || true
+printf 'y\n' | aibox init my-project --yes --base debian --profile human-dev --user aibox --theme gruvbox --prompt default --tmux-status extended --addon python --addon-tool python:python=3.14 --addon-tool python:uv=0.12.0 --harness claude --processkit-version v0.26.15 --no-container 2>&1 || true
 
 sleep 1
 echo -ne '\033[32m❯\033[0m '


### PR DESCRIPTION
## Summary

- classify reviewed v1-to-v0 port obligations
- refresh actionable release dependencies
- add the v0.28.18 compatibility entry
- bump the CLI to v0.28.18

## Validation

- version-line port gate clear
- cargo fmt, clippy, tests, and audit pass
- Tier 2 companion E2E: 39 passed, 0 failed, 6 intentionally ignored
- Linux release artifacts built for x86_64 and aarch64

Refs #236