### PR TITLE
chore(v1): promote final Alpha.1 candidate

### DIFF
--- a/.github/version-line-port-baselines.toml
+++ b/.github/version-line-port-baselines.toml
@@ -1,4 +1,9 @@
 # Enforcement begins after these branch commits. Earlier history predates the
 # cross-line port contract and is intentionally grandfathered.
-v0 = "ec9530fafdd3fbdc833c4c620d40740683a02028"
+# Reviewed through v0.28.18:
+# - the Codex MCP gateway startup correction is implemented on v1 by PR #279;
+# - the Hugo/Docsy and release-selector changes have equivalent v1 implementations;
+# - v0 compatibility metadata and generated-runtime refreshes are line-specific;
+# - the Rust 1.97 cleanup is already satisfied by the zero-warning v1 Clippy gate.
+v0 = "da6e4c788d041dd62b64499d7ddb325b0f3de7b7"
 v1 = "6266f1e9fd8c4bd90130203d8c46f392a1480ea4"

--- a/addons/docs/docs-zensical.yaml
+++ b/addons/docs/docs-zensical.yaml
@@ -17,8 +17,8 @@ tools:
   - name: zensical
     description: "Python documentation site generator"
     default_enabled: true
-    default_version: "0.0.51"
-    supported_versions: ["0.0.43", "0.0.44", "0.0.47", "0.0.51"]
+    default_version: "0.0.52"
+    supported_versions: ["0.0.43", "0.0.44", "0.0.47", "0.0.51", "0.0.52"]
 
 builder: null
 

--- a/addons/languages/node.yaml
+++ b/addons/languages/node.yaml
@@ -20,8 +20,8 @@ tools:
   - name: pnpm
     description: "Fast disk-efficient Node package manager"
     default_enabled: true
-    default_version: "11.17.0"
-    supported_versions: ["9", "10", "11.1.3", "11.5.2", "11.10.0", "11.17.0"]
+    default_version: "11.18.0"
+    supported_versions: ["9", "10", "11.1.3", "11.5.2", "11.10.0", "11.17.0", "11.18.0"]
   - name: yarn
     description: "Yarn Node package manager"
     default_enabled: false

--- a/addons/languages/python.yaml
+++ b/addons/languages/python.yaml
@@ -8,7 +8,7 @@ exported_surfaces: ["language-runtime", "build-toolchain", "cli-binary"]
 builder_weight: null
 
 # As of aibox v0.16.5 (DEC-036), python3 (Debian Trixie default, 3.13.x)
-# and uv (0.11.32 from ghcr.io/astral-sh/uv) are unconditionally present
+# and uv (0.12.0 from ghcr.io/astral-sh/uv) are unconditionally present
 # in the base-debian image. This addon now provides ADDITIONAL Python
 # tooling beyond that minimum: alternative Python versions (3.12, 3.14),
 # poetry, pdm, and the recommended skills below.
@@ -27,8 +27,8 @@ tools:
   - name: uv
     description: "Fast Python package manager and virtual environment tool"
     default_enabled: true
-    default_version: "0.11.32"
-    supported_versions: ["0.7", "0.11.10", "0.11.11", "0.11.15", "0.11.19", "0.11.26", "0.11.32"]
+    default_version: "0.12.0"
+    supported_versions: ["0.7", "0.11.10", "0.11.11", "0.11.15", "0.11.19", "0.11.26", "0.11.32", "0.12.0"]
   - name: pip
     description: "Python package installer for pip-based projects"
     default_enabled: false
@@ -67,7 +67,7 @@ runtime: |
       && rm -rf /var/lib/apt/lists/*
   {% endif %}
 
-  {% if tools.uv.version != "0.11.32" %}
+  {% if tools.uv.version != "0.12.0" %}
   COPY --from=ghcr.io/astral-sh/uv:{{ tools.uv.version }} /uv /usr/local/bin/uv
   COPY --from=ghcr.io/astral-sh/uv:{{ tools.uv.version }} /uvx /usr/local/bin/uvx
   {% endif %}

--- a/aibox.toml
+++ b/aibox.toml
@@ -301,7 +301,7 @@ docusaurus = { version = "3.10.1" } # React and MDX documentation site generator
 
 # Documentation/docs-zensical — Zensical – Python docs site; requires python
 # [addons.docs-zensical.tools]
-# zensical = {} # Python documentation site generator; default on; options: {}, { enabled = true|false }, { version = "0.0.43" | "0.0.44" | "0.0.47" | "0.0.51" (default) or "latest" }
+# zensical = {} # Python documentation site generator; default on; options: {}, { enabled = true|false }, { version = "0.0.43" | "0.0.44" | "0.0.47" | "0.0.51" | "0.0.52" (default) or "latest" }
 
 # ---- Languages ------------------------------------------------------------
 
@@ -326,14 +326,14 @@ docusaurus = { version = "3.10.1" } # React and MDX documentation site generator
 # Languages/node — Node.js runtime with pnpm, yarn, or bun
 [addons.node.tools]
 node = { version = "26" } # Node.js JavaScript and TypeScript runtime; default on; options: {}, { enabled = true|false }, { version = "20" | "22" | "24" | "26" (default) or "latest" }
-pnpm = { version = "11.17.0" } # Fast disk-efficient Node package manager; default on; options: {}, { enabled = true|false }, { version = "9" | "10" | "11.1.3" | "11.5.2" | "11.10.0" | "11.17.0" (default) or "latest" }
+pnpm = { version = "11.18.0" } # Fast disk-efficient Node package manager; default on; options: {}, { enabled = true|false }, { version = "9" | "10" | "11.1.3" | "11.5.2" | "11.10.0" | "11.17.0" | "11.18.0" (default) or "latest" }
 # yarn = { enabled = true } # Yarn Node package manager; default off; options: {}, { enabled = true|false }, { version = "4" | "4.16.0" | "4.17.0" (default) or "latest" }
 # bun = { enabled = true } # Bun JavaScript runtime, package manager, and test runner; default off; options: {}, { enabled = true|false }, { version = "1.2" | "1.3.14" (default) or "latest" }
 
 # Languages/python — Python runtime with uv, poetry, or pdm
 [addons.python.tools]
 python = { version = "3.14" } # Python interpreter runtime for applications and scripts; default on; options: {}, { enabled = true|false }, { version = "3.12" | "3.13" | "3.14" (default) or "latest" }
-uv = { version = "0.11.32" } # Fast Python package manager and virtual environment tool; default on; options: {}, { enabled = true|false }, { version = "0.7" | "0.11.10" | "0.11.11" | "0.11.15" | "0.11.19" | "0.11.26" | "0.11.32" (default) or "latest" }
+uv = { version = "0.12.0" } # Fast Python package manager and virtual environment tool; default on; options: {}, { enabled = true|false }, { version = "0.7" | "0.11.10" | "0.11.11" | "0.11.15" | "0.11.19" | "0.11.26" | "0.11.32" | "0.12.0" (default) or "latest" }
 # pip = { enabled = true } # Python package installer for pip-based projects; default off; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
 # poetry = { enabled = true } # Python dependency and packaging workflow manager; default off; options: {}, { enabled = true|false }, { version = "1.8" | "2.0" | "2.4.1" (default) or "latest" }
 # pdm = { enabled = true } # Python project and dependency manager using PEP standards; default off; options: {}, { enabled = true|false }, { version = "2.22" | "2.26.9" | "2.27.0" | "2.28.0" (default) or "latest" }

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -458,9 +458,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -474,9 +474,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -1125,9 +1125,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/cli/src/addon_cmd.rs
+++ b/cli/src/addon_cmd.rs
@@ -461,7 +461,7 @@ name = "test"
 
 [addons.python.tools]
 python = { version = "3.14" }
-	uv = { version = "0.11.32" }
+	uv = { version = "0.12.0" }
 "#,
         )
         .unwrap();

--- a/cli/src/addon_registry.rs
+++ b/cli/src/addon_registry.rs
@@ -190,8 +190,8 @@ mod tests {
         assert!(py.supported_versions.contains(&"3.14"));
         assert_eq!(py.default_version, "3.14");
         let uv = addon.tools.iter().find(|t| t.name == "uv").unwrap();
-        assert!(uv.supported_versions.contains(&"0.11.32"));
-        assert_eq!(uv.default_version, "0.11.32");
+        assert!(uv.supported_versions.contains(&"0.12.0"));
+        assert_eq!(uv.default_version, "0.12.0");
     }
 
     #[test]
@@ -252,7 +252,7 @@ mod tests {
     #[test]
     fn python_runtime_uses_base_python_uv_without_extra_layers() {
         ensure_loaded();
-        let tools = tc(&[("python", true, "3.13"), ("uv", true, "0.11.32")]);
+        let tools = tc(&[("python", true, "3.13"), ("uv", true, "0.12.0")]);
         let cmds = generate_runtime_commands("python", &tools);
         assert!(
             !cmds.contains("python3-pip"),
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn python_runtime_installs_alternate_python_with_uv() {
         ensure_loaded();
-        let tools = tc(&[("python", true, "3.14"), ("uv", true, "0.11.32")]);
+        let tools = tc(&[("python", true, "3.14"), ("uv", true, "0.12.0")]);
         let cmds = generate_runtime_commands("python", &tools);
         assert!(
             cmds.contains("uv python install 3.14"),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1099,7 +1099,7 @@ pub struct AddonToolsSection {
 /// ```toml
 /// [addons.python.tools]
 /// python = { version = "3.14" }
-/// uv = { version = "0.11.32" }
+/// uv = { version = "0.12.0" }
 /// ```
 ///
 /// Deserialized as `HashMap<String, AddonToolsSection>` where the outer key
@@ -6125,7 +6125,7 @@ uv = { version = "0.7" }
 
 [addons.node.tools]
 node = { version = "26" }
-pnpm = { version = "11.17.0" }
+pnpm = { version = "11.18.0" }
 
 [addons.rust.tools]
 rustc = { version = "1.97.1" }
@@ -7219,7 +7219,7 @@ harnesses = []
         assert!(config.addons.has_tool("python", "uv"));
         assert!(!config.addons.has_tool("python", "poetry"));
         assert_eq!(config.addons.tool_version("node", "node"), Some("26"));
-        assert_eq!(config.addons.tool_version("node", "pnpm"), Some("11.17.0"));
+        assert_eq!(config.addons.tool_version("node", "pnpm"), Some("11.18.0"));
         assert_eq!(config.addons.tool_version("cloud-aws", "aws-cli"), None);
     }
 

--- a/cli/src/mcp_registration.rs
+++ b/cli/src/mcp_registration.rs
@@ -1509,14 +1509,24 @@ fn gateway_daemon_proxy_spec(
     specs: &[McpServerSpec],
 ) -> Option<McpServerSpec> {
     let gateway = gateway_spec(specs)?;
-    let script = gateway
+    let script_index = gateway
         .args
         .iter()
-        .find(|arg| arg.ends_with(".py") && arg.contains("processkit-gateway/mcp/server.py"))
-        .cloned()
+        .position(|arg| arg.ends_with(".py") && arg.contains("processkit-gateway/mcp/server.py"));
+    let mut args = script_index
+        .map(|index| gateway.args[..=index].to_vec())
         .unwrap_or_else(|| {
-            "context/skills/processkit/processkit-gateway/mcp/server.py".to_string()
+            vec![
+                "run".to_string(),
+                "--script".to_string(),
+                "context/skills/processkit/processkit-gateway/mcp/server.py".to_string(),
+            ]
         });
+    args.extend([
+        "stdio-proxy".to_string(),
+        "--url".to_string(),
+        config.mcp.gateway.url(),
+    ]);
     let mut env = processkit_mcp_env(BTreeMap::new());
     env.insert("PROCESSKIT_MCP_MODE".to_string(), "gateway".to_string());
     if config.mcp.gateway.lazy_catalog {
@@ -1529,13 +1539,7 @@ fn gateway_daemon_proxy_spec(
     Some(McpServerSpec {
         name: "processkit-gateway".to_string(),
         command: gateway.command,
-        args: vec![
-            "run".to_string(),
-            script,
-            "stdio-proxy".to_string(),
-            "--url".to_string(),
-            config.mcp.gateway.url(),
-        ],
+        args,
         env,
     })
 }
@@ -3648,7 +3652,7 @@ args = ["server.js"]
             version,
             "processkit",
             "processkit-gateway",
-            r#"{"mcpServers":{"processkit-gateway":{"command":"uv","args":["run","context/skills/processkit/processkit-gateway/mcp/server.py"]}}}"#,
+            r#"{"mcpServers":{"processkit-gateway":{"command":"uv","args":["run","--script","context/skills/processkit/processkit-gateway/mcp/server.py"]}}}"#,
         );
         fs::write(
             tmp.path().join(".mcp.json"),
@@ -3697,6 +3701,11 @@ args = ["server.js"]
         assert!(
             args.iter().any(|arg| arg == "stdio-proxy"),
             "auto mode should use the daemon stdio proxy when processkit-gateway is installed: {}",
+            body
+        );
+        assert!(
+            args.iter().any(|arg| arg == "--script"),
+            "auto mode must preserve uv's --script flag so inline gateway dependencies are installed: {}",
             body
         );
         assert!(

--- a/cli/src/processkit_vocab.rs
+++ b/cli/src/processkit_vocab.rs
@@ -175,7 +175,7 @@ pub const TIER_SPECIFIC_MCP_SKILLS: &[&str] = &[
 /// constant serves as the canonical reference for tests and documentation.
 // Used in #[cfg(test)] blocks across multiple modules and in documentation.
 #[allow(dead_code)]
-pub const PROCESSKIT_DEFAULT_VERSION: &str = "v0.28.4";
+pub const PROCESSKIT_DEFAULT_VERSION: &str = "v0.28.5";
 
 // ---------------------------------------------------------------------------
 // v0.26.0 — RoleSlot MCP tools (team-manager skill)

--- a/docs-site/content/docs/addons/documentation.md
+++ b/docs-site/content/docs/addons/documentation.md
@@ -17,7 +17,7 @@ Documentation addons install static site generators and documentation tools.
 | `docs-hugo` | Hugo Extended | Binary download |
 
 Current curated pins are Docusaurus 3.10.1, Hugo 0.164.0, mdBook 0.5.4,
-MkDocs 1.6.1 with Material 9.7.7, and Zensical 0.0.51. Starlight remains
+MkDocs 1.6.1 with Material 9.7.7, and Zensical 0.0.52. Starlight remains
 scaffolded through the upstream `create-starlight` package.
 
 ## Example

--- a/docs-site/content/docs/addons/language-runtimes.md
+++ b/docs-site/content/docs/addons/language-runtimes.md
@@ -12,7 +12,7 @@ Language runtimes install compilers, interpreters, and package managers into you
 ```toml
 [addons.python.tools]
 python = { version = "3.14" }   # 3.12, 3.13, 3.14
-uv = { version = "0.11.32" }    # 0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26, 0.11.32
+uv = { version = "0.12.0" }    # 0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26, 0.11.32, 0.12.0
 # poetry = { version = "2.4.1" } # Optional: 1.8, 2.0, 2.4.1
 # pdm = { version = "2.28.0" }   # Optional: 2.22, 2.26.9, 2.27.0, 2.28.0
 ```
@@ -35,7 +35,7 @@ Installs the Rust toolchain via rustup with clippy and rustfmt. Uses a multi-sta
 ```toml
 [addons.node.tools]
 node = { version = "26" }       # 20, 22, 24, 26
-pnpm = { version = "11.17.0" }  # 9, 10, 11.1.3, 11.5.2, 11.10.0, 11.17.0
+pnpm = { version = "11.18.0" }  # 9, 10, 11.1.3, 11.5.2, 11.10.0, 11.17.0, 11.18.0
 # yarn = { version = "4.17.0" } # Optional: 4, 4.16.0, 4.17.0
 # bun = { version = "1.3.14" }  # Optional
 ```

--- a/docs-site/content/docs/addons/overview.md
+++ b/docs-site/content/docs/addons/overview.md
@@ -33,7 +33,7 @@ aibox describe addon-catalog -o json
 ```toml
 [addons.python.tools]
 python = { version = "3.14" }
-uv = { version = "0.11.32" }
+uv = { version = "0.12.0" }
 
 [addons.rust.tools]
 rustc = { version = "1.97.1" }
@@ -42,7 +42,7 @@ rustfmt = {}
 
 [addons.node.tools]
 node = { version = "26" }
-pnpm = { version = "11.17.0" }
+pnpm = { version = "11.18.0" }
 ```
 
 Each addon has **default-enabled tools** that are included automatically, and **optional tools** you can enable explicitly. Tools with version selection let you pick from curated, tested versions.
@@ -61,9 +61,9 @@ After editing `aibox.toml`, run `aibox apply` to regenerate the Dockerfile and r
 
 | Addon | Default Tools | Optional Tools |
 |-------|--------------|----------------|
-| `python` | python (3.12/3.13/3.14), uv (0.7/0.11.10/0.11.11/0.11.15/0.11.19/0.11.26/0.11.32) | poetry (1.8/2.0/2.4.1), pdm (2.22/2.26.9/2.27.0/2.28.0) |
+| `python` | python (3.12/3.13/3.14), uv (0.7/0.11.10/0.11.11/0.11.15/0.11.19/0.11.26/0.11.32/0.12.0) | poetry (1.8/2.0/2.4.1), pdm (2.22/2.26.9/2.27.0/2.28.0) |
 | `rust` | rustc (1.90/1.91/1.92/1.93/1.94/1.94.1/1.96.0/1.96.1/1.97.1), clippy, rustfmt | — |
-| `node` | node (20/22/24/26), pnpm (9/10/11.1.3/11.5.2/11.10.0/11.17.0) | yarn (4/4.16.0/4.17.0), bun (1.2/1.3.14) |
+| `node` | node (20/22/24/26), pnpm (9/10/11.1.3/11.5.2/11.10.0/11.17.0/11.18.0) | yarn (4/4.16.0/4.17.0), bun (1.2/1.3.14) |
 | `go` | go (1.25/1.26/1.26.3/1.26.4/1.26.5) | — |
 | `typst` | typst (0.13.1/0.14.2/0.15.0) | — |
 | `latex` | texlive-core, texlive-recommended, texlive-fonts, biber, texlive-code, texlive-diagrams, texlive-math | texlive-music, texlive-chemistry |
@@ -174,7 +174,7 @@ Recipe version: 1.0.0
 
   TOOL      DEFAULT    VERSION  SUPPORTED
   python        yes       3.14  3.12, 3.13, 3.14
-  uv            yes    0.11.32  0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26, 0.11.32
+  uv            yes    0.12.0  0.7, 0.11.10, 0.11.11, 0.11.15, 0.11.19, 0.11.26, 0.11.32, 0.12.0
   poetry         no      2.4.1  1.8, 2.0, 2.4.1
   pdm            no     2.28.0  2.22, 2.26.9, 2.27.0, 2.28.0
 ```

--- a/docs-site/content/docs/getting-started/new-project.md
+++ b/docs-site/content/docs/getting-started/new-project.md
@@ -155,7 +155,7 @@ schema_version = "1.0.0"
 # Run `aibox get addon` to see all available addons.
 # [addons.python.tools]
 # python = { version = "3.14" }
-# uv     = { version = "0.11.32" }
+# uv     = { version = "0.12.0" }
 
 # AI harnesses — controls which AI CLIs/configs are enabled.
 [ai]

--- a/docs-site/content/docs/reference/configuration.md
+++ b/docs-site/content/docs/reference/configuration.md
@@ -65,7 +65,7 @@ schema_version = "1.0.0"              # Context schema version (semver)
 
 [addons.python.tools]                 # Addon: Python runtime
 python = { version = "3.14" }
-uv     = { version = "0.11.32" }
+uv     = { version = "0.12.0" }
 
 [addons.rust.tools]                   # Addon: Rust toolchain
 rustc   = { version = "1.97.1" }
@@ -446,7 +446,7 @@ to install their CLIs.
 ```toml
 [addons.python.tools]
 python = { version = "3.14" }
-uv = { version = "0.11.32" }
+uv = { version = "0.12.0" }
 ```
 
 For interactive Git tooling:

--- a/images/base-debian/Dockerfile
+++ b/images/base-debian/Dockerfile
@@ -278,7 +278,7 @@ COPY --from=build-aibox-runtime-tools /build/aibox-runtime-tools/bin/aibox-diagn
 # image since v0.16.5 (DEC-036) so processkit's PEP 723 MCP server
 # scripts run via `uv run` out of the box. Works against the
 # externally-installed python3 from apt above.
-COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.12.0 /uv /uvx /usr/local/bin/
 ENV UV_CACHE_DIR=/tmp/aibox/uv-cache
 
 ARG AIBOX_IMAGE_SOURCE_SHA=unknown

--- a/scripts/record-asciinema.sh
+++ b/scripts/record-asciinema.sh
@@ -335,7 +335,7 @@ for c in a i b o x ' ' i n i t ' ' m y - p r o j e c t ' ' - - y e s ' ' - - b a
   sleep 0.06
 done
 echo
-printf 'y\n' | aibox init my-project --yes --base debian --profile human-dev --user aibox --theme gruvbox --prompt default --tmux-status extended --addon python --addon-tool python:python=3.14 --addon-tool python:uv=0.11.32 --harness claude --processkit-version v0.26.15 --no-container 2>&1 || true
+printf 'y\n' | aibox init my-project --yes --base debian --profile human-dev --user aibox --theme gruvbox --prompt default --tmux-status extended --addon python --addon-tool python:python=3.14 --addon-tool python:uv=0.12.0 --harness claude --processkit-version v0.26.15 --no-container 2>&1 || true
 
 sleep 1
 echo -ne '\033[32m❯\033[0m '


### PR DESCRIPTION
## Summary

Promote the reviewed Alpha.1 candidate monotonically from `v1.x-dev` to `v1.x-pre-release`.

Includes:
- Codex MCP gateway startup correction from #279
- final actionable dependency refresh from #287
- reviewed cross-line port dispositions

The exact merge commit produced here becomes the M7c and release-evidence candidate.

Refs #236