### PR TITLE
chore(v1): promote prerelease host-release fix

### DIFF
--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -57,8 +57,8 @@ fi
 # ── Parse arguments ──────────────────────────────────────────────────────────
 VERSION="${1:-}"
 if [[ -n "${VERSION}" ]]; then
-  if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${VERSION})"
+  if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${VERSION})"
   fi
   VERSION_TAG="v${VERSION}-"
 else

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -1065,8 +1065,8 @@ cmd_release_runtime_smoke() {
   local version="${1:-}"
   [[ -z "${version}" ]] && die "Usage: ./scripts/maintain.sh release-runtime-smoke <version>  (e.g. 0.10.2)"
 
-  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${version})"
+  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})"
   fi
 
   "${SCRIPT_DIR}/release-runtime-smoke.sh" "${version}" \

--- a/scripts/release-runtime-smoke.sh
+++ b/scripts/release-runtime-smoke.sh
@@ -16,8 +16,8 @@ if [[ -z "${version}" ]]; then
   echo "Usage: ./scripts/release-runtime-smoke.sh <version>" >&2
   exit 2
 fi
-if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Version must be semver: X.Y.Z (got: ${version})" >&2
+if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+  echo "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})" >&2
   exit 2
 fi
 

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -12,6 +12,12 @@ AIBOX_MAINTAIN_SOURCE_ONLY=1 source "${SCRIPT_DIR}/maintain.sh"
   || die "v1 prereleases must resolve to v1.x-pre-release"
 [[ "$(release_branch_for_version 1.0.0)" == "v1.x-release" ]] \
   || die "v1 GA versions must resolve to v1.x-release"
+declare -f cmd_release_host | grep -Fq 'X.Y.Z or X.Y.Z-prerelease' \
+  || die "release-host must accept prerelease SemVer"
+grep -Fq 'X.Y.Z or X.Y.Z-prerelease' "${SCRIPT_DIR}/build-macos.sh" \
+  || die "macOS artifact builds must accept prerelease SemVer"
+grep -Fq 'X.Y.Z or X.Y.Z-prerelease' "${SCRIPT_DIR}/release-runtime-smoke.sh" \
+  || die "release runtime smoke must accept prerelease SemVer"
 declare -F publish_release_candidate >/dev/null \
   || die "release candidate protected-branch publisher is missing"
 declare -F release_docs_gate >/dev/null \


### PR DESCRIPTION
Promote the reviewed host-side SemVer prerelease correction from #290 so `release-host 1.0.0-alpha.1` can complete from the designated prerelease branch.

Refs #236