### PR TITLE
fix(v0): accept prerelease versions in host release tooling

### DIFF
--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -57,8 +57,8 @@ fi
 # ── Parse arguments ──────────────────────────────────────────────────────────
 VERSION="${1:-}"
 if [[ -n "${VERSION}" ]]; then
-  if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${VERSION})"
+  if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${VERSION})"
   fi
   VERSION_TAG="v${VERSION}-"
 else

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -705,8 +705,8 @@ cmd_push_images() {
   local version="${1:-}"
   [[ -z "${version}" ]] && die "Usage: ./scripts/maintain.sh push-images <version>  (e.g. 0.2.0)"
 
-  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${version})"
+  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})"
   fi
 
   ensure_ghcr_login
@@ -945,8 +945,8 @@ cmd_release_runtime_smoke() {
   local version="${1:-}"
   [[ -z "${version}" ]] && die "Usage: ./scripts/maintain.sh release-runtime-smoke <version>  (e.g. 0.10.2)"
 
-  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${version})"
+  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})"
   fi
 
   "${SCRIPT_DIR}/release-runtime-smoke.sh" "${version}" \
@@ -2204,8 +2204,8 @@ cmd_release() {
   done
 
   # Validate semver (simple check)
-  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${version})"
+  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})"
   fi
 
   local tag="v${version}"
@@ -2449,11 +2449,13 @@ cmd_release() {
 }
 
 release_branch_for_version() {
-  local version="$1" major
-  major="${version%%.*}"
-  [[ "${major}" =~ ^[0-9]+$ ]] \
-    || die "Cannot infer a release branch from version '${version}'."
-  printf 'v%s.x-release' "${major}"
+  local version="$1"
+  case "${version}" in
+    0.*) printf '%s\n' 'v0.x-release' ;;
+    1.*-*) printf '%s\n' 'v1.x-pre-release' ;;
+    1.*) printf '%s\n' 'v1.x-release' ;;
+    *) die "Unsupported release line for ${version}; add a branch mapping first." ;;
+  esac
 }
 
 publish_release_candidate() {
@@ -2496,8 +2498,8 @@ cmd_release_finalize_runtime() {
   local version="${1:-}"
   [[ -z "${version}" ]] && die "Usage: ./scripts/maintain.sh release-finalize-runtime <version>  (e.g. 0.10.2)"
 
-  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${version})"
+  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})"
   fi
 
   local release_branch finalization_branch pr_url
@@ -2579,8 +2581,8 @@ cmd_release_host() {
   local release_started_epoch="$(date +%s)"
   [[ -z "${version}" ]] && die "Usage: ./scripts/maintain.sh release-host <version>  (e.g. 0.10.2)"
 
-  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    die "Version must be semver: X.Y.Z (got: ${version})"
+  if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    die "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})"
   fi
 
   local tag="v${version}"

--- a/scripts/release-runtime-smoke.sh
+++ b/scripts/release-runtime-smoke.sh
@@ -16,8 +16,8 @@ if [[ -z "${version}" ]]; then
   echo "Usage: ./scripts/release-runtime-smoke.sh <version>" >&2
   exit 2
 fi
-if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Version must be semver: X.Y.Z (got: ${version})" >&2
+if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+  echo "Version must be semver: X.Y.Z or X.Y.Z-prerelease (got: ${version})" >&2
   exit 2
 fi
 

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -8,8 +8,16 @@ AIBOX_MAINTAIN_SOURCE_ONLY=1 source "${SCRIPT_DIR}/maintain.sh"
 
 [[ "$(release_branch_for_version 0.28.4)" == "v0.x-release" ]] \
   || die "v0 release versions must resolve to v0.x-release"
+[[ "$(release_branch_for_version 1.0.0-alpha.1)" == "v1.x-pre-release" ]] \
+  || die "v1 prereleases must resolve to v1.x-pre-release"
 [[ "$(release_branch_for_version 1.0.0)" == "v1.x-release" ]] \
   || die "v1 release versions must resolve to v1.x-release"
+declare -f cmd_release_host | grep -Fq 'X.Y.Z or X.Y.Z-prerelease' \
+  || die "release-host must accept prerelease SemVer"
+grep -Fq 'X.Y.Z or X.Y.Z-prerelease' "${SCRIPT_DIR}/build-macos.sh" \
+  || die "macOS artifact builds must accept prerelease SemVer"
+grep -Fq 'X.Y.Z or X.Y.Z-prerelease' "${SCRIPT_DIR}/release-runtime-smoke.sh" \
+  || die "release runtime smoke must accept prerelease SemVer"
 declare -F publish_release_candidate >/dev/null \
   || die "release candidate protected-branch publisher is missing"
 


### PR DESCRIPTION
## Summary

Port the shared prerelease SemVer handling from v1 so a checkout on either maintained line can route `release-host 1.0.0-alpha.1` to `v1.x-pre-release` and accept the version in macOS/runtime validation.

## Validation

- shell syntax checks
- `./scripts/test-maintain-release.sh`

Ported from #290.