### PR TITLE
chore(v0): prepare v0.28.19 release metadata

### DIFF
--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -633,6 +633,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.5",
         note: "Patch release: restores Codex processkit MCP startup by preserving uv run --script in gateway daemon-proxy commands, integrates processkit v0.28.5's MCP 1.x compatibility bound, and restores zero-warning clippy under Rust 1.97.",
     },
+    CompatEntry {
+        aibox_version: "0.28.19",
+        processkit_version: "v0.28.5",
+        note: "Patch release: preserves prerelease identifiers when resolving the latest published GHCR image so v1.0.0-alpha.1 is not rewritten to the nonexistent v1.0.0 tag.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/dist/RELEASE-NOTES.md
+++ b/dist/RELEASE-NOTES.md
@@ -1,0 +1,14 @@
+# aibox v0.28.19 — 2026-07-31
+
+**Summary:** This patch restores `aibox apply` for projects that track the latest published image after the v1 alpha appeared. Users can upgrade normally; no configuration change is required.
+
+## Fixed
+
+- Preserve the complete published image SemVer, including prerelease identifiers, so `v1.0.0-alpha.1` resolves to its real GHCR runtime tag instead of the nonexistent `v1.0.0` tag.
+- Add regression coverage for exact prerelease image-tag generation.
+
+## Upgrade notes
+
+Upgrade the host CLI to v0.28.19 and rerun `aibox apply`.
+
+[v0.28.19]: https://github.com/projectious-work/aibox/compare/v0.28.18...v0.28.19

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.28.19 | v0.28.5 | preserves prerelease identifiers when resolving the latest published GHCR image so `v1.0.0-alpha.1` is not rewritten to the nonexistent `v1.0.0` tag |
 | 0.28.18 | v0.28.5 | restores Codex processkit MCP startup by preserving `uv run --script` in gateway daemon-proxy commands, integrates processkit's MCP 1.x compatibility bound, and restores zero-warning clippy under Rust 1.97 |
 | 0.28.17 | v0.28.4 | repairs Go, Typst, AWS CLI, and Node.js add-on installers and adds a clean companion-container build gate for download-based add-on defaults |
 | 0.28.16 | v0.28.4 | installs Node.js from checksum-verified official release archives after the NodeSource signing-key endpoint became unavailable and refreshes generated runtime and processkit package-selection state |


### PR DESCRIPTION
## Summary

- add v0.28.19 compatibility metadata for processkit v0.28.5
- document the exact prerelease image-tag resolution fix
- add curated summary-first release notes

## Validation

- `cargo fmt -- --check`
- `cargo test compat::tests::cargo_pkg_version_has_compat_entry`
- `git diff --check`