### PR TITLE
chore(v0): reconcile v1 release obligations

### DIFF
--- a/addons/docs/docs-zensical.yaml
+++ b/addons/docs/docs-zensical.yaml
@@ -17,8 +17,8 @@ tools:
   - name: zensical
     description: "Python documentation site generator"
     default_enabled: true
-    default_version: "0.0.51"
-    supported_versions: ["0.0.43", "0.0.44", "0.0.47", "0.0.51"]
+    default_version: "0.0.52"
+    supported_versions: ["0.0.43", "0.0.44", "0.0.47", "0.0.51", "0.0.52"]
 
 builder: null
 

--- a/aibox.toml
+++ b/aibox.toml
@@ -301,7 +301,7 @@ hugo = { enabled = true } # Fast Go-based static site generator; default off; op
 
 # Documentation/docs-zensical — Zensical – Python docs site; requires python
 # [addons.docs-zensical.tools]
-# zensical = {} # Python documentation site generator; default on; options: {}, { enabled = true|false }, { version = "0.0.43" | "0.0.44" | "0.0.47" | "0.0.51" (default) or "latest" }
+# zensical = {} # Python documentation site generator; default on; options: {}, { enabled = true|false }, { version = "0.0.43" | "0.0.44" | "0.0.47" | "0.0.51" | "0.0.52" (default) or "latest" }
 
 # ---- Languages ------------------------------------------------------------
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -474,9 +474,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]

--- a/docs-site/content/docs/addons/documentation.md
+++ b/docs-site/content/docs/addons/documentation.md
@@ -17,7 +17,7 @@ Documentation addons install static site generators and documentation tools.
 | `docs-hugo` | Hugo Extended | Binary download |
 
 Current curated pins are Docusaurus 3.10.1, Hugo 0.164.0, mdBook 0.5.4,
-MkDocs 1.6.1 with Material 9.7.7, and Zensical 0.0.51. Starlight remains
+MkDocs 1.6.1 with Material 9.7.7, and Zensical 0.0.52. Starlight remains
 scaffolded through the upstream `create-starlight` package.
 
 ## Example


### PR DESCRIPTION
## Summary

- settle four exact cross-line release obligations with traceable source SHA trailers
- refresh Zensical to 0.0.52 and current Rust lockfile dependencies
- record why the v1 legacy-runtime smoke selector needs no v0 code change

## Validation

- `AIBOX_PORT_TARGET_REF=HEAD scripts/check-version-line-ports.sh check v0`
- `cargo fmt -- --check`
- `cargo test addon_loader`
- `cargo test release_scripts_publish_checksum_sidecars`