### PR TITLE
chore: release v0.28.19

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.28.18"
+version = "0.28.19"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.28.18"
+version = "0.28.19"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"


### PR DESCRIPTION
Promotes the validated v0.28.19 release candidate to v0.x-release.