### PR TITLE
fix(v1): enforce shared e2e companion contract

### DIFF
--- a/.devcontainer/Dockerfile.e2e
+++ b/.devcontainer/Dockerfile.e2e
@@ -220,6 +220,15 @@ RUN mkdir -p /workspaces && chown testuser:testuser /workspaces
 # deploy the latest build without rebuilding this image.
 RUN mkdir -p /opt/aibox/addons && chown -R testuser:testuser /opt/aibox
 
+# ── Companion compatibility contract ─────────────────────────────────────────
+# This is intentionally an image-resident, root-owned marker rather than a
+# Compose label or environment-only setting: SSH readiness checks can verify it
+# after a rebuild and cannot be fooled by a stale service configuration.
+RUN install -d -m 0755 /usr/local/share/aibox \
+    && printf '%s\n' 'aibox-e2e-companion-contract=2' \
+       > /usr/local/share/aibox/e2e-companion-contract \
+    && chmod 0444 /usr/local/share/aibox/e2e-companion-contract
+
 # ── Entrypoint: systemd starts sshd and the lingering testuser manager ───────
 EXPOSE 22
 STOPSIGNAL SIGRTMIN+3

--- a/cli/tests/e2e/kubernetes_kind.rs
+++ b/cli/tests/e2e/kubernetes_kind.rs
@@ -63,7 +63,7 @@ fn kubernetes_kind_lifecycle_produces_release_candidate_evidence() {
     );
 
     let preflight = runner.exec(
-        "set -eu; kind version; kubectl version --client; \
+        "set -eu; test \"$(cat /usr/local/share/aibox/e2e-companion-contract)\" = \"aibox-e2e-companion-contract=2\"; kind version; kubectl version --client; \
          test \"$(ps -p 1 -o comm= | tr -d ' ')\" = systemd; \
          test \"$(stat -fc %T /sys/fs/cgroup)\" = cgroup2fs; \
          test \"$(podman info --format '{{.Host.CgroupManager}}')\" = systemd; \

--- a/cli/tests/e2e/runner.rs
+++ b/cli/tests/e2e/runner.rs
@@ -613,7 +613,8 @@ impl E2eRunner {
     /// low-level terminal or TOML errors.
     pub fn assert_companion_tool_versions(&self) {
         let output = self.exec(
-            "tmux -V && \
+            "test \"$(cat /usr/local/share/aibox/e2e-companion-contract)\" = \"aibox-e2e-companion-contract=2\" && \
+             tmux -V && \
              yazi --version && \
              command -v ya && \
              ya --version && \
@@ -641,7 +642,7 @@ impl E2eRunner {
                 && stdout.contains("newuidmap")
                 && stdout.contains("newgidmap")
                 && stdout.contains("bwrap-ok"),
-            "aibox-e2e-testrunner image is stale; expected tmux, Yazi {EXPECTED_YAZI_VERSION}, the ya companion entrypoint, uidmap helpers for rootless Podman, and a working bubblewrap user-namespace smoke probe.\n\
+            "aibox-e2e-testrunner image is stale; expected companion contract version 2, tmux, Yazi {EXPECTED_YAZI_VERSION}, the ya companion entrypoint, uidmap helpers for rootless Podman, and a working bubblewrap user-namespace smoke probe.\n\
              Rebuild/recreate the companion service from .devcontainer/Dockerfile.e2e, then rerun `./scripts/maintain.sh test-e2e`.\n\
              observed:\n{stdout}"
         );

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -786,7 +786,11 @@ fn e2e_companion_delegates_kind_through_systemd() {
     let kind_lifecycle =
         std::fs::read_to_string(root.join("scripts/test-kubernetes-kind.sh")).unwrap();
     let maintain = std::fs::read_to_string(root.join("scripts/maintain.sh")).unwrap();
+    let contract_guard =
+        std::fs::read_to_string(root.join("scripts/check-e2e-companion-contract.sh")).unwrap();
 
+    assert!(dockerfile.contains("aibox-e2e-companion-contract=2"));
+    assert!(dockerfile.contains("/usr/local/share/aibox/e2e-companion-contract"));
     assert!(dockerfile.contains("CMD [\"/sbin/init\"]"));
     assert!(dockerfile.contains("Delegate=yes"));
     assert!(dockerfile.contains("cgroup_manager = \"systemd\""));
@@ -794,8 +798,10 @@ fn e2e_companion_delegates_kind_through_systemd() {
     assert!(compose.contains("cgroup: private"));
     assert!(compose.contains("/lib/modules:/lib/modules:ro"));
     assert!(kind_gate.contains("systemd-run --user --scope --quiet -p Delegate=yes"));
+    assert!(kind_gate.contains("aibox-e2e-companion-contract=2"));
     assert!(kind_gate.contains(r#"awk -F: \"\\$1 == 0 { print \\$3 }\""#));
     assert!(maintain.contains("systemd-run --user --scope --quiet -p Delegate=yes"));
+    assert!(maintain.contains("aibox-e2e-companion-contract=2"));
     assert!(maintain.contains("e2e_companion_preflight"));
     assert!(maintain.contains("E2E companion is stale. Rebuild it on the Docker host"));
     assert!(kind_gate.contains("copy_file_to"));
@@ -836,6 +842,14 @@ fn e2e_companion_delegates_kind_through_systemd() {
         "the release gate must reject evidence from another candidate binary"
     );
     assert!(maintain.contains("kubernetes_kind -- --ignored --nocapture"));
+    assert!(contract_guard.contains("--require-reference"));
+    assert!(contract_guard.contains("v0.x-release"));
+    assert!(contract_guard.contains(".devcontainer/Dockerfile.e2e"));
+    assert!(contract_guard.contains(".devcontainer/docker-compose.override.yml"));
+    let version_line_guard =
+        std::fs::read_to_string(root.join("scripts/check-version-line-ports.sh")).unwrap();
+    assert!(version_line_guard.contains("check-e2e-companion-contract.sh"));
+    assert!(version_line_guard.contains("--candidate \"${target_ref}\""));
 }
 
 #[test]

--- a/scripts/check-e2e-companion-contract.sh
+++ b/scripts/check-e2e-companion-contract.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Verify the E2E companion's local contract and, when available, that the
+# supported v0 and v1 lines use byte-identical companion sources.
+#
+# The reference is optional on purpose: ordinary branch CI and source tarballs
+# do not need to fetch another release line. Release-line integration invokes
+# this with a locally available v0.x-release ref to catch source divergence.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd "${script_dir}/.." && pwd)"
+reference="${AIBOX_E2E_COMPANION_REFERENCE:-v0.x-release}"
+candidate="HEAD"
+
+usage() {
+  echo "Usage: $0 [--reference <git-ref>] [--candidate <git-ref>] [--require-reference]" >&2
+}
+
+require_reference=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reference)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      reference="$2"
+      shift 2
+      ;;
+    --require-reference)
+      require_reference=1
+      shift
+      ;;
+    --candidate)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      candidate="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+dockerfile="${project_root}/.devcontainer/Dockerfile.e2e"
+compose="${project_root}/.devcontainer/docker-compose.override.yml"
+marker='aibox-e2e-companion-contract=2'
+
+grep -Fqx "    && printf '%s\\n' 'aibox-e2e-companion-contract=2' \\" "${dockerfile}"
+grep -Fq "${marker}" "${dockerfile}"
+grep -Fq '/usr/local/share/aibox/e2e-companion-contract' "${dockerfile}"
+grep -Fq 'CMD ["/sbin/init"]' "${dockerfile}"
+grep -Fq 'cgroup_manager = "systemd"' "${dockerfile}"
+grep -Fq 'cgroup: private' "${compose}"
+grep -Fq '/lib/modules:/lib/modules:ro' "${compose}"
+
+if ! git -C "${project_root}" rev-parse --verify --quiet "${reference}^{commit}" >/dev/null; then
+  if [[ "${require_reference}" -eq 1 ]]; then
+    echo "E2E companion parity reference '${reference}' is unavailable locally." >&2
+    exit 1
+  fi
+  echo "E2E companion local contract is valid; parity skipped because '${reference}' is unavailable locally." >&2
+  exit 0
+fi
+
+if ! git -C "${project_root}" rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null; then
+  echo "E2E companion parity candidate '${candidate}' is unavailable locally." >&2
+  exit 1
+fi
+
+for path in .devcontainer/Dockerfile.e2e .devcontainer/docker-compose.override.yml; do
+  if ! cmp -s \
+      <(git -C "${project_root}" show "${reference}:${path}") \
+      <(git -C "${project_root}" show "${candidate}:${path}"); then
+    echo "E2E companion source diverges: ${candidate} does not match ${reference}: ${path}" >&2
+    exit 1
+  fi
+done
+
+echo "E2E companion local contract and ${candidate}/${reference} parity are valid."

--- a/scripts/check-version-line-ports.sh
+++ b/scripts/check-version-line-ports.sh
@@ -75,6 +75,11 @@ check_target() {
   git -C "${PROJECT_ROOT}" merge-base --is-ancestor "${source_baseline}" "${source_ref}" \
     || die "${source_baseline} is not an ancestor of ${source_ref}"
 
+  "${PROJECT_ROOT}/scripts/check-e2e-companion-contract.sh" \
+    --reference "${source_ref}" \
+    --candidate "${target_ref}" \
+    --require-reference
+
   while IFS= read -r sha; do
     [[ -n "${sha}" ]] || continue
     parents="$(git -C "${PROJECT_ROOT}" rev-list --parents -n 1 "${sha}")"

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -363,6 +363,7 @@ e2e_companion_preflight() {
     'set -eu
      command -v kind >/dev/null
      command -v kubectl >/dev/null
+     test "$(cat /usr/local/share/aibox/e2e-companion-contract)" = "aibox-e2e-companion-contract=2"
      test "$(ps -p 1 -o comm= | tr -d " ")" = systemd
      test "$(stat -fc %T /sys/fs/cgroup)" = cgroup2fs
      test -d /lib/modules


### PR DESCRIPTION
## Summary
- stamp E2E companion images with immutable contract version 2
- validate the marker in ordinary Tier 2, release readiness, and M7c kind preflights
- enforce byte-identical companion Dockerfile and Compose definitions through the existing version-line port gate

## Validation
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- bash syntax checks for all touched scripts
- cross-line parity passed against v0 candidate 92be39df

## Integration order
Merge the paired v0 alignment PR first, then this PR.