### PR TITLE
docs: record session handover

### DIFF
--- a/context/logs/2026/08/LOG-20260801_0858-BraveRiver-session-handover.md
+++ b/context/logs/2026/08/LOG-20260801_0858-BraveRiver-session-handover.md
@@ -1,0 +1,60 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260801_0858-BraveRiver-session-handover
+  created: '2026-08-01T08:58:09+00:00'
+spec:
+  event_type: session.handover
+  timestamp: '2026-08-01T08:58:09+00:00'
+  summary: Session handover — aligned E2E companions, reconciled processkit v0.28.5,
+    and merged all work
+  actor: codex
+  subject: BACK-20260724_1843-PatientLynx-implement-aibox-v1-orchestration
+  subject_kind: WorkItem
+  details:
+    session_date: '2026-08-01'
+    current_state: 'The v0.x-release and v1.x-pre-release E2E companion definitions
+      are aligned and protected by an image-resident contract marker plus cross-line
+      parity enforcement; PRs #307 and #308 are merged. The reviewed processkit v0.28.5
+      content/runtime reconciliation was committed and merged through PR #309. Branch
+      v1.x-pre-release is clean at 08512b85 and matches origin; pk-doctor reports
+      0 errors, 0 warnings, 0 actionable infos, and 0 pending migrations.'
+    open_threads:
+    - 'BLOCKED critical BACK-20260728_1004-GracefulSea: rebuild the companion on the
+      macOS OrbStack host and produce exact-candidate M7c evidence.'
+    - 'BLOCKED high BACK-20260725_1003-GiftedBlossom: M7c disposable-cluster E2E remains
+      blocked on that host rebuild and live evidence.'
+    - 'IN-PROGRESS high BACK-20260724_1843-PatientLynx: v1 orchestration epic continues
+      after M7c evidence.'
+    - 'IN-PROGRESS medium BACK-20260514_0924-ActiveSummit and BACK-20260514_0925-VastHare:
+      tmux layout/theme switching stories remain open.'
+    - Eight named historical stashes remain. stash@{0} is the processkit-v0.28.5 reconciliation
+      safety stash; stash@{1..7} are earlier release/host or main-line safety stashes
+      and were intentionally not dropped without separate ancestry/content review.
+    next_recommended_action: On the macOS OrbStack host, rebuild and force-recreate
+      aibox-e2e-testrunner from the now-aligned v1.x-pre-release checkout, verify
+      companion contract version 2/systemd/kind readiness, then run the exact 08512b85
+      candidate through the M7c disposable-cluster lifecycle and rerun release readiness.
+    branch: v1.x-pre-release
+    commit: 08512b85
+    worktree: clean; only /workspace remains
+    stashes:
+    - 'stash@{0}: processkit-v0.28.5-reconciled-20260801'
+    - 'stash@{1}: pre-release-host-v0.28.19-primary-20260731T184419Z'
+    - 'stash@{2}: pre-release-host-v0.28.18-primary-20260730T203342Z'
+    - 'stash@{3}: pre-release-host-v0.28.14-primary-20260726T164837Z'
+    - 'stash@{4}: pre-release-host-v0.28.13-local-work-2026-07-26'
+    - 'stash@{5}: keep-aibox-toml-comment-drift'
+    - 'stash@{6}: visual test family-theme WIP'
+    - 'stash@{7}: pre-v0.25.14-release-unrelated-dirty-state'
+    behavioral_retrospective:
+    - The initial stale-companion diagnosis over-weighted cached-image reuse. The
+      user's OrbStack cleanup evidence prompted a timestamp/reflog check, which established
+      that the companion was freshly built from v0.x-release before the checkout returned
+      to v1.x-pre-release.
+    - 'The correction was encoded durably: both version lines now share byte-identical
+      companion sources, images carry contract version 2, readiness paths validate
+      it, and the version-line port gate enforces parity.'
+    - No promised entity creation or repository publication remained deferred at wrapup.
+---


### PR DESCRIPTION
Record the canonical processkit session handover after merging the E2E companion alignment and processkit v0.28.5 reconciliation. Captures current git state, open WorkItems, host-side M7c next action, stash inventory, and the corrected stale-companion diagnosis.