### PR TITLE
chore: expose docs service on loopback

### DIFF
--- a/.devcontainer/docker-compose.override.yml
+++ b/.devcontainer/docker-compose.override.yml
@@ -3,6 +3,9 @@
 # This file is never overwritten by `aibox sync`.
 
 services:
+  aibox-docs:
+    ports:
+      - "127.0.0.1:1316:1316"
   aibox:
     build:
       target: aibox


### PR DESCRIPTION
Adds the aibox-docs override port mapping on 127.0.0.1:1316. Ported consistently across all maintained code branches.