### PR TITLE
fix: bind docs port on the main service

### DIFF
--- a/.devcontainer/docker-compose.override.yml
+++ b/.devcontainer/docker-compose.override.yml
@@ -3,9 +3,6 @@
 # This file is never overwritten by `aibox sync`.
 
 services:
-  aibox-docs:
-    ports:
-      - "127.0.0.1:1316:1316"
   aibox:
     build:
       target: aibox
@@ -21,7 +18,8 @@ services:
     # namespace creation before bubblewrap gets control.
     # security_opt:
     #  - seccomp=unconfined
-
+    ports:
+      - "127.0.0.1:1316:1316"
   # ── E2E Test Companion Container ───────────────────────────────────────────
   # Simulates a user's host machine for end-to-end testing of the aibox CLI.
   # No shared volumes — the test harness SCPs the aibox binary + addons into


### PR DESCRIPTION
Corrects the prior port by attaching 127.0.0.1:1316 to the existing aibox service instead of declaring an override-only aibox-docs service.