### PR TITLE
test(release): make visual e2e gate mandatory

### DIFF
--- a/cli/tests/e2e/visual_matrix.rs
+++ b/cli/tests/e2e/visual_matrix.rs
@@ -643,7 +643,6 @@ fn assert_generated_layout_created_real_tmux_surfaces(layout: &str, logs: &str) 
 
 #[test]
 #[serial(companion_visual)]
-#[ignore = "visual e2e matrix is release-gated; run explicitly via scripts/maintain.sh test-e2e-visual-status or test-e2e-visual"]
 #[ntest::timeout(720_000)]
 fn visual_generated_layouts_render_across_all_themes() {
     let runner = E2eRunner::new();
@@ -690,7 +689,6 @@ fn visual_generated_layouts_render_across_all_themes() {
 
 #[test]
 #[serial(companion_visual)]
-#[ignore = "visual tab-traversal e2e is release-gated; run explicitly via scripts/maintain.sh test-e2e-visual-tabs or test-e2e-visual"]
 #[ntest::timeout(300_000)]
 fn visual_generated_tools_and_harness_windows_render_when_enabled() {
     let runner = E2eRunner::new();
@@ -749,7 +747,6 @@ fn visual_generated_tools_and_harness_windows_render_when_enabled() {
 
 #[test]
 #[serial(companion_visual)]
-#[ignore = "visual Yazi preview e2e is release-gated; run explicitly via scripts/maintain.sh test-e2e-visual-yazi or test-e2e-visual"]
 #[ntest::timeout(300_000)]
 fn visual_yazi_previews_git_symbols_and_optional_plugins_render() {
     let runner = E2eRunner::new();

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -2304,15 +2304,12 @@ cmd_release() {
   fi
 
   if release_step_requested visual; then
-    case "${AIBOX_RELEASE_VISUAL_E2E:-skip}" in
-      skip|"")
-        warn "Skipping opt-in visual E2E during release. The release agent must justify this in notes or handover, or run AIBOX_RELEASE_VISUAL_E2E=<status|tabs|yazi|render|full|docs>."
-        ;;
-      *)
-        release_run_evidenced_step "visual-${AIBOX_RELEASE_VISUAL_E2E}" "${version}" \
-          "Visual E2E (${AIBOX_RELEASE_VISUAL_E2E})" release_visual_gate
-        ;;
-    esac
+    if [[ "${AIBOX_RELEASE_SKIP_VISUAL:-}" == "1" ]]; then
+      warn "AIBOX_RELEASE_SKIP_VISUAL=1 set — skipping the mandatory visual gate. Record the emergency justification in the release notes or handover."
+    else
+      AIBOX_RELEASE_VISUAL_E2E=full release_run_evidenced_step \
+        "visual-full" "${version}" "Mandatory visual E2E" release_visual_gate
+    fi
   fi
 
   if release_step_requested version-smoke; then


### PR DESCRIPTION
Recover the semantic source changes from the historical visual-E2E stash without restoring obsolete generated casts.

Changes:
- unignore the three visual matrix tests
- make the full visual release gate mandatory
- retain an explicit emergency skip with required justification

Validation:
- bash -n scripts/maintain.sh
- cargo fmt -- --check
- cargo test --features e2e --test e2e --no-run