### PR TITLE
fix(docs): serve local preview on port 1316

### DIFF
--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -123,7 +123,7 @@ ${bold}Development:${reset}
                            Plan or delete GHCR BuildKit cache package versions
   release-runtime-smoke <version>
                            Run host-side generated-runtime smoke and write logs
-  docs-serve               Serve Docusaurus locally (http://localhost:3000)
+  docs-serve               Serve Docusaurus locally (http://localhost:1316)
   docs-deploy [--dry-run]  Build Docusaurus and push to gh-pages branch
   test-visual              Run screencast smoke tests (~40s)
   record-docs              Regenerate all docs screencasts + README GIF
@@ -1217,8 +1217,8 @@ cmd_ghcr_prune_buildcache_tags() {
 
 cmd_docs_serve() {
   cd "${PROJECT_ROOT}/docs-site"
-  info "Serving docs with Docusaurus at http://localhost:3000 ..."
-  npx docusaurus start --host 0.0.0.0
+  info "Serving docs with Docusaurus at http://localhost:1316 ..."
+  npx docusaurus start --host 0.0.0.0 --port 1316
 }
 
 cmd_docs_deploy() {


### PR DESCRIPTION
Keep the existing localhost-only Compose mapping `127.0.0.1:1316:1316` and make the branch local docs server listen on container port 1316.

Validation:
- `bash -n scripts/maintain.sh`
- `git diff --check`
- no stale docs-serve URLs on ports 1313 or 3000