### PR TITLE
fix(docs): serve local preview on port 1316

### DIFF
--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -191,7 +191,7 @@ ${bold}Development:${reset}
                            Plan or delete GHCR BuildKit cache package versions
   release-runtime-smoke <version>
                            Run host-side generated-runtime smoke and write logs
-  docs-serve               Serve Hugo/Docsy locally (http://localhost:1313/aibox/)
+  docs-serve               Serve Hugo/Docsy locally (http://localhost:1316/aibox/)
   docs-deploy --line <v0.x|v1.x> [--version vX.Y.Z] [--dry-run]
                            Build Hugo/Docsy, retain release snapshots, and push gh-pages
   test-visual              Run screencast smoke tests (~40s)
@@ -1345,9 +1345,9 @@ cmd_docs_serve() {
   if [[ ! -d "${PROJECT_ROOT}/docs-site/node_modules" ]]; then
     npm --prefix "${PROJECT_ROOT}/docs-site" ci
   fi
-  info "Serving docs with Hugo and Docsy at http://localhost:1313/aibox/v1.x/ ..."
+  info "Serving docs with Hugo and Docsy at http://localhost:1316/aibox/v1.x/ ..."
   hugo server --source "${PROJECT_ROOT}/docs-site" \
-    --bind 0.0.0.0 --baseURL "http://localhost:1313/aibox/v1.x/"
+    --bind 0.0.0.0 --port 1316 --baseURL "http://localhost:1316/aibox/v1.x/"
 }
 
 cmd_docs_deploy() {


### PR DESCRIPTION
Keep the existing localhost-only Compose mapping `127.0.0.1:1316:1316` and make the branch local docs server listen on container port 1316.

Validation:
- `bash -n scripts/maintain.sh`
- `git diff --check`
- no stale docs-serve URLs on ports 1313 or 3000