### PR TITLE
chore(context): record session handover

### DIFF
--- a/context/logs/2026/08/LOG-20260801_1227-HopefulCrow-session-handover.md
+++ b/context/logs/2026/08/LOG-20260801_1227-HopefulCrow-session-handover.md
@@ -1,0 +1,66 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260801_1227-HopefulCrow-session-handover
+  created: '2026-08-01T12:27:44+00:00'
+spec:
+  event_type: session.handover
+  timestamp: '2026-08-01T12:27:44+00:00'
+  summary: Session handover — reconciled runtime/processkit state, resolved all stashes,
+    and standardized docs preview port 1316 across maintained branches
+  actor: codex
+  details:
+    session_date: '2026-08-01'
+    current_state: 'All requested repository changes are merged and pushed. PRs #317-#321
+      corrected the aibox-docs Compose override across every maintained branch; PR
+      #322 merged the complete v1 runtime/processkit reconciliation and prerelease
+      image-tag fix; PRs #323-#324 resolved the recoverable stash work; PRs #325-#329
+      retained the localhost-only 127.0.0.1:1316:1316 mapping and made every docs
+      server listen on port 1316. The v1.x-pre-release worktree is clean at cc538669,
+      there are no stashes, and /workspace is the only worktree.'
+    open_threads:
+    - 'BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence
+      remains blocked: produce candidateCommit/binarySha256-bound live M7c evidence
+      using the rebuilt E2E companion before alpha publication.'
+    - BACK-20260725_1003-GiftedBlossom-implement-m7c-disposable-cluster-e2e-and remains
+      blocked pending the same disposable-cluster lifecycle and recovery evidence.
+    - 'A v0.x-release pk-doctor validation during stash reconciliation reported 0
+      errors and 7 actionable/pre-existing warnings: one filename case mismatch, mixed
+      filename policy, and five missing Claude TeamMember exports. Do not claim that
+      v0 line doctor-clean until remediated and rerun.'
+    next_recommended_action: Verify SSH reachability to the rebuilt aibox-e2e-testrunner,
+      rebuild/recreate it only if its running image is stale, then run the exact cc538669
+      v1.x-pre-release candidate through the live M7c disposable-cluster evidence
+      workflow and update the two blocked WorkItems from evidence.
+    branch: v1.x-pre-release
+    commit: cc538669
+    git_context:
+      worktree_clean: true
+      stashes: 0
+      worktrees:
+      - /workspace
+      merged_pull_requests:
+      - '#317'
+      - '#318'
+      - '#319'
+      - '#320'
+      - '#321'
+      - '#322'
+      - '#323'
+      - '#324'
+      - '#325'
+      - '#326'
+      - '#327'
+      - '#328'
+      - '#329'
+    behavioral_retrospective:
+    - 'The user had to correct the Compose override twice and then identify that port
+      publication alone did not match the actual docs-server listen ports. The correction
+      is now encoded in source on all maintained branches: Compose remains 127.0.0.1:1316:1316
+      and Docusaurus/Hugo explicitly listen on 1316.'
+    - Historical stashes were initially preserved during cleanup because ancestry
+      and intent were unclear; each was subsequently audited, recoverable work was
+      merged through PRs, obsolete content was dropped, and stash/worktree state was
+      verified clean.
+---


### PR DESCRIPTION
Record the canonical end-of-session processkit handover after repository reconciliation, stash resolution, and docs port standardization.