### PR TITLE
feat: add Tau coding-agent harness to v0

### DIFF
--- a/addons/ai/ai-tau.yaml
+++ b/addons/ai/ai-tau.yaml
@@ -1,0 +1,35 @@
+name: ai-tau
+version: "1.0.0"
+description: "Tau educational coding agent (multi-provider)"
+profile_intent: provider-cli
+usage_class: manual-escalation-only
+profiles: ["human-dev"]
+exported_surfaces: ["cli-binary", "config-files"]
+builder_weight: null
+
+tools:
+  - name: tau
+    description: "Tau terminal coding agent"
+    default_enabled: true
+    default_version: "0.3.5"
+    supported_versions: ["0.3.5"]
+
+builder: null
+
+runtime: |
+  # Addon: ai-tau
+  # Tau: https://twotimespi.dev/
+  # Python coding agent with durable sessions, AGENTS.md project instructions,
+  # and Agent Skills discovery from .agents/skills.
+  # Config: ~/.tau/  |  Binary: tau
+  # Auth: start Tau and use /login, or configure a supported provider.
+  #
+  # Install through uv tool using the pinned PyPI package. Keep the tool
+  # environment outside /root so the non-root runtime user can execute it.
+  {% if tools.tau.version %}
+  RUN UV_TOOL_DIR=/opt/aibox/uv-tools uv tool install tau-ai=={{ tools.tau.version }} \
+      && chmod -R a+rX /opt/aibox/uv-tools
+  {% else %}
+  RUN UV_TOOL_DIR=/opt/aibox/uv-tools uv tool install tau-ai \
+      && chmod -R a+rX /opt/aibox/uv-tools
+  {% endif %}

--- a/aibox.toml
+++ b/aibox.toml
@@ -422,6 +422,7 @@ rich = {} # Markdown, JSON, RST, and notebook terminal rendering for Yazi previe
 # GitHub Copilot              copilot        (uses GITHUB_TOKEN)
 # OpenCode                    opencode       any (multi-provider)
 # Hermes                      hermes         any (multi-provider)
+# Tau                         tau            any (multi-provider)
 #
 # Harnesses are configured by the ordered `harnesses` list below.
 # The list order is the tmux/layout order: 1st, 2nd, 3rd harness.
@@ -444,7 +445,7 @@ model_providers = [
 ]
 
 # Ordered harness list. Supported harness values:
-# claude, codex, gemini, aider, continue, cursor, copilot, opencode, hermes.
+# claude, codex, gemini, aider, continue, cursor, copilot, opencode, hermes, tau.
 # Each one-line entry is directly uncommentable; list order is tmux/layout order.
 # `enable = true` includes the harness in generated agent/MCP/runtime config.
 # `install = true` installs the matching in-container CLI recipe when one exists.
@@ -461,6 +462,7 @@ harnesses = [
 #   { harness = "copilot", enable = true, install = true },
 #   { harness = "opencode", enable = true, install = true },
 #   { harness = "hermes", enable = true, install = true },
+#   { harness = "tau", enable = true, install = true },
 ]
 
 # AI harness execution policy. These are aibox-level intent settings;

--- a/cli/src/addon_registry.rs
+++ b/cli/src/addon_registry.rs
@@ -389,5 +389,11 @@ mod tests {
             !hermes.contains("USER aibox"),
             "Hermes installation must retain root access to /usr/local/bin: {hermes}"
         );
+        let tau = generate_runtime_commands("ai-tau", &tc(&[("tau", true, "0.3.5")]));
+        assert!(tau.contains("tau-ai==0.3.5"), "{tau}");
+        assert!(
+            tau.contains("UV_TOOL_DIR=/opt/aibox/uv-tools"),
+            "Tau tool environment must use the shared uv path: {tau}"
+        );
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -475,6 +475,8 @@ pub enum AiHarness {
     OpenCode,
     /// Nous Research autonomous agent.
     Hermes,
+    /// Tau educational multi-provider coding agent.
+    Tau,
     /// Mistral has no CLI harness; retained only so old config can be parsed.
     #[serde(rename = "mistral")]
     #[clap(skip)]
@@ -493,6 +495,7 @@ impl std::fmt::Display for AiHarness {
             AiHarness::Copilot => write!(f, "copilot"),
             AiHarness::OpenCode => write!(f, "opencode"),
             AiHarness::Hermes => write!(f, "hermes"),
+            AiHarness::Tau => write!(f, "tau"),
             AiHarness::Mistral => write!(f, "mistral"),
         }
     }
@@ -511,6 +514,7 @@ impl AiHarness {
             AiHarness::Copilot => "copilot",
             AiHarness::OpenCode => "opencode",
             AiHarness::Hermes => "hermes",
+            AiHarness::Tau => "tau",
             AiHarness::Mistral => "mistral",
         }
     }
@@ -527,6 +531,7 @@ impl AiHarness {
             AiHarness::Copilot => "GitHub Copilot (copilot)",
             AiHarness::OpenCode => "OpenCode (opencode)",
             AiHarness::Hermes => "Hermes (hermes)",
+            AiHarness::Tau => "Tau (tau)",
             AiHarness::Mistral => "Mistral (mistral, legacy)",
         }
     }
@@ -561,6 +566,7 @@ impl AiHarness {
             AiHarness::Copilot => Some(".copilot"),
             AiHarness::OpenCode => Some(".opencode"),
             AiHarness::Hermes => Some(".hermes"),
+            AiHarness::Tau => Some(".tau"),
             AiHarness::Mistral => None,
         }
     }
@@ -582,6 +588,7 @@ impl AiHarness {
             AiHarness::Copilot,
             AiHarness::OpenCode,
             AiHarness::Hermes,
+            AiHarness::Tau,
         ]
     }
 }

--- a/cli/src/container.rs
+++ b/cli/src/container.rs
@@ -1611,6 +1611,7 @@ pub(crate) fn serialize_config_with_comments(config: &AiboxConfig) -> String {
     out.push_str("# GitHub Copilot              copilot        (uses GITHUB_TOKEN)\n");
     out.push_str("# OpenCode                    opencode       any (multi-provider)\n");
     out.push_str("# Hermes                      hermes         any (multi-provider)\n");
+    out.push_str("# Tau                         tau            any (multi-provider)\n");
     out.push_str("#\n");
     out.push_str("# Harnesses are configured by the ordered `harnesses` list below.\n");
     out.push_str("# The list order is the tmux/layout order: 1st, 2nd, 3rd harness.\n");
@@ -2364,7 +2365,9 @@ fn render_ai_model_provider_catalog(out: &mut String, selected: &[crate::config:
 
 fn render_ai_harness_detail_catalog(out: &mut String, config: &AiboxConfig) {
     out.push_str("\n# Ordered harness list. Supported harness values:\n");
-    out.push_str("# claude, codex, gemini, aider, continue, cursor, copilot, opencode, hermes.\n");
+    out.push_str(
+        "# claude, codex, gemini, aider, continue, cursor, copilot, opencode, hermes, tau.\n",
+    );
     out.push_str(
         "# Each one-line entry is directly uncommentable; list order is tmux/layout order.\n",
     );

--- a/cli/src/generate.rs
+++ b/cli/src/generate.rs
@@ -1876,6 +1876,24 @@ mod tests {
     }
 
     #[test]
+    fn dockerfile_installs_tau_in_shared_uv_tool_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = make_config(&[], false);
+        config.ai.harnesses = vec![crate::config::AiProvider::Tau];
+        config.resolve_ai_provider_addons();
+        generate_dockerfile(&config, dir.path(), &test_env()).unwrap();
+        let content = fs::read_to_string(dir.path().join("Dockerfile")).unwrap();
+        assert!(
+            content.contains("UV_TOOL_DIR=/opt/aibox/uv-tools uv tool install tau-ai==0.3.5"),
+            "Tau should be installed from its pinned PyPI package: {content}"
+        );
+        assert!(
+            content.contains("chmod -R a+rX /opt/aibox/uv-tools"),
+            "Tau tool environment must be traversable by the runtime user: {content}"
+        );
+    }
+
+    #[test]
     fn dockerfile_claude_installed_via_addon() {
         let dir = tempfile::tempdir().unwrap();
         let mut config = make_config(&[], false);

--- a/cli/src/harness_commands.rs
+++ b/cli/src/harness_commands.rs
@@ -25,6 +25,7 @@
 //! | Cursor   | `.cursor/commands/<name>.md`               | md verbatim |
 //! | Gemini   | `.gemini/commands/<name>.toml`             | TOML (converted) |
 //! | OpenCode | `.opencode/commands/<name>.md`             | md verbatim |
+//! | Tau      | `.agents/skills/<name>/SKILL.md`           | Agent Skill |
 //!
 //! Codex Skills are the supported reusable-workflow surface and are invoked
 //! with `$<name>` or selected through `/skills`. Codex custom prompts provide
@@ -138,6 +139,15 @@ fn profile_for(harness: AiHarness, project_root: &Path) -> Option<HarnessCommand
             format: CommandFormat::CodexSkill,
             subdir_per_command: true,
         }),
+        AiHarness::Tau => Some(HarnessCommandProfile {
+            harness,
+            // Tau implements the Agent Skills specification and discovers
+            // project skills from .agents/skills.
+            target_dir: project_root.join(".agents").join("skills"),
+            file_extension: "md",
+            format: CommandFormat::CodexSkill,
+            subdir_per_command: true,
+        }),
         AiHarness::Cursor => Some(HarnessCommandProfile {
             harness,
             target_dir: project_root.join(".cursor").join("commands"),
@@ -197,6 +207,7 @@ const SCAFFOLDABLE_HARNESSES: &[AiHarness] = &[
     AiHarness::Cursor,
     AiHarness::Gemini,
     AiHarness::OpenCode,
+    AiHarness::Tau,
 ];
 
 /// Sync processkit command adapter files to every enabled harness target.
@@ -1381,6 +1392,26 @@ mod tests {
 
         assert!(!project.join(".agents/skills").exists());
         assert!(!project.join(".aibox-home/.codex/prompts").exists());
+    }
+
+    #[test]
+    fn tau_profile_writes_agent_skill_without_codex_prompt_alias() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+        fixture_with_pk_resume(project);
+
+        let config = config_with("v0.20.0", vec![AiHarness::Tau]);
+        sync_harness_commands(project, &config).unwrap();
+
+        let skill = project.join(".agents/skills/pk-resume/SKILL.md");
+        assert!(skill.exists(), "Tau must receive an Agent Skills adapter");
+        let content = fs::read_to_string(skill).unwrap();
+        assert!(content.contains("\nname: pk-resume\n"));
+        assert!(content.contains("Do the thing."));
+        assert!(
+            !project.join(".aibox-home/.codex/prompts").exists(),
+            "Tau must not create Codex-only prompt aliases"
+        );
     }
 
     #[test]

--- a/cli/src/provider_backend.rs
+++ b/cli/src/provider_backend.rs
@@ -161,7 +161,7 @@ fn has_container_cli(harness: &AiHarness) -> bool {
 }
 
 fn has_mcp_client(harness: &AiHarness) -> bool {
-    !matches!(harness, AiHarness::Aider)
+    !matches!(harness, AiHarness::Aider | AiHarness::Tau)
 }
 
 fn mcp_config_target(harness: &AiHarness) -> Option<&'static str> {
@@ -174,6 +174,7 @@ fn mcp_config_target(harness: &AiHarness) -> Option<&'static str> {
         AiHarness::Codex => Some(".codex/config.toml"),
         AiHarness::Continue => Some(".continue/mcpServers/"),
         AiHarness::Aider => None,
+        AiHarness::Tau => None,
         AiHarness::Mistral => Some(".mcp.json"),
     }
 }
@@ -188,7 +189,7 @@ fn permission_target(harness: &AiHarness) -> Option<&'static str> {
         AiHarness::Cursor => Some(".cursor/settings.json"),
         AiHarness::Copilot => Some(".copilot-env"),
         AiHarness::OpenCode => Some(".opencode/config.toml"),
-        AiHarness::Hermes | AiHarness::Mistral => None,
+        AiHarness::Hermes | AiHarness::Tau | AiHarness::Mistral => None,
     }
 }
 
@@ -197,6 +198,9 @@ fn notes(harness: &AiHarness) -> Vec<&'static str> {
         AiHarness::Aider => vec!["no built-in MCP client; aibox emits permission fallback only"],
         AiHarness::Cursor => vec!["host-side IDE backend; no in-container CLI addon"],
         AiHarness::Hermes => vec!["uses .mcp.json registration; no permission projection yet"],
+        AiHarness::Tau => {
+            vec!["no built-in MCP client; reads AGENTS.md and Agent Skills from .agents/skills"]
+        }
         _ => Vec::new(),
     }
 }

--- a/cli/src/seed.rs
+++ b/cli/src/seed.rs
@@ -1334,6 +1334,7 @@ fn cleanup_disabled_harness_state(config: &AiboxConfig, root: &Path) -> Result<V
             AiHarness::Claude => vec![".claude", ".mcp.json"],
             AiHarness::Copilot => vec![".copilot"],
             AiHarness::Hermes => vec![".hermes"],
+            AiHarness::Tau => vec![".tau"],
             AiHarness::Mistral => vec![],
         }
     }

--- a/cli/src/templates/aibox-tmux-refresh-theme.sh
+++ b/cli/src/templates/aibox-tmux-refresh-theme.sh
@@ -81,7 +81,7 @@ while IFS=$'\t' read -r pane_id pane_cmd; do
             tmux send-keys -t "$pane_id" ':plugin theme-reload' Enter
             (( refreshed_count += 1 )) || true
             ;;
-        lazygit|lnav|claude|codex|aider|gemini|opencode|hermes)
+        lazygit|lnav|claude|codex|aider|gemini|opencode|hermes|tau)
             # These need a full restart to pick up new colors (tier 2).
             # Collect them now; act on them only in tier 2.
             tui_panes+=("$pane_id")

--- a/cli/tests/e2e/visual_matrix.rs
+++ b/cli/tests/e2e/visual_matrix.rs
@@ -50,6 +50,7 @@ const HARNESSES: &[(&str, &str, &str)] = &[
     ("copilot", "copilot", "COPILOT"),
     ("opencode", "opencode", "OPENCODE"),
     ("hermes", "hermes", "HERMES"),
+    ("tau", "tau", "TAU"),
 ];
 
 const DEFAULT_STATUS_THEME: &str = "projectious";
@@ -567,7 +568,7 @@ fn record_generated_layout(runner: &E2eRunner, test_name: &str, layout: &str) ->
     let capture = format!(
         r#"{setup}{harness_windows}
   : > "{workspace}/{stem}.screens"
-  for win in work files ai lazygit shell claude codex gemini aider continue cursor copilot opencode hermes synthetic-files synthetic-editor synthetic-git synthetic-shell synthetic-claude synthetic-codex synthetic-gemini synthetic-aider synthetic-continue synthetic-cursor synthetic-copilot synthetic-opencode synthetic-hermes; do
+  for win in work files ai lazygit shell claude codex gemini aider continue cursor copilot opencode hermes tau synthetic-files synthetic-editor synthetic-git synthetic-shell synthetic-claude synthetic-codex synthetic-gemini synthetic-aider synthetic-continue synthetic-cursor synthetic-copilot synthetic-opencode synthetic-hermes synthetic-tau; do
     tmux select-window -t "{stem}:$win" >/dev/null 2>&1 || continue
     sleep 0.4
     printf '\n--- window:%s ---\n' "$win" >> "{workspace}/{stem}.screens"

--- a/docs-site/content/docs/reference/configuration.md
+++ b/docs-site/content/docs/reference/configuration.md
@@ -501,7 +501,7 @@ controlled independently by `install = true`.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `harnesses[].harness` | String | Yes for each entry | none | Harness id. Supported values: `claude`, `codex`, `gemini`, `aider`, `continue`, `cursor`, `copilot`, `opencode`, `hermes`. |
+| `harnesses[].harness` | String | Yes for each entry | none | Harness id. Supported values: `claude`, `codex`, `gemini`, `aider`, `continue`, `cursor`, `copilot`, `opencode`, `hermes`, `tau`. Tau reads project instructions from `AGENTS.md` and Agent Skills from `.agents/skills/`; Tau does not currently expose a built-in MCP client. |
 | `harnesses[].enable` | Boolean | No | `false` | Include this harness in generated runtime, agent, and MCP config. Alias: `enabled`. |
 | `harnesses[].install` | Boolean | No | `false` | Install the matching in-container CLI recipe when available. Cursor has no container CLI, so keep this false for `cursor`. |
 | `harnesses[].version` | String | No | addon's default | Optional CLI version pin. |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -249,6 +249,7 @@ main() {
     ai/ai-copilot.yaml
     ai/ai-gemini.yaml
     ai/ai-hermes.yaml
+    ai/ai-tau.yaml
     ai/ai-mistral.yaml
     ai/ai-opencode.yaml
   "

--- a/scripts/release-check-state.sh
+++ b/scripts/release-check-state.sh
@@ -551,6 +551,7 @@ check_addon_version "Kustomize" "$(addon_tool_default "${PROJECT_ROOT}/addons/to
 check_addon_tool_github "k9s" "${PROJECT_ROOT}/addons/tools/kubernetes.yaml" "k9s" "derailed/k9s"
 check_addon_tool_github "OpenCode" "${PROJECT_ROOT}/addons/ai/ai-opencode.yaml" "opencode" "opencode-ai/opencode"
 check_addon_tool_pypi "Hermes Agent" "${PROJECT_ROOT}/addons/ai/ai-hermes.yaml" "hermes" "hermes-agent"
+check_addon_tool_pypi "Tau" "${PROJECT_ROOT}/addons/ai/ai-tau.yaml" "tau" "tau-ai"
 line ""
 line "Python defaults are curated in the addon catalog and installed through uv when they differ from the Debian base interpreter."
 


### PR DESCRIPTION
## What changed

- add Tau as a first-class `tau` harness
- install pinned `tau-ai==0.3.5` through the shared uv tool directory
- persist `~/.tau` and expose the `tau` terminal profile
- project processkit commands into Tau's Agent Skills-compatible `.agents/skills/`
- document Tau's AGENTS.md/skills support and current lack of built-in MCP
- include Tau in addon publication and release pin validation

## Validation

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1` (1069 unit, 90 Tier-1 E2E passed with 1 ignored, 31 integration)
- `uv tool run --from tau-ai==0.3.5 tau --version` → `tau 0.3.5`

Refs: BACK-20260801_1627-SoundLynx-add-tau-harness-support-across-v0