### PR TITLE
chore(release): prepare v0.29.0 metadata

### DIFF
--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -638,6 +638,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.5",
         note: "Patch release: preserves prerelease identifiers when resolving the latest published GHCR image so v1.0.0-alpha.1 is not rewritten to the nonexistent v1.0.0 tag.",
     },
+    CompatEntry {
+        aibox_version: "0.29.0",
+        processkit_version: "v0.28.5",
+        note: "Minor release: adds Tau as a first-class multi-provider coding-agent harness with pinned installation, persistent runtime state, AGENTS.md discovery, Agent Skills projection, and explicit MCP capability reporting.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/dist/RELEASE-NOTES.md
+++ b/dist/RELEASE-NOTES.md
@@ -1,14 +1,20 @@
-# aibox v0.28.19 — 2026-07-31
+# aibox v0.29.0 — 2026-08-01
 
-**Summary:** This patch restores `aibox apply` for projects that track the latest published image after the v1 alpha appeared. Users can upgrade normally; no configuration change is required.
+**Summary:** This minor release adds Tau as a first-class coding-agent harness for users who want its readable, provider-neutral terminal workflow inside an aibox dev container. Enable the new tau harness and rebuild the container; existing configurations remain compatible.
 
-## Fixed
+## Added
 
-- Preserve the complete published image SemVer, including prerelease identifiers, so `v1.0.0-alpha.1` resolves to its real GHCR runtime tag instead of the nonexistent `v1.0.0` tag.
-- Add regression coverage for exact prerelease image-tag generation.
+- Add tau to the supported AI harness catalog and generated aibox.toml configuration.
+- Install the pinned tau-ai 0.3.5 package through the shared uv tool environment and persist Tau state under ~/.tau.
+- Project processkit command adapters into Tau's Agent Skills-compatible .agents/skills/ directory.
+- Add Tau to terminal profiles, tmux layout coverage, addon publication, release pin validation, and user documentation.
+
+## Changed
+
+- Provider-backend reporting now states that Tau loads root AGENTS.md instructions and Agent Skills but does not currently provide a built-in MCP client.
 
 ## Upgrade notes
 
-Upgrade the host CLI to v0.28.19 and rerun `aibox apply`.
+Add { harness = "tau", enable = true, install = true } to [ai].harnesses, then run aibox apply.
 
-[v0.28.19]: https://github.com/projectious-work/aibox/compare/v0.28.18...v0.28.19
+[v0.29.0]: https://github.com/projectious-work/aibox/compare/v0.28.19...v0.29.0

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.29.0 | v0.28.5 | adds Tau as a first-class multi-provider coding-agent harness with pinned installation, persistent runtime state, AGENTS.md discovery, Agent Skills projection, and explicit reporting that Tau does not currently expose a built-in MCP client |
 | 0.28.19 | v0.28.5 | preserves prerelease identifiers when resolving the latest published GHCR image so `v1.0.0-alpha.1` is not rewritten to the nonexistent `v1.0.0` tag |
 | 0.28.18 | v0.28.5 | restores Codex processkit MCP startup by preserving `uv run --script` in gateway daemon-proxy commands, integrates processkit's MCP 1.x compatibility bound, and restores zero-warning clippy under Rust 1.97 |
 | 0.28.17 | v0.28.4 | repairs Go, Typst, AWS CLI, and Node.js add-on installers and adds a clean companion-container build gate for download-based add-on defaults |


### PR DESCRIPTION
Adds the required v0.29.0 compatibility metadata and curated release notes before the canonical release workflow runs.

Validation:
- `cargo fmt -- --check`
- `cargo test compat::tests -- --test-threads=1`
- `git diff --check`