### PR TITLE
feat(addons): add production Go release tooling

### DIFF
--- a/addons/languages/go-quality.yaml
+++ b/addons/languages/go-quality.yaml
@@ -1,0 +1,74 @@
+name: go-quality
+version: "1.0.0"
+description: "Production Go formatting, linting, vulnerability, and security tools"
+profile_intent: build
+usage_class: automated
+profiles: ["human-dev", "headless-runner"]
+exported_surfaces: ["build-toolchain", "cli-binary"]
+builder_weight: null
+requires: ["go"]
+
+tools:
+  - name: goimports
+    description: "Go import organizer and formatter"
+    default_enabled: true
+    default_version: "v0.48.0"
+    supported_versions: ["v0.48.0"]
+  - name: staticcheck
+    description: "Advanced Go static analysis suite"
+    default_enabled: true
+    default_version: "v0.7.0"
+    supported_versions: ["v0.7.0"]
+  - name: golangci-lint
+    description: "Fast aggregate Go linter runner"
+    default_enabled: true
+    default_version: "v2.12.2"
+    supported_versions: ["v2.12.2"]
+  - name: govulncheck
+    description: "Official Go vulnerability analyzer"
+    default_enabled: true
+    default_version: "v1.6.0"
+    supported_versions: ["v1.6.0"]
+  - name: gosec
+    description: "Go source security analyzer"
+    default_enabled: true
+    default_version: "v2.28.0"
+    supported_versions: ["v2.28.0"]
+
+builder: null
+
+runtime: |
+  # Addon: go-quality (runtime)
+  # gcc and libc headers are the Linux prerequisites for `go test -race ./...`.
+  RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
+      rm -rf /var/lib/apt/lists/*
+  {% if tools.goimports.enabled %}
+  RUN GOBIN=/usr/local/bin go install golang.org/x/tools/cmd/goimports@{{ tools.goimports.version }}
+  {% endif %}
+  {% if tools.staticcheck.enabled %}
+  RUN GOBIN=/usr/local/bin go install honnef.co/go/tools/cmd/staticcheck@{{ tools.staticcheck.version }}
+  {% endif %}
+  {% if tools["golangci-lint"].enabled %}
+  RUN GOBIN=/usr/local/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@{{ tools["golangci-lint"].version }}
+  {% endif %}
+  {% if tools.govulncheck.enabled %}
+  RUN GOBIN=/usr/local/bin go install golang.org/x/vuln/cmd/govulncheck@{{ tools.govulncheck.version }}
+  {% endif %}
+  {% if tools.gosec.enabled %}
+  RUN GOBIN=/usr/local/bin go install github.com/securego/gosec/v2/cmd/gosec@{{ tools.gosec.version }}
+  {% endif %}
+  {% if not tools.goimports.enabled %}
+  RUN rm -f /usr/local/bin/goimports
+  {% endif %}
+  {% if not tools.staticcheck.enabled %}
+  RUN rm -f /usr/local/bin/staticcheck
+  {% endif %}
+  {% if not tools["golangci-lint"].enabled %}
+  RUN rm -f /usr/local/bin/golangci-lint
+  {% endif %}
+  {% if not tools.govulncheck.enabled %}
+  RUN rm -f /usr/local/bin/govulncheck
+  {% endif %}
+  {% if not tools.gosec.enabled %}
+  RUN rm -f /usr/local/bin/gosec
+  {% endif %}

--- a/addons/languages/go.yaml
+++ b/addons/languages/go.yaml
@@ -7,6 +7,14 @@ profiles: ["human-dev", "headless-runner"]
 exported_surfaces: ["language-runtime", "build-toolchain", "cli-binary"]
 builder_weight: null
 
+groups:
+  infrastructure: infrastructure
+  quality: go-quality
+  lint: go-quality
+  security: supply-chain
+  supply-chain: supply-chain
+  release: go-release
+
 skills:
   - go-conventions
   - concurrency-patterns

--- a/addons/languages/latex.yaml
+++ b/addons/languages/latex.yaml
@@ -7,6 +7,12 @@ profiles: ["human-dev", "headless-runner"]
 exported_surfaces: ["build-toolchain", "cli-binary"]
 builder_weight: "heavy"
 
+groups:
+  infrastructure: infrastructure
+  security: supply-chain
+  supply-chain: supply-chain
+  release: release
+
 skills:
   - latex-authoring
   - documentation

--- a/addons/languages/node.yaml
+++ b/addons/languages/node.yaml
@@ -7,6 +7,12 @@ profiles: ["human-dev", "headless-runner"]
 exported_surfaces: ["language-runtime", "build-toolchain", "cli-binary"]
 builder_weight: null
 
+groups:
+  infrastructure: infrastructure
+  security: supply-chain
+  supply-chain: supply-chain
+  release: release
+
 skills:
   - typescript-patterns
   - tailwind

--- a/addons/languages/python.yaml
+++ b/addons/languages/python.yaml
@@ -7,6 +7,12 @@ profiles: ["human-dev", "headless-runner"]
 exported_surfaces: ["language-runtime", "build-toolchain", "cli-binary"]
 builder_weight: null
 
+groups:
+  infrastructure: infrastructure
+  security: supply-chain
+  supply-chain: supply-chain
+  release: release
+
 # As of aibox v0.16.5 (DEC-036), python3 (Debian Trixie default, 3.13.x)
 # and uv (0.12.0 from ghcr.io/astral-sh/uv) are unconditionally present
 # in the base-debian image. This addon now provides ADDITIONAL Python

--- a/addons/languages/rust.yaml
+++ b/addons/languages/rust.yaml
@@ -7,6 +7,12 @@ profiles: ["human-dev", "headless-runner"]
 exported_surfaces: ["language-runtime", "build-toolchain", "cli-binary"]
 builder_weight: "medium"
 
+groups:
+  infrastructure: infrastructure
+  security: supply-chain
+  supply-chain: supply-chain
+  release: release
+
 skills:
   - rust-conventions
   - concurrency-patterns

--- a/addons/languages/typst.yaml
+++ b/addons/languages/typst.yaml
@@ -7,6 +7,12 @@ profiles: ["human-dev", "headless-runner"]
 exported_surfaces: ["build-toolchain", "cli-binary"]
 builder_weight: null
 
+groups:
+  infrastructure: infrastructure
+  security: supply-chain
+  supply-chain: supply-chain
+  release: release
+
 skills:
   - documentation
 

--- a/addons/tools/go-release.yaml
+++ b/addons/tools/go-release.yaml
@@ -1,0 +1,24 @@
+name: go-release
+version: "1.0.0"
+description: "GoReleaser plus language-neutral release validation"
+profile_intent: build
+usage_class: automated
+profiles: ["human-dev", "headless-runner"]
+exported_surfaces: ["cli-binary", "build-toolchain"]
+builder_weight: "light"
+requires: ["go", "release"]
+
+tools:
+  - { name: goreleaser, description: "Multi-platform Go release packager", default_enabled: true, default_version: "2.17.1", supported_versions: ["2.17.1"] }
+
+builder: null
+runtime: |
+  # Addon: go-release (runtime)
+  {% if tools.goreleaser.enabled %}
+  RUN ARCH="$(uname -m)" && case "$ARCH" in x86_64) ASSET_ARCH=x86_64 ;; aarch64) ASSET_ARCH=arm64 ;; *) exit 1 ;; esac && \
+      FILE="goreleaser_Linux_${ASSET_ARCH}.tar.gz" && BASE="https://github.com/goreleaser/goreleaser/releases/download/v{{ tools.goreleaser.version }}" && \
+      curl -fsSL "$BASE/$FILE" -o "/tmp/$FILE" && curl -fsSL "$BASE/checksums.txt" -o /tmp/checksums && \
+      (cd /tmp && grep "  $FILE$" checksums | sha256sum -c -) && tar -xzf "/tmp/$FILE" -C /usr/local/bin goreleaser
+  {% else %}
+  RUN rm -f /usr/local/bin/goreleaser
+  {% endif %}

--- a/addons/tools/release.yaml
+++ b/addons/tools/release.yaml
@@ -1,0 +1,34 @@
+name: release
+version: "1.0.0"
+description: "Language-neutral shell and container release validation"
+profile_intent: build
+usage_class: automated
+profiles: ["human-dev", "headless-runner"]
+exported_surfaces: ["cli-binary", "build-toolchain"]
+builder_weight: "light"
+
+tools:
+  - { name: shellcheck, description: "Shell script static analyzer", default_enabled: true, default_version: "0.11.0", supported_versions: ["0.11.0"] }
+  - { name: hadolint, description: "Dockerfile linter", default_enabled: true, default_version: "2.15.1", supported_versions: ["2.15.1"] }
+
+builder: null
+runtime: |
+  # Addon: release (runtime)
+  {% if tools.shellcheck.enabled %}
+  # ShellCheck publishes versioned release archives but no checksum sidecar.
+  # Pinning plus HTTPS is the strongest upstream-supported verification path.
+  RUN apt-get update && apt-get install -y --no-install-recommends xz-utils && rm -rf /var/lib/apt/lists/* && \
+      ARCH="$(uname -m)" && FILE="shellcheck-v{{ tools.shellcheck.version }}.linux.${ARCH}.tar.xz" && \
+      curl --proto '=https' --tlsv1.2 -fsSL "https://github.com/koalaman/shellcheck/releases/download/v{{ tools.shellcheck.version }}/$FILE" -o "/tmp/$FILE" && \
+      tar -xJf "/tmp/$FILE" -C /tmp && install "/tmp/shellcheck-v{{ tools.shellcheck.version }}/shellcheck" /usr/local/bin/shellcheck && \
+      rm -rf "/tmp/$FILE" "/tmp/shellcheck-v{{ tools.shellcheck.version }}" && shellcheck --version
+  {% else %}
+  RUN rm -f /usr/local/bin/shellcheck /usr/bin/shellcheck
+  {% endif %}
+  {% if tools.hadolint.enabled %}
+  RUN ARCH="$(uname -m | sed 's/aarch64/arm64/')" && FILE="hadolint-linux-${ARCH}" && BASE="https://github.com/hadolint/hadolint/releases/download/v{{ tools.hadolint.version }}" && \
+      curl -fsSL "$BASE/$FILE" -o /usr/local/bin/hadolint && curl -fsSL "$BASE/checksums.sha256" -o /tmp/hadolint-checksums && \
+      (cd /usr/local/bin && awk -v file="$FILE" '$NF ~ file "$" { print $1 "  hadolint" }' /tmp/hadolint-checksums | sha256sum -c -) && chmod +x /usr/local/bin/hadolint
+  {% else %}
+  RUN rm -f /usr/local/bin/hadolint /usr/bin/hadolint
+  {% endif %}

--- a/addons/tools/supply-chain.yaml
+++ b/addons/tools/supply-chain.yaml
@@ -1,0 +1,57 @@
+name: supply-chain
+version: "1.0.0"
+description: "Secret scanning, vulnerability analysis, SBOM generation, and signing"
+profile_intent: build
+usage_class: automated
+profiles: ["human-dev", "headless-runner"]
+exported_surfaces: ["cli-binary", "build-toolchain"]
+builder_weight: "medium"
+
+tools:
+  - { name: gitleaks, description: "Repository secret scanner", default_enabled: true, default_version: "8.30.1", supported_versions: ["8.30.1"] }
+  - { name: osv-scanner, description: "OSV dependency vulnerability scanner", default_enabled: true, default_version: "2.4.0", supported_versions: ["2.4.0"] }
+  - { name: syft, description: "Software bill of materials generator", default_enabled: true, default_version: "1.50.0", supported_versions: ["1.50.0"] }
+  - { name: grype, description: "Artifact and container vulnerability scanner", default_enabled: true, default_version: "0.116.1", supported_versions: ["0.116.1"] }
+  - { name: cosign, description: "Sigstore artifact signing and verification CLI", default_enabled: true, default_version: "3.1.2", supported_versions: ["3.1.2"] }
+
+builder: |
+  FROM debian:trixie-slim AS supply-chain-builder
+  RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl tar && rm -rf /var/lib/apt/lists/*
+  RUN mkdir -p /build/bin
+  {% if tools.gitleaks.enabled %}
+  RUN ARCH="$(dpkg --print-architecture)" && case "$ARCH" in amd64) ASSET_ARCH=x64 ;; arm64) ASSET_ARCH=arm64 ;; *) exit 1 ;; esac && \
+      FILE="gitleaks_{{ tools.gitleaks.version }}_linux_${ASSET_ARCH}.tar.gz" && \
+      BASE="https://github.com/gitleaks/gitleaks/releases/download/v{{ tools.gitleaks.version }}" && \
+      curl -fsSL "$BASE/$FILE" -o "/tmp/$FILE" && curl -fsSL "$BASE/gitleaks_{{ tools.gitleaks.version }}_checksums.txt" -o /tmp/checksums && \
+      (cd /tmp && grep "  $FILE$" checksums | sha256sum -c -) && tar -xzf "/tmp/$FILE" -C /build/bin gitleaks
+  {% endif %}
+  {% if tools["osv-scanner"].enabled %}
+  RUN ARCH="$(dpkg --print-architecture)" && FILE="osv-scanner_linux_${ARCH}" && BASE="https://github.com/google/osv-scanner/releases/download/v{{ tools["osv-scanner"].version }}" && \
+      curl -fsSL "$BASE/$FILE" -o "/build/bin/osv-scanner" && curl -fsSL "$BASE/osv-scanner_SHA256SUMS" -o /tmp/checksums && \
+      (cd /build/bin && grep "  $FILE$" /tmp/checksums | sed "s/$FILE/osv-scanner/" | sha256sum -c -) && chmod +x /build/bin/osv-scanner
+  {% endif %}
+  {% if tools.syft.enabled %}
+  RUN ARCH="$(dpkg --print-architecture)" && FILE="syft_{{ tools.syft.version }}_linux_${ARCH}.tar.gz" && BASE="https://github.com/anchore/syft/releases/download/v{{ tools.syft.version }}" && \
+      curl -fsSL "$BASE/$FILE" -o "/tmp/$FILE" && curl -fsSL "$BASE/syft_{{ tools.syft.version }}_checksums.txt" -o /tmp/checksums && \
+      (cd /tmp && grep "  $FILE$" checksums | sha256sum -c -) && tar -xzf "/tmp/$FILE" -C /build/bin syft
+  {% endif %}
+  {% if tools.grype.enabled %}
+  RUN ARCH="$(dpkg --print-architecture)" && FILE="grype_{{ tools.grype.version }}_linux_${ARCH}.tar.gz" && BASE="https://github.com/anchore/grype/releases/download/v{{ tools.grype.version }}" && \
+      curl -fsSL "$BASE/$FILE" -o "/tmp/$FILE" && curl -fsSL "$BASE/grype_{{ tools.grype.version }}_checksums.txt" -o /tmp/checksums && \
+      (cd /tmp && grep "  $FILE$" checksums | sha256sum -c -) && tar -xzf "/tmp/$FILE" -C /build/bin grype
+  {% endif %}
+  {% if tools.cosign.enabled %}
+  RUN ARCH="$(dpkg --print-architecture)" && FILE="cosign-linux-${ARCH}" && BASE="https://github.com/sigstore/cosign/releases/download/v{{ tools.cosign.version }}" && \
+      curl -fsSL "$BASE/$FILE" -o /build/bin/cosign && curl -fsSL "$BASE/cosign_checksums.txt" -o /tmp/checksums && \
+      (cd /build/bin && grep "  $FILE$" /tmp/checksums | sed "s/$FILE/cosign/" | sha256sum -c -) && chmod +x /build/bin/cosign
+  {% endif %}
+
+runtime: |
+  # Addon: supply-chain (runtime)
+  {% for tool in ["gitleaks", "osv-scanner", "syft", "grype", "cosign"] %}
+  {% if tools[tool].enabled %}
+  COPY --from=supply-chain-builder /build/bin/{{ tool }} /usr/local/bin/{{ tool }}
+  {% else %}
+  RUN rm -f /usr/local/bin/{{ tool }}
+  {% endif %}
+  {% endfor %}

--- a/cli/src/addon_cmd.rs
+++ b/cli/src/addon_cmd.rs
@@ -286,6 +286,7 @@ pub fn cmd_addon_info(name: &str, format: OutputFormat) -> Result<()> {
                 description: &'a str,
                 addon_version: &'a str,
                 requires: &'a [String],
+                groups: &'a std::collections::HashMap<String, String>,
                 profile_intent: Option<&'static str>,
                 usage_class: Option<&'static str>,
                 profiles: Vec<&'static str>,
@@ -298,6 +299,7 @@ pub fn cmd_addon_info(name: &str, format: OutputFormat) -> Result<()> {
                 description: &loaded.description,
                 addon_version: &loaded.addon_version,
                 requires: &loaded.requires,
+                groups: &loaded.groups,
                 profile_intent: loaded.profile_intent.map(|v| v.as_str()),
                 usage_class: loaded.usage_class.map(|v| v.as_str()),
                 profiles: loaded.profiles.iter().map(|p| p.as_str()).collect(),
@@ -350,6 +352,18 @@ pub fn cmd_addon_info(name: &str, format: OutputFormat) -> Result<()> {
             }
             if !loaded.requires.is_empty() {
                 println!("Requires:     {}", loaded.requires.join(", "));
+            }
+            if !loaded.groups.is_empty() {
+                let mut groups: Vec<_> = loaded.groups.iter().collect();
+                groups.sort_by_key(|(name, _)| *name);
+                println!(
+                    "Groups:       {}",
+                    groups
+                        .into_iter()
+                        .map(|(name, target)| format!("{name} -> {target}"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
             }
             println!();
 

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -48,6 +48,10 @@ pub struct AddonYaml {
     pub tools: Vec<ToolYaml>,
     #[serde(default)]
     pub requires: Vec<String>,
+    /// Nested configuration aliases exposed below `[addons.<language>]`.
+    /// Values are canonical addon names, e.g. `supply-chain: supply-chain`.
+    #[serde(default)]
+    pub groups: HashMap<String, String>,
     /// Tolerated for backwards-compat with addon YAML files that still
     /// declare a `skills:` block. Ignored since v0.16.0 — skills are
     /// owned by processkit and installed via the content-source pipeline.
@@ -194,6 +198,7 @@ pub struct LoadedAddon {
     pub builder_weight: Option<String>,
     pub tools: Vec<LoadedTool>,
     pub requires: Vec<String>,
+    pub groups: HashMap<String, String>,
     pub builder_template: Option<String>,
     pub runtime_template: Option<String>,
 }
@@ -226,6 +231,7 @@ pub struct AddonCatalogEntry {
     pub profiles: Vec<String>,
     pub exported_surfaces: Vec<String>,
     pub requires: Vec<String>,
+    pub groups: HashMap<String, String>,
     pub tools: Vec<AddonCatalogTool>,
 }
 
@@ -358,6 +364,7 @@ fn load_yaml_file(path: &Path) -> Result<LoadedAddon> {
         category,
         builder_weight: yaml.builder_weight,
         requires: yaml.requires,
+        groups: yaml.groups,
         tools: yaml
             .tools
             .into_iter()
@@ -425,6 +432,7 @@ pub fn addon_catalog_index(addons: &[LoadedAddon]) -> AddonCatalogIndex {
                 .map(|surface| surface.as_str().to_string())
                 .collect(),
             requires: addon.requires.clone(),
+            groups: addon.groups.clone(),
             tools: addon
                 .tools
                 .iter()
@@ -734,6 +742,49 @@ runtime: |
     }
 
     #[test]
+    fn load_addon_with_language_groups() {
+        let addon = load_repo_addon("go");
+        assert_eq!(
+            addon.groups.get("quality").map(String::as_str),
+            Some("go-quality")
+        );
+        assert_eq!(
+            addon.groups.get("supply-chain").map(String::as_str),
+            Some("supply-chain")
+        );
+        assert_eq!(
+            addon.groups.get("release").map(String::as_str),
+            Some("go-release")
+        );
+    }
+
+    #[test]
+    fn every_language_exposes_consistent_shared_groups() {
+        for language in ["go", "rust", "python", "node", "typst", "latex"] {
+            let addon = load_repo_addon(language);
+            assert_eq!(
+                addon.groups.get("infrastructure").map(String::as_str),
+                Some("infrastructure"),
+                "{language} infrastructure group"
+            );
+            assert_eq!(
+                addon.groups.get("security").map(String::as_str),
+                Some("supply-chain"),
+                "{language} security group"
+            );
+            assert_eq!(
+                addon.groups.get("supply-chain").map(String::as_str),
+                Some("supply-chain"),
+                "{language} supply-chain group"
+            );
+            assert!(
+                addon.groups.contains_key("release"),
+                "{language} release group"
+            );
+        }
+    }
+
+    #[test]
     fn render_runtime_substitutes_versions() {
         let addon = LoadedAddon {
             name: "test".to_string(),
@@ -753,6 +804,7 @@ runtime: |
                 default_version: "3.0".to_string(),
                 supported_versions: vec!["3.0".to_string()],
             }],
+            groups: HashMap::new(),
             builder_template: None,
             runtime_template: Some("RUN install mytool={{ tools.mytool.version }}".to_string()),
         };
@@ -799,6 +851,7 @@ runtime: |
                     supported_versions: vec![],
                 },
             ],
+            groups: HashMap::new(),
             builder_template: None,
             runtime_template: Some(
                 "RUN install required\n\
@@ -836,6 +889,7 @@ runtime: |
             builder_weight: Some("heavy".to_string()),
             tools: vec![],
             requires: vec![],
+            groups: HashMap::new(),
             builder_template: Some("FROM debian".to_string()),
             runtime_template: None,
         };
@@ -851,6 +905,7 @@ runtime: |
             builder_weight: Some("medium".to_string()),
             tools: vec![],
             requires: vec![],
+            groups: HashMap::new(),
             builder_template: Some("FROM debian".to_string()),
             runtime_template: None,
         };
@@ -866,6 +921,7 @@ runtime: |
             builder_weight: None,
             tools: vec![],
             requires: vec![],
+            groups: HashMap::new(),
             builder_template: None,
             runtime_template: None,
         };
@@ -906,6 +962,7 @@ runtime: |
                 default_version: "1.0".to_string(),
                 supported_versions: vec![],
             }],
+            groups: HashMap::new(),
             builder_template: None,
             runtime_template: Some(
                 "{% if tools.mytool.version %}RUN install mytool={{ tools.mytool.version }}{% else %}RUN install mytool{% endif %}"
@@ -1015,6 +1072,7 @@ runtime: |
                 builder_weight: None,
                 tools: vec![],
                 requires: vec![],
+                groups: HashMap::new(),
                 builder_template: None,
                 runtime_template: None,
             },
@@ -1030,6 +1088,7 @@ runtime: |
                 builder_weight: None,
                 tools: vec![],
                 requires: vec![],
+                groups: HashMap::new(),
                 builder_template: None,
                 runtime_template: None,
             },
@@ -1067,6 +1126,7 @@ runtime: |
                 builder_weight: None,
                 tools: vec![],
                 requires: vec![],
+                groups: HashMap::new(),
                 builder_template: None,
                 runtime_template: None,
             },
@@ -1082,6 +1142,7 @@ runtime: |
                 builder_weight: None,
                 tools: vec![],
                 requires: vec![],
+                groups: HashMap::new(),
                 builder_template: None,
                 runtime_template: None,
             },
@@ -1123,6 +1184,7 @@ runtime: |
                     supported_versions: vec!["2.0".to_string()],
                 }],
                 requires: vec!["base".to_string()],
+                groups: HashMap::new(),
                 builder_template: None,
                 runtime_template: None,
             },
@@ -1138,6 +1200,7 @@ runtime: |
                 builder_weight: None,
                 tools: vec![],
                 requires: vec![],
+                groups: HashMap::new(),
                 builder_template: None,
                 runtime_template: None,
             },
@@ -1211,6 +1274,30 @@ runtime: |
             missing.is_empty(),
             "addon tools must describe their purpose for generated aibox.toml comments: {missing:?}"
         );
+    }
+
+    #[test]
+    fn production_tool_addons_render_enabled_and_disabled_paths() {
+        for name in ["go-quality", "supply-chain", "release", "go-release"] {
+            let addon = load_repo_addon(name);
+            let enabled = all_enabled_tools(&addon);
+            if addon.builder_template.is_some() {
+                let rendered = render_builder(&addon, &enabled).unwrap().unwrap();
+                assert!(!rendered.trim().is_empty(), "{name} builder must render");
+            }
+            let rendered = render_runtime(&addon, &enabled).unwrap();
+            assert!(!rendered.trim().is_empty(), "{name} runtime must render");
+
+            let disabled = render_runtime(&addon, &all_disabled_tools(&addon)).unwrap();
+            for tool in &addon.tools {
+                assert!(
+                    disabled.contains(&format!("rm -f /usr/local/bin/{}", tool.name))
+                        || disabled.contains(&format!("rm -f /usr/local/bin/{} ", tool.name)),
+                    "{name}.{} must purge its disabled binary: {disabled}",
+                    tool.name
+                );
+            }
+        }
     }
 
     fn all_disabled_tools(addon: &LoadedAddon) -> HashMap<String, ToolConfig> {

--- a/cli/src/addons.rs
+++ b/cli/src/addons.rs
@@ -395,6 +395,7 @@ mod tests {
             "nonexistent-addon".to_string(),
             crate::config::AddonToolsSection {
                 tools: HashMap::new(),
+                ..Default::default()
             },
         );
         let addons = AddonsSection { addons: addons_map };

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1098,6 +1098,9 @@ pub struct ToolEntry {
 pub struct AddonToolsSection {
     #[serde(default)]
     pub tools: HashMap<String, ToolEntry>,
+    /// Language-scoped group selections such as `[addons.go.supply-chain]`.
+    #[serde(flatten)]
+    pub groups: HashMap<String, AddonToolsSection>,
 }
 
 /// [addons] section — each key is an addon name mapping to its tools table.
@@ -3740,6 +3743,7 @@ impl AiboxConfig {
             .with_context(|| format!("Failed to parse config file: {}", path.display()))?;
         config.migrate_legacy_sections();
         config.resolve_ai_provider_addons();
+        config.resolve_addon_groups();
         config.validate()?;
         Ok(config)
     }
@@ -3966,6 +3970,7 @@ impl AiboxConfig {
             toml::from_str(toml_str).context("Failed to parse TOML config")?;
         config.migrate_legacy_sections();
         config.resolve_ai_provider_addons();
+        config.resolve_addon_groups();
         config.validate()?;
         Ok(config)
     }
@@ -4765,6 +4770,46 @@ impl AiboxConfig {
                 }
                 bail!(message);
             }
+            for (group_name, group_tools) in &addon_tools.groups {
+                let Some(target_name) = addon.groups.get(group_name) else {
+                    bail!(
+                        "unknown group '{}' in [addons.{}]; '{}' supports: {}",
+                        group_name,
+                        addon_name,
+                        addon_name,
+                        addon
+                            .groups
+                            .keys()
+                            .cloned()
+                            .collect::<BTreeSet<_>>()
+                            .into_iter()
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                };
+                let target = crate::addon_loader::get_addon(target_name).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "addon '{}' group '{}' references unknown addon '{}'",
+                        addon_name,
+                        group_name,
+                        target_name
+                    )
+                })?;
+                let target_tools: BTreeSet<&str> =
+                    target.tools.iter().map(|tool| tool.name.as_str()).collect();
+                for tool_name in group_tools.tools.keys() {
+                    if !target_tools.contains(tool_name.as_str()) {
+                        bail!(
+                            "unknown tool '{}' in [addons.{}.{}.tools]; '{}' supports: {}",
+                            tool_name,
+                            addon_name,
+                            group_name,
+                            target_name,
+                            target_tools.iter().copied().collect::<Vec<_>>().join(", ")
+                        );
+                    }
+                }
+            }
         }
 
         Ok(())
@@ -4949,6 +4994,7 @@ impl AiboxConfig {
                     .entry(addon_name)
                     .or_insert_with(|| AddonToolsSection {
                         tools: HashMap::new(),
+                        groups: HashMap::new(),
                     });
             if let Some(version) = self.ai.harness_version(harness) {
                 addon_tools
@@ -4967,7 +5013,41 @@ impl AiboxConfig {
                 .entry("audio-voice".to_string())
                 .or_insert_with(|| AddonToolsSection {
                     tools: HashMap::new(),
+                    groups: HashMap::new(),
                 });
+        }
+    }
+
+    /// Expand `[addons.<language>.<group>]` aliases into canonical addons.
+    /// Existing flat selections remain authoritative; nested tool entries are
+    /// merged without overwriting explicitly configured flat overrides.
+    pub fn resolve_addon_groups(&mut self) {
+        let selected: Vec<(String, HashMap<String, AddonToolsSection>)> = self
+            .addons
+            .addons
+            .iter()
+            .map(|(name, section)| (name.clone(), section.groups.clone()))
+            .collect();
+
+        let mut expanded_targets = Vec::new();
+        for (parent_name, groups) in selected {
+            let Some(parent) = crate::addon_loader::get_addon(&parent_name) else {
+                continue;
+            };
+            for (group_name, group_section) in groups {
+                let Some(target_name) = parent.groups.get(&group_name) else {
+                    continue;
+                };
+                let target = self.addons.addons.entry(target_name.clone()).or_default();
+                for (tool, entry) in group_section.tools {
+                    target.tools.entry(tool).or_insert(entry);
+                }
+                expanded_targets.push(target_name.clone());
+            }
+        }
+
+        for addon_name in crate::container::expand_addon_requires(&expanded_targets) {
+            self.addons.addons.entry(addon_name).or_default();
         }
     }
 
@@ -5237,12 +5317,14 @@ fn check_addons_table(root: &toml::map::Map<String, toml::Value>, mismatches: &m
         let Some(addon_table) = addon_value.as_table() else {
             continue;
         };
-        check_unknown_keys(
-            &format!("[addons.{addon_name}]"),
-            addon_table,
-            &["tools"],
-            mismatches,
-        );
+        let known_groups = crate::addon_loader::get_addon(addon_name)
+            .map(|addon| addon.groups.keys().cloned().collect::<BTreeSet<_>>())
+            .unwrap_or_default();
+        for key in addon_table.keys() {
+            if key != "tools" && !known_groups.contains(key) {
+                mismatches.push(format!("[addons.{addon_name}]: unknown key `{key}`"));
+            }
+        }
         let Some(tools) = table_child(addon_table, "tools") else {
             continue;
         };
@@ -5256,6 +5338,30 @@ fn check_addons_table(root: &toml::map::Map<String, toml::Value>, mismatches: &m
                 &["version", "enabled"],
                 mismatches,
             );
+        }
+        for group_name in known_groups {
+            let Some(group) = table_child(addon_table, &group_name) else {
+                continue;
+            };
+            check_unknown_keys(
+                &format!("[addons.{addon_name}.{group_name}]"),
+                group,
+                &["tools"],
+                mismatches,
+            );
+            let Some(group_tools) = table_child(group, "tools") else {
+                continue;
+            };
+            for (tool_name, tool_value) in group_tools {
+                if let Some(tool_table) = tool_value.as_table() {
+                    check_unknown_keys(
+                        &format!("[addons.{addon_name}.{group_name}.tools.{tool_name}]"),
+                        tool_table,
+                        &["version", "enabled"],
+                        mismatches,
+                    );
+                }
+            }
         }
     }
 }

--- a/cli/src/container.rs
+++ b/cli/src/container.rs
@@ -628,7 +628,10 @@ fn populate_addon_tools(
     let Some(loaded) = crate::addon_loader::get_addon(addon_name) else {
         // Unknown addon — caller will surface this elsewhere; we just
         // return an empty section so the rest of init can proceed.
-        return Ok(AddonToolsSection { tools });
+        return Ok(AddonToolsSection {
+            tools,
+            ..Default::default()
+        });
     };
 
     for tool in &loaded.tools {
@@ -696,7 +699,10 @@ fn populate_addon_tools(
         );
     }
 
-    Ok(AddonToolsSection { tools })
+    Ok(AddonToolsSection {
+        tools,
+        ..Default::default()
+    })
 }
 
 /// Determine the default project name from the current directory.
@@ -4465,6 +4471,7 @@ mod tests {
                 )]
                 .into_iter()
                 .collect(),
+                ..Default::default()
             },
         );
 

--- a/cli/src/generate.rs
+++ b/cli/src/generate.rs
@@ -819,6 +819,7 @@ mod tests {
                 name.to_string(),
                 AddonToolsSection {
                     tools: HashMap::new(),
+                    ..Default::default()
                 },
             );
         }

--- a/cli/src/lock.rs
+++ b/cli/src/lock.rs
@@ -998,7 +998,10 @@ kubectl = "v1.30.0"
         let mut addons_map = HashMap::new();
         addons_map.insert(
             "kubernetes".to_string(),
-            AddonToolsSection { tools: k8s_tools },
+            AddonToolsSection {
+                tools: k8s_tools,
+                ..Default::default()
+            },
         );
         let addons = AddonsSection { addons: addons_map };
 

--- a/cli/src/provider_backend.rs
+++ b/cli/src/provider_backend.rs
@@ -224,6 +224,7 @@ mod tests {
             exported_surfaces: vec![AddonExportSurface::CliBinary],
             builder_weight: None,
             tools: Vec::new(),
+            groups: Default::default(),
             builder_template: None,
             runtime_template: None,
         }

--- a/cli/src/seed.rs
+++ b/cli/src/seed.rs
@@ -2302,10 +2302,13 @@ mod tests {
                 enabled: Some(true),
             },
         );
-        config
-            .addons
-            .addons
-            .insert("git-ui".to_string(), AddonToolsSection { tools });
+        config.addons.addons.insert(
+            "git-ui".to_string(),
+            AddonToolsSection {
+                tools,
+                ..Default::default()
+            },
+        );
 
         seed_root_dir(&config).unwrap();
 
@@ -2748,10 +2751,13 @@ mod tests {
                 enabled: Some(false),
             },
         );
-        config
-            .addons
-            .addons
-            .insert("git-ui".to_string(), AddonToolsSection { tools });
+        config.addons.addons.insert(
+            "git-ui".to_string(),
+            AddonToolsSection {
+                tools,
+                ..Default::default()
+            },
+        );
 
         let files = managed_runtime_files(&config);
         let generated_layouts: Vec<_> = files
@@ -2801,10 +2807,13 @@ mod tests {
                 enabled: None,
             },
         );
-        config
-            .addons
-            .addons
-            .insert("git-ui".to_string(), AddonToolsSection { tools });
+        config.addons.addons.insert(
+            "git-ui".to_string(),
+            AddonToolsSection {
+                tools,
+                ..Default::default()
+            },
+        );
 
         let files = managed_runtime_files(&config);
         let git_config = files

--- a/cli/tests/e2e/addon.rs
+++ b/cli/tests/e2e/addon.rs
@@ -130,11 +130,14 @@ fn download_based_addons_build_with_published_defaults() {
         "docs-hugo",
         "docs-mdbook",
         "go",
+        "go-quality",
+        "go-release",
         "infrastructure",
         "kubernetes",
         "node",
         "preview-archive",
         "rust",
+        "supply-chain",
         "typst",
     ] {
         args.extend(["--addon", addon]);

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -339,6 +339,74 @@ lazygit = { enabled = false }
 }
 
 #[test]
+fn nested_go_groups_expand_render_and_honor_tool_disablement() {
+    let dir = tempfile::tempdir().unwrap();
+    let installed_addons = install_script_addons_dir();
+    std::fs::write(
+        dir.path().join("aibox.toml"),
+        r#"[aibox]
+version = "0.29.0"
+base = "debian"
+
+[container]
+name = "nested-go-groups"
+
+[processkit]
+version = "unset"
+
+[addons.go]
+
+[addons.go.quality.tools]
+staticcheck = { enabled = false }
+
+[addons.go.supply-chain.tools]
+grype = { enabled = false }
+
+[addons.go.release]
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(aibox_bin())
+        .args(["apply", "--no-container"])
+        .current_dir(dir.path())
+        .env("AIBOX_ADDONS_DIR", installed_addons.path())
+        .output()
+        .expect("failed to execute aibox apply");
+    assert!(
+        output.status.success(),
+        "nested Go groups should apply successfully\nstderr:\n{}\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let dockerfile = std::fs::read_to_string(dir.path().join(".devcontainer/Dockerfile")).unwrap();
+    for marker in [
+        "Addon: go (runtime)",
+        "Addon: go-quality (runtime)",
+        "Addon: supply-chain (runtime)",
+        "Addon: release (runtime)",
+        "Addon: go-release (runtime)",
+        "go test -race ./...",
+        "go install golang.org/x/tools/cmd/goimports@v0.48.0",
+        "goreleaser_Linux_",
+    ] {
+        assert!(
+            dockerfile.contains(marker),
+            "missing {marker}:\n{dockerfile}"
+        );
+    }
+    assert!(dockerfile.contains("rm -f /usr/local/bin/staticcheck"));
+    assert!(dockerfile.contains("rm -f /usr/local/bin/grype"));
+    assert!(!dockerfile.contains("go install honnef.co/go/tools/cmd/staticcheck"));
+    assert!(!dockerfile.contains("COPY --from=supply-chain-builder /build/bin/grype"));
+    let persisted = std::fs::read_to_string(dir.path().join("aibox.toml")).unwrap();
+    assert!(persisted.contains("[addons.go.quality.tools]"));
+    assert!(persisted.contains("[addons.go.supply-chain.tools]"));
+    assert!(persisted.contains("[addons.go.release]"));
+}
+
+#[test]
 fn init_help_exits_zero() {
     let output = run(&["init", "--help"]);
     assert!(output.status.success(), "aibox init --help should exit 0");
@@ -828,6 +896,14 @@ fn describe_addon_catalog_json_contract() {
             .iter()
             .any(|tool| tool["name"] == "python")
     );
+
+    let go = addons
+        .iter()
+        .find(|addon| addon["name"] == "go")
+        .expect("catalog should include go addon");
+    assert_eq!(go["groups"]["quality"], "go-quality");
+    assert_eq!(go["groups"]["supply-chain"], "supply-chain");
+    assert_eq!(go["groups"]["release"], "go-release");
 }
 
 #[test]

--- a/context/logs/2026/08/LOG-20260805_1647-CoolStream-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260805_1647-CoolStream-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260805_1647-CoolStream-workitem-transitioned
+  created: '2026-08-05T16:47:09+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-05T16:47:09+00:00'
+  summary: Transitioned WorkItem 'BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+  subject_kind: WorkItem
+  actor: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+---

--- a/context/logs/2026/08/LOG-20260805_1647-TenderQuail-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260805_1647-TenderQuail-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260805_1647-TenderQuail-workitem-created
+  created: '2026-08-05T16:47:05+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-05T16:47:05+00:00'
+  summary: 'Created WorkItem ''BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality'':
+    ''Implement v0.x language-scoped addon groups and production Go toolchain'''
+  subject: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+  subject_kind: WorkItem
+  actor: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+---

--- a/context/logs/2026/08/LOG-20260805_1839-EagerBlossom-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260805_1839-EagerBlossom-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260805_1839-EagerBlossom-workitem-transitioned
+  created: '2026-08-05T18:39:15+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-05T18:39:15+00:00'
+  summary: Transitioned WorkItem 'BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality'
+    from 'in-progress' to 'review'
+  subject: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+  subject_kind: WorkItem
+  actor: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+---

--- a/context/logs/2026/08/LOG-20260805_1839-HonestBridge-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260805_1839-HonestBridge-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260805_1839-HonestBridge-workitem-transitioned
+  created: '2026-08-05T18:39:19+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-05T18:39:19+00:00'
+  summary: Transitioned WorkItem 'BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality'
+    from 'review' to 'done'
+  subject: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+  subject_kind: WorkItem
+  actor: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+---

--- a/context/logs/2026/08/LOG-20260805_1839-KeenMoon-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260805_1839-KeenMoon-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260805_1839-KeenMoon-workitem-archive-moved
+  created: '2026-08-05T18:39:19+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-05T18:39:19+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality'
+    to /workspace/context/workitems/done/2026/08/BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality.md
+  subject: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+  subject_kind: WorkItem
+  actor: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality.md
+---

--- a/context/workitems/done/2026/08/BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality.md
+++ b/context/workitems/done/2026/08/BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality.md
@@ -1,0 +1,32 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260805_1647-SoundTower-v0x-language-addon-groups-go-quality
+  created: '2026-08-05T16:47:05+00:00'
+  updated: '2026-08-05T18:39:19+00:00'
+spec:
+  title: Implement v0.x language-scoped addon groups and production Go toolchain
+  state: done
+  type: story
+  priority: high
+  description: 'Implement GitHub issue #337: consistent nested language-scoped addon
+    groups, Go quality tooling, reusable supply-chain and release tools, verified
+    installation/removal, documentation, and test coverage on the v0.x line.'
+  started_at: '2026-08-05T16:47:09+00:00'
+  completed_at: '2026-08-05T18:39:19+00:00'
+---
+
+## Transition note (2026-08-05T16:47:09+00:00)
+
+Implementation started from GitHub issue #337 on v0.x-release.
+
+
+## Transition note (2026-08-05T18:39:15+00:00)
+
+Issue #337 implementation complete; unit, integration, clippy, docs, and focused Tier 2 companion build pass.
+
+
+## Transition note (2026-08-05T18:39:19+00:00)
+
+Acceptance verified: nested group config, pinned/checksummed production tools, enable/disable behavior, docs, and real companion image build all pass; pk-doctor clean.

--- a/docs-site/content/docs/addons/language-runtimes.md
+++ b/docs-site/content/docs/addons/language-runtimes.md
@@ -51,6 +51,34 @@ go = { version = "1.26.5" }     # 1.25, 1.26, 1.26.3, 1.26.4, 1.26.5
 
 Installs Go and sets up GOPATH.
 
+### Production Go groups
+
+Go projects can compose production tooling without bloating the base runtime:
+
+```toml
+[addons.go]
+
+[addons.go.infrastructure]
+
+[addons.go.quality.tools]
+staticcheck = { enabled = false } # optional per-tool override
+
+[addons.go.supply-chain]
+
+[addons.go.release]
+```
+
+`quality` installs `goimports`, `staticcheck`, `golangci-lint`,
+`govulncheck`, and `gosec`, plus the Linux compiler and libc headers required
+by `go test -race ./...`. `supply-chain` adds `gitleaks`, `osv-scanner`,
+`syft`, `grype`, and `cosign`. `release` adds GoReleaser, ShellCheck, and
+Hadolint. The built-in `gofmt`, `go vet`, `go test`, fuzzing, and coverage
+commands remain part of the Go toolchain and need no extra binary.
+
+The same `infrastructure`, `security`/`supply-chain`, and `release` group names
+are accepted below every language addon. Go additionally exposes `quality`
+and its `lint` alias.
+
 ## Typst
 
 ```toml

--- a/docs-site/content/docs/addons/overview.md
+++ b/docs-site/content/docs/addons/overview.md
@@ -5,7 +5,7 @@ title: "Overview"
 
 # Addons
 
-aibox uses the Debian runtime image family (`base-debian-v0.26.x` for legacy releases, `base-debian-runtime-v0.27.0+` after the image-tag cutover) with **31 composable addons** that install language runtimes, tool bundles, documentation frameworks, and AI coding agents into your container.
+aibox uses the Debian runtime image family (`base-debian-v0.26.x` for legacy releases, `base-debian-runtime-v0.27.0+` after the image-tag cutover) with **35 composable addons** that install language runtimes, tool bundles, documentation frameworks, and AI coding agents into your container.
 
 ## Managing Addons
 
@@ -47,6 +47,13 @@ pnpm = { version = "11.18.0" }
 
 Each addon has **default-enabled tools** that are included automatically, and **optional tools** you can enable explicitly. Tools with version selection let you pick from curated, tested versions.
 
+Language addons also expose composable nested groups. For example,
+`[addons.go.quality]`, `[addons.go.supply-chain]`, and
+`[addons.go.release]` select the canonical `go-quality`, `supply-chain`, and
+`go-release` recipes and expand their dependencies automatically. Nested
+`[addons.<language>.<group>.tools]` entries use the same `version` and
+`enabled` overrides as flat addons.
+
 `aibox describe addon-catalog -o json` emits the stable `aibox.addon-catalog.v0`
 index used by downstream automation. It includes each addon's profile intent,
 automation usage class, supported aibox profiles, exported surfaces,
@@ -65,6 +72,7 @@ After editing `aibox.toml`, run `aibox apply` to regenerate the Dockerfile and r
 | `rust` | rustc (1.90/1.91/1.92/1.93/1.94/1.94.1/1.96.0/1.96.1/1.97.1), clippy, rustfmt | — |
 | `node` | node (20/22/24/26), pnpm (9/10/11.1.3/11.5.2/11.10.0/11.18.0) | yarn (4/4.16.0/4.17.0), bun (1.2/1.3.14) |
 | `go` | go (1.25/1.26/1.26.3/1.26.4/1.26.5) | — |
+| `go-quality` | goimports, staticcheck, golangci-lint, govulncheck, gosec | — |
 | `typst` | typst (0.13.1/0.14.2/0.15.0) | — |
 | `latex` | texlive-core, texlive-recommended, texlive-fonts, biber, texlive-code, texlive-diagrams, texlive-math | texlive-music, texlive-chemistry |
 
@@ -73,6 +81,9 @@ After editing `aibox.toml`, run `aibox apply` to regenerate the Dockerfile and r
 | Addon | Default Tools | Optional Tools |
 |-------|--------------|----------------|
 | `infrastructure` | opentofu, ansible, packer | — |
+| `supply-chain` | gitleaks, osv-scanner, syft, grype, cosign | — |
+| `release` | shellcheck, hadolint | — |
+| `go-release` | goreleaser (requires `go` and `release`) | — |
 | `git-ui` | gh, lazygit | — |
 | `preview-archive` | chafa, librsvg, poppler, timg, mupdf, entr, p7zip, resvg | — |
 | `preview-enhanced` | rich, ffmpeg, ghostscript | — |

--- a/docs-site/content/docs/addons/tool-bundles.md
+++ b/docs-site/content/docs/addons/tool-bundles.md
@@ -7,6 +7,33 @@ title: "Tool Bundles"
 
 Tool bundles install infrastructure, orchestration, and cloud CLI tools.
 
+## Supply Chain
+
+```toml
+[addons.supply-chain.tools]
+gitleaks = {}
+osv-scanner = {}
+syft = {}
+grype = {}
+cosign = {}
+```
+
+This language-neutral bundle covers secret scanning, dependency and artifact
+vulnerability checks, SBOM generation, and Sigstore signing. Release archives
+are pinned and checked against upstream-published checksums.
+
+## Release Validation
+
+```toml
+[addons.release.tools]
+shellcheck = {}
+hadolint = {}
+```
+
+The language-neutral `release` bundle validates shell scripts and Dockerfiles.
+Go projects should normally select `[addons.go.release]`, which composes this
+bundle with the `go-release` recipe and GoReleaser.
+
 ## Git UI
 
 ```toml

--- a/docs-site/content/docs/reference/configuration.md
+++ b/docs-site/content/docs/reference/configuration.md
@@ -463,6 +463,28 @@ not required for every generated project.
 
 Run `aibox get addon` to see all available addons, or `aibox describe addon <name>` for tool details and supported versions. See the [Addons page](../addons/overview.md) for full documentation.
 
+Language-scoped groups compose shared tooling and automatically expand their
+dependencies:
+
+```toml
+[addons.go]
+[addons.go.infrastructure]
+[addons.go.quality]
+[addons.go.supply-chain]
+[addons.go.release]
+
+[addons.go.quality.tools]
+staticcheck = { enabled = false }
+golangci-lint = { version = "v2.12.2" }
+```
+
+Every language addon supports `infrastructure`, `security`/`supply-chain`, and
+`release`; Go also supports `quality` and `lint`. Existing flat selections such
+as `[addons.infrastructure.tools]` and `[addons.supply-chain.tools]` remain
+valid and require no migration. To adopt language scoping, move only the table
+prefix—for example, `[addons.supply-chain.tools]` becomes
+`[addons.go.supply-chain.tools]`; tool entries and overrides are unchanged.
+
 ### [skills]
 
 Controls which skills from processkit are installed into `context/skills/`.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -223,9 +223,13 @@ main() {
     languages/rust.yaml
     languages/node.yaml
     languages/go.yaml
+    languages/go-quality.yaml
     languages/typst.yaml
     languages/latex.yaml
     tools/infrastructure.yaml
+    tools/supply-chain.yaml
+    tools/release.yaml
+    tools/go-release.yaml
     tools/kubernetes.yaml
     tools/cloud-aws.yaml
     tools/cloud-gcp.yaml


### PR DESCRIPTION
Implements #337 for the v0.x line. Adds nested language addon groups, pinned Go quality tooling, language-neutral supply-chain and release bundles, checksum verification, overrides, documentation, and Tier 2 coverage.\n\nValidation: full Rust tests, zero-warning Clippy, Hugo build, pk-doctor clean, and focused Tier 2 companion image build.