### PR TITLE
fix: make release validation retryable and faster

### DIFF
--- a/.devcontainer/Dockerfile.e2e
+++ b/.devcontainer/Dockerfile.e2e
@@ -93,6 +93,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Podman for rootless container operations
     podman \
     podman-compose \
+    # Rootless image layers use this when /dev/fuse is available. Podman
+    # automatically falls back to vfs when it is not, which keeps the nested
+    # companion usable on runtimes that do not expose FUSE.
+    fuse-overlayfs \
     aardvark-dns \
     nftables \
     # SSH server for remote test execution
@@ -197,10 +201,14 @@ RUN mkdir -p /home/testuser/.ssh && chmod 700 /home/testuser/.ssh \
     && chown -R testuser:testuser /home/testuser/.ssh
 
 # ── Podman rootless configuration ─────────────────────────────────────────────
-# Use vfs storage driver (works without FUSE/overlay inside containers)
+# Deliberately do not create storage.conf. In rootless mode Podman discovers
+# fuse-overlayfs and uses overlay storage when the enclosing runtime exposes
+# /dev/fuse; otherwise it safely selects vfs. Pinning driver = "vfs" here made
+# every large E2E image build copy full layers even on FUSE-capable hosts.
+#
+# The companion has no persistent Podman graphroot volume, so recreating it
+# after this image change gives Podman a fresh, correctly selected store.
 RUN mkdir -p /home/testuser/.config/containers \
-    && printf '[storage]\ndriver = "vfs"\n' \
-       > /home/testuser/.config/containers/storage.conf \
     && printf '[engine]\ncgroup_manager = "systemd"\n\n[containers]\nlog_driver = "k8s-file"\npids_limit = 8192\n' \
        > /home/testuser/.config/containers/containers.conf \
     && chown -R testuser:testuser /home/testuser/.config
@@ -225,7 +233,7 @@ RUN mkdir -p /opt/aibox/addons && chown -R testuser:testuser /opt/aibox
 # Compose label or environment-only setting: SSH readiness checks can verify it
 # after a rebuild and cannot be fooled by a stale service configuration.
 RUN install -d -m 0755 /usr/local/share/aibox \
-    && printf '%s\n' 'aibox-e2e-companion-contract=2' \
+    && printf '%s\n' 'aibox-e2e-companion-contract=3' \
        > /usr/local/share/aibox/e2e-companion-contract \
     && chmod 0444 /usr/local/share/aibox/e2e-companion-contract
 

--- a/aibox.toml
+++ b/aibox.toml
@@ -309,6 +309,14 @@ hugo = { enabled = true } # Fast Go-based static site generator; default off; op
 # [addons.go.tools]
 # go = {} # Go compiler, tooling, and module workflow; default on; options: {}, { enabled = true|false }, { version = "1.25.12" | "1.26.3" | "1.26.4" | "1.26.5" (default) or "latest" }
 
+# Languages/go-quality — Production Go formatting, linting, vulnerability, and security tools; requires go
+# [addons.go-quality.tools]
+# goimports = {} # Go import organizer and formatter; default on; options: {}, { enabled = true|false }, { version = "v0.48.0" (default) or "latest" }
+# staticcheck = {} # Advanced Go static analysis suite; default on; options: {}, { enabled = true|false }, { version = "v0.7.0" (default) or "latest" }
+# golangci-lint = {} # Fast aggregate Go linter runner; default on; options: {}, { enabled = true|false }, { version = "v2.12.2" (default) or "latest" }
+# govulncheck = {} # Official Go vulnerability analyzer; default on; options: {}, { enabled = true|false }, { version = "v1.6.0" (default) or "latest" }
+# gosec = {} # Go source security analyzer; default on; options: {}, { enabled = true|false }, { version = "v2.28.0" (default) or "latest" }
+
 # Languages/latex — TeX Live LaTeX typesetting system
 # [addons.latex.tools]
 # texlive-core = {} # Core LaTeX engines and basic TeX Live packages; default on; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
@@ -378,6 +386,10 @@ cargo-audit = {} # Rust dependency vulnerability scanner; default on; options: {
 gh = {} # GitHub CLI for issues, PRs, releases, and auth; default on; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
 lazygit = { enabled = true } # Interactive terminal UI for Git status, commits, and branches; default on; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
 
+# Tools/go-release — GoReleaser plus language-neutral release validation; requires go, release
+# [addons.go-release.tools]
+# goreleaser = {} # Multi-platform Go release packager; default on; options: {}, { enabled = true|false }, { version = "2.17.1" (default) or "latest" }
+
 # Tools/infrastructure — OpenTofu, Ansible, Packer
 # [addons.infrastructure.tools]
 # opentofu = {} # Open-source Terraform-compatible infrastructure as code CLI; default on; options: {}, { enabled = true|false }, { version = "1.9.0" | "1.12.0" | "1.12.1" | "1.12.3" | "1.12.5" (default) or "latest" }
@@ -407,6 +419,19 @@ p7zip = {} # Archive listing and extraction support for previews; default on; op
 # ffmpeg = { enabled = false } # Video and audio metadata plus thumbnail support for previews; default on; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
 # ghostscript = { enabled = false } # PostScript and EPS rendering support for document previews; default on; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
 rich = {} # Markdown, JSON, RST, and notebook terminal rendering for Yazi previews; default on; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
+
+# Tools/release — Language-neutral shell and container release validation
+# [addons.release.tools]
+# shellcheck = {} # Shell script static analyzer; default on; options: {}, { enabled = true|false }, { version = "0.11.0" (default) or "latest" }
+# hadolint = {} # Dockerfile linter; default on; options: {}, { enabled = true|false }, { version = "2.15.1" (default) or "latest" }
+
+# Tools/supply-chain — Secret scanning, vulnerability analysis, SBOM generation, and signing
+# [addons.supply-chain.tools]
+# gitleaks = {} # Repository secret scanner; default on; options: {}, { enabled = true|false }, { version = "8.30.1" (default) or "latest" }
+# osv-scanner = {} # OSV dependency vulnerability scanner; default on; options: {}, { enabled = true|false }, { version = "2.4.0" (default) or "latest" }
+# syft = {} # Software bill of materials generator; default on; options: {}, { enabled = true|false }, { version = "1.50.0" (default) or "latest" }
+# grype = {} # Artifact and container vulnerability scanner; default on; options: {}, { enabled = true|false }, { version = "0.116.1" (default) or "latest" }
+# cosign = {} # Sigstore artifact signing and verification CLI; default on; options: {}, { enabled = true|false }, { version = "3.1.2" (default) or "latest" }
 
 # =============================================================================
 # [ai] — AI agent harnesses and model providers
@@ -520,6 +545,11 @@ network    = "ask"
 # network    = "ask"
 
 # [ai.execution.hermes]
+# filesystem = "workspace-write"
+# approval   = "on-request"
+# network    = "ask"
+
+# [ai.execution.tau]
 # filesystem = "workspace-write"
 # approval   = "on-request"
 # network    = "ask"

--- a/cli/src/generate.rs
+++ b/cli/src/generate.rs
@@ -2014,7 +2014,7 @@ mod tests {
         let compose = include_str!("../../.devcontainer/docker-compose.override.yml");
 
         assert!(
-            dockerfile.contains("aibox-e2e-companion-contract=2")
+            dockerfile.contains("aibox-e2e-companion-contract=3")
                 && dockerfile.contains("CMD [\"/sbin/init\"]")
                 && dockerfile.contains("COPY --from=fetch-kubernetes-e2e /usr/local/bin/kind"),
             "E2E companion Dockerfile must declare its systemd/kind compatibility contract"
@@ -2024,6 +2024,17 @@ mod tests {
                 && compose.contains("cgroup: private")
                 && compose.contains("- /run/lock"),
             "E2E companion Compose service must provide the systemd/kind runtime contract"
+        );
+    }
+
+    #[test]
+    fn e2e_companion_prefers_fuse_overlay_without_forcing_a_storage_driver() {
+        let dockerfile = include_str!("../../.devcontainer/Dockerfile.e2e");
+
+        assert!(
+            dockerfile.contains("fuse-overlayfs")
+                && !dockerfile.contains("/home/testuser/.config/containers/storage.conf"),
+            "E2E companion must let rootless Podman select fuse-overlayfs when available and vfs otherwise"
         );
     }
 

--- a/cli/tests/e2e/addon.rs
+++ b/cli/tests/e2e/addon.rs
@@ -2,6 +2,8 @@
 //!
 //! Requires the e2e-runner companion container (feature = "e2e").
 
+use serial_test::serial;
+
 use super::runner::E2eRunner;
 
 #[test]
@@ -115,6 +117,9 @@ fn addon_rebuild_includes_tools_in_dockerfile() {
 }
 
 #[test]
+#[serial(companion_runtime)]
+#[ignore = "resource-heavy addon image build; run through scripts/run-e2e-shards.sh addon or all"]
+#[ntest::timeout(1_800_000)]
 fn download_based_addons_build_with_published_defaults() {
     let runner = E2eRunner::new();
     let test = "addon-download-smoke";

--- a/cli/tests/e2e/latex_preview.rs
+++ b/cli/tests/e2e/latex_preview.rs
@@ -8,7 +8,8 @@ const PREVIEW_PORT: u16 = 18765;
 
 #[test]
 #[serial(companion_runtime)]
-#[ntest::timeout(900_000)]
+#[ignore = "resource-heavy LaTeX image build; run through scripts/run-e2e-shards.sh latex or all"]
+#[ntest::timeout(1_800_000)]
 fn latex_watcher_builds_and_preview_sidecar_serves_updated_pdf() {
     let runner = E2eRunner::new();
     let test = "latex-watch-preview";

--- a/cli/tests/e2e/main.rs
+++ b/cli/tests/e2e/main.rs
@@ -2,7 +2,10 @@
 //!
 //! - Tier 1 (always run): appearance tests, config coverage tests
 //! - Tier 2 (--features e2e): lifecycle, reset, migration, addon, doctor, smoke,
-//!   generated runtime, and visual tests
+//!   generated runtime, and visual tests. The two resource-heavy image builds
+//!   are intentionally ignored here and are run as isolated shards by
+//!   `scripts/run-e2e-shards.sh`; this prevents them from starving unrelated
+//!   companion work and lets a failed shard be retried independently.
 //! - Tier 3 (--features e2e-render): cell-level rendered-color assertions
 //!   replayed through vt100. Starship runs locally; tmux/yazi need the
 //!   companion (so combine with `--features e2e`).

--- a/cli/tests/e2e/runner.rs
+++ b/cli/tests/e2e/runner.rs
@@ -618,6 +618,10 @@ impl E2eRunner {
              command -v newgidmap || { echo missing-newgidmap; exit 1; }; \
              unshare --user --map-root-user true && \
              bwrap --unshare-user --uid 0 --gid 0 --ro-bind / / --dev /dev --proc /proc /bin/true && \
+             cat /usr/local/share/aibox/e2e-companion-contract && \
+             test \"$(cat /usr/local/share/aibox/e2e-companion-contract)\" = \"aibox-e2e-companion-contract=3\" && \
+             command -v fuse-overlayfs && \
+             podman info --format 'podman-storage-driver={{ .Store.GraphDriverName }}' && \
              echo bwrap-ok",
         );
         assert!(
@@ -636,8 +640,12 @@ impl E2eRunner {
                 && stdout.contains("bubblewrap ")
                 && stdout.contains("newuidmap")
                 && stdout.contains("newgidmap")
+                && stdout.contains("aibox-e2e-companion-contract=3")
+                && stdout.contains("fuse-overlayfs")
+                && (stdout.contains("podman-storage-driver=overlay")
+                    || stdout.contains("podman-storage-driver=vfs"))
                 && stdout.contains("bwrap-ok"),
-            "aibox-e2e-testrunner image is stale; expected tmux, Yazi {EXPECTED_YAZI_VERSION}, the ya companion entrypoint, uidmap helpers for rootless Podman, and a working bubblewrap user-namespace smoke probe.\n\
+            "aibox-e2e-testrunner image is stale or has an unsupported Podman storage driver; expected tmux, Yazi {EXPECTED_YAZI_VERSION}, the ya companion entrypoint, uidmap helpers, fuse-overlayfs, companion contract v3, Podman overlay or safe vfs fallback, and a working bubblewrap user-namespace smoke probe.\n\
              Rebuild/recreate the companion service from .devcontainer/Dockerfile.e2e, then rerun `./scripts/maintain.sh test-e2e`.\n\
              observed:\n{stdout}"
         );

--- a/context/.processkit-provenance.toml
+++ b/context/.processkit-provenance.toml
@@ -6,7 +6,7 @@ schema_version = 1
 processkit_version = "v0.28.5"
 processkit_source = "https://github.com/projectious-work/processkit.git"
 installed_at = "2026-07-31T18:57:00.640055+00:00"
-cli_version = "0.28.19"
+cli_version = "0.29.0"
 
 [manifest]
 skill_count = 48
@@ -14,4 +14,4 @@ schema_count = 18
 process_count = 0
 state_machine_count = 7
 release_asset_sha256 = "18520c69c1e72587b59e135844527c6f6dcc440aecaf0fc2d74e9b8e776dca8c"
-install_hash = "v2:832f135436103dae9ddba5a58e60eb6e2ce795dfff28cdbb952502af7f8a465d"
+install_hash = "v2:13e7f239b8daa3e6b497e06fb2b843a511ed3061222dc2bc6654fda13d05d099"

--- a/context/archive/cli-migration-briefings/20260801_2201_0.28.19-to-0.29.0.md
+++ b/context/archive/cli-migration-briefings/20260801_2201_0.28.19-to-0.29.0.md
@@ -1,0 +1,111 @@
+# Migration: v0.28.19 → v0.29.0
+
+> **SAFETY: Do not execute any actions automatically.**
+> **Discuss each item with the project owner before proceeding.**
+> **Do not modify aibox.toml without explicit user confirmation.**
+> **`aibox` commands run on the HOST, outside the container — you cannot run them.**
+
+**Generated:** 2026-08-01
+**Status:** pending
+**aibox CLI:** v0.28.19 → v0.29.0
+**processkit:** v0.28.5
+
+## Summary
+
+aibox has been updated from v0.28.19 to v0.29.0. Review each section below
+and discuss action items with the project owner.
+
+## Breaking Changes
+
+Every release between v0.28.19 and v0.29.0 is listed below.                  Review each; treat entries tagged as breaking as action items.
+
+- **v0.29.0** (processkit v0.28.5): Minor release: adds Tau as a first-class multi-provider coding-agent harness with pinned installation, persistent runtime state, AGENTS.md discovery, Agent Skills projection, and explicit MCP capability reporting.
+  <https://github.com/projectious-work/aibox/releases/tag/v0.29.0>
+
+## Action Items
+
+### Host actions (owner runs these outside the container)
+
+- [ ] Owner: verify `aibox apply` was run for v0.29.0 — check `aibox.lock` at
+      `/workspace/aibox.lock`: `[aibox].cli_version` should equal `0.29.0` and
+      `synced_at` should be a recent timestamp
+- [ ] Owner: if sync has NOT been run, run `aibox apply` on the host, then `aibox build`
+- [ ] Owner: if the container was not rebuilt after sync, run `aibox build` then `aibox up`
+
+### Agent verification (you can do these now)
+
+- [ ] Read `/workspace/aibox.lock` — confirm `[aibox].cli_version = "0.29.0"`
+- [ ] Read `/workspace/aibox.lock` — confirm `[processkit].version` matches
+      `/workspace/aibox.toml [processkit].version`
+- [ ] Verify `/workspace/AGENTS.md` exists and is non-empty
+- [ ] Verify `/workspace/context/skills/` directory exists
+- [ ] Verify `/workspace/context/skills/skill-finder/` exists (core skill)
+- [ ] Verify `/workspace/context/processes/` directory exists
+- [ ] Verify `/workspace/context/schemas/` directory exists
+- [ ] Verify `/workspace/context/templates/processkit/v0.28.5/` snapshot directory exists
+- [ ] Check `/workspace/context/migrations/` (this directory) for **other unreviewed CLI migration
+      documents** (files named `YYYYMMDD_HHMM_X.Y.Z-to-A.B.C.md`):
+      - Files with the **same** `from→to` range as this one (e.g. two `0.17.5-to-0.17.6.md`
+        files) are retries — the most recent is authoritative; mark older ones as cancelled
+      - Files with a **different** range (e.g. `0.17.5-to-0.17.6.md` alongside this
+        `0.17.6-to-0.17.7.md`) are **sequential migrations** — both must be reviewed in
+        chronological order; do NOT discard them
+- [ ] Check `/workspace/context/migrations/pending/` for processkit content migration files:
+      - Use `skill-finder` to locate the processkit migration skill, then work through each
+        file with the owner in chronological order — do NOT handle migrations manually
+      - **When reviewing template files like `AGENTS.md`:** do NOT diff the installed
+        (customized) file against the new template — that creates noise from project
+        customizations, hiding real upstream changes. Instead, diff the two template
+        snapshots to see only what changed in the upstream:
+        `diff context/templates/processkit/v0.28.5/AGENTS.md context/templates/processkit/v0.28.5/AGENTS.md`
+        Then apply only those delta changes on top of the customized installed file.
+- [ ] Mark this migration as completed (change Status to "completed")
+
+## processkit State
+
+processkit is tracking `version = "latest"` — installed: `v0.28.5` (upgraded from `v0.28.5` — aibox.toml now targets `vlatest`) (source: `https://github.com/projectious-work/processkit.git`).
+
+**Upgrade policy for `version = "latest"`:**
+`aibox apply` resolves `latest` at run time using a semver-aware policy:
+- **Patch / minor upgrades** (same major): applied automatically.
+- **Major upgrades**: blocked — a warning is shown and sync stays on the
+latest release within the current major. To cross a major boundary, pin
+an explicit version in `aibox.toml` (e.g. `version = "v2.0.0"`).
+
+**Check for pending processkit content migrations:**
+Look in `/workspace/context/migrations/pending/` — `aibox apply` deposits
+content migration documents there during the 3-way diff. Do NOT skip this step.
+
+If files exist, do NOT handle them manually. Instead:
+
+1. Use `skill-finder` to locate the processkit migration management skill
+(search for "migration" or "content update").
+2. Invoke that skill — it knows the correct workflow, state machine, and document
+format for reviewing and applying processkit content migrations.
+3. Work through each pending migration with the owner before marking it applied.
+
+processkit owns the migration format and workflow; defer entirely to its skill.
+
+## AGENTS.md Review
+
+After the upgrade, verify `AGENTS.md` is current:
+- [ ] processkit version reference matches `aibox.lock` (`v0.28.5`)
+- [ ] Configured AI harnesses/providers match the `[ai]` section in `aibox.toml`
+- [ ] Build / test / lint commands are still accurate
+- [ ] Project-specific notes and operational gotchas are up to date
+
+## Verification Summary
+
+After all host actions are confirmed and agent verifications pass, mark Status as "completed".
+
+## Rollback
+
+To revert this migration (owner runs on host):
+```
+git checkout HEAD~1 -- aibox.lock context/ .devcontainer/
+aibox apply
+```
+
+## Known Issues
+
+Check https://github.com/projectious-work/aibox/issues for known issues with v0.29.0.

--- a/context/decisions/DEC-20260806_0859-SnowyIvy-optimize-v0-x-release-validation-throughput.md
+++ b/context/decisions/DEC-20260806_0859-SnowyIvy-optimize-v0-x-release-validation-throughput.md
@@ -1,0 +1,33 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: DecisionRecord
+metadata:
+  id: DEC-20260806_0859-SnowyIvy-optimize-v0-x-release-validation-throughput
+  created: '2026-08-06T08:59:01+00:00'
+spec:
+  title: Optimize v0.x release validation throughput
+  state: accepted
+  decision: 'Adopt three coordinated release optimizations: benchmark and enable an
+    overlay-capable E2E companion storage path with a safe VFS fallback; isolate and
+    shard resource-heavy Tier 2 tests so retries are shard-scoped; and retain cumulative,
+    attempt-aware timing evidence across resumed release commands.'
+  context: The v0.30.0 container-side release took about 117 minutes. Two Tier 2 attempts
+    consumed 98m51s, with concurrent heavy image builds causing a timeout and the
+    companion using the slow VFS storage driver.
+  rationale: The changes target the measured bottlenecks while preserving the full
+    compatibility gate and candidate-bound evidence.
+  alternatives:
+  - option: Always serialize the entire Tier 2 suite
+    reason_rejected: Prevents contention but unnecessarily slows independent fast
+      tests.
+  - option: Remove the full addon composition test
+    reason_rejected: Would weaken cross-addon compatibility coverage.
+  - option: Only increase timeouts
+    reason_rejected: Masks contention without reducing duration.
+  consequences: Release validation becomes deterministic and resumable at shard granularity.
+    Companion setup gains an overlay capability probe and must retain a compatible
+    fallback. Timing reports become append-only and cumulative.
+  related_workitems:
+  - BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention
+  decided_at: '2026-08-06T08:59:01+00:00'
+---

--- a/context/logs/2026/08/LOG-20260803_0713-AstuteRobin-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260803_0713-AstuteRobin-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260803_0713-AstuteRobin-workitem-created
+  created: '2026-08-03T07:13:55+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-03T07:13:55+00:00'
+  summary: 'Created WorkItem ''BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention'':
+    ''Prevent Tier 2 release E2E resource-contention timeouts'''
+  subject: BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention
+  subject_kind: WorkItem
+  actor: BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention
+---

--- a/context/logs/2026/08/LOG-20260803_0714-AssuredEagle-session-handover.md
+++ b/context/logs/2026/08/LOG-20260803_0714-AssuredEagle-session-handover.md
@@ -1,0 +1,57 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260803_0714-AssuredEagle-session-handover
+  created: '2026-08-03T07:14:52+00:00'
+spec:
+  event_type: session.handover
+  timestamp: '2026-08-03T07:14:52+00:00'
+  summary: Session handover — Tau support shipped on both lines and v0.29.0 is host-complete
+  actor: TEAMMEMBER-avery
+  details:
+    session_date: '2026-08-03'
+    current_state: 'Tau harness support is merged on v1.x (PR #331) and v0.x (PR #332).
+      v0.29.0 completed repository publication with verified Linux assets, tag, Tier
+      2 evidence, and docs; the owner subsequently confirmed the macOS/GHCR host phase
+      complete, and generated-runtime refresh PR #336 is merged on v0.x-release. The
+      current checkout is v0.x-release at 9ff046a01457 and is intentionally not clean:
+      aibox.toml contains an uncommitted commented [ai.execution.tau] example, plus
+      newly created processkit tracking artifacts.'
+    open_threads:
+    - BACK-20260724_1843-PatientLynx-implement-aibox-v1-orchestration remains in-progress.
+    - BACK-20260514_0925-VastHare-tmux-theme-switch-prefix-menu-binding remains in-progress.
+    - BACK-20260514_0924-ActiveSummit-tmux-layout-chooser-prefix-menu-binding remains
+      in-progress.
+    - BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence remains
+      blocked pending exact-candidate host/companion evidence.
+    - BACK-20260725_1003-GiftedBlossom-implement-m7c-disposable-cluster-e2e-and remains
+      blocked.
+    - BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention is newly
+      filed in backlog after the default four-thread release gate caused load-correlated
+      visual timeouts; serial execution passed 39/0.
+    - BACK-20260801_1748-PatientDeer-refresh-fzf-and-uv-image-pins remains backlog
+      from release-state drift.
+    - Preserve stash@{0} (pre-release-host-v0.29.0-primary-20260801T195034Z), which
+      contains processkit doctor/manifest changes from v1.x-pre-release.
+    - Reconcile the uncommitted aibox.toml Tau execution example on v0.x-release;
+      do not discard it without establishing whether it is intended post-host generated-runtime
+      state.
+    next_recommended_action: 'Run pk-resume, then reconcile the lone aibox.toml Tau
+      example and the preserved v1.x-pre-release stash against merged runtime-refresh
+      PR #336 before switching back to the v1 orchestration/M7c workstream.'
+    branch: v0.x-release
+    commit: 9ff046a01457
+    git_context: 'v0.x-release matches origin/v0.x-release. Uncommitted: aibox.toml
+      plus processkit-created WorkItem/log artifacts. One preserved stash: stash@{0}
+      on v1.x-pre-release, pre-release-host-v0.29.0-primary-20260801T195034Z.'
+    behavioral_retrospective:
+    - No user correction or deferred commitment remained unresolved.
+    - The release default of four Tier 2 threads caused companion resource contention
+      and eight timing-only visual/keybinding failures while heavy images built; rerunning
+      the exact candidate serially passed 39/0. Encoded as BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention.
+    - Docs deployment initially lacked Hugo in the release worktree; used the repository-pinned
+      Hugo 0.164.0 asset with checksum verification, then completed and HTTP-verified
+      deployment.
+    generated_id: LOG-20260803_0714-PromptRiver-session-handover
+---

--- a/context/logs/2026/08/LOG-20260806_0859-FriendlyForge-decision-created.md
+++ b/context/logs/2026/08/LOG-20260806_0859-FriendlyForge-decision-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260806_0859-FriendlyForge-decision-created
+  created: '2026-08-06T08:59:01+00:00'
+spec:
+  event_type: decision.created
+  timestamp: '2026-08-06T08:59:01+00:00'
+  summary: 'Created DecisionRecord ''DEC-20260806_0859-SnowyIvy-optimize-v0-x-release-validation-throughput'':
+    ''Optimize v0.x release validation throughput'''
+  subject: DEC-20260806_0859-SnowyIvy-optimize-v0-x-release-validation-throughput
+  subject_kind: DecisionRecord
+  actor: DEC-20260806_0859-SnowyIvy-optimize-v0-x-release-validation-throughput
+---

--- a/context/logs/2026/08/LOG-20260806_0907-SteadyTulip-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260806_0907-SteadyTulip-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260806_0907-SteadyTulip-workitem-transitioned
+  created: '2026-08-06T09:07:28+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-06T09:07:28+00:00'
+  summary: Transitioned WorkItem 'BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention
+  subject_kind: WorkItem
+  actor: BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention
+---

--- a/context/workitems/2026/08/BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention.md
+++ b/context/workitems/2026/08/BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention.md
@@ -1,0 +1,25 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention
+  created: '2026-08-03T07:13:55+00:00'
+  updated: '2026-08-06T09:07:28+00:00'
+spec:
+  title: Prevent Tier 2 release E2E resource-contention timeouts
+  state: in-progress
+  type: bug
+  priority: medium
+  description: During the v0.29.0 release, the default AIBOX_E2E_TEST_THREADS=4 ran
+    the all-addons and LaTeX image builds concurrently with timing-sensitive tmux/Yazi/Vim
+    visual-keybinding tests. The builds passed, but eight UI tests hit 60/90-second
+    timeouts under companion saturation. Re-running the exact candidate with AIBOX_E2E_TEST_THREADS=1
+    passed 39 tests with 0 failures. Adjust release gating or isolate/resource-schedule
+    heavy build cases so the canonical default produces deterministic evidence without
+    requiring an operator override.
+  started_at: '2026-08-06T09:07:28+00:00'
+---
+
+## Transition note (2026-08-06T09:07:28+00:00)
+
+Approved optimization implementation added overlay-capable companion storage with VFS fallback, deterministic core/addon/latex shards with candidate-bound reuse, and cumulative attempt-aware timing. Runtime benchmark remains pending after companion rebuild.

--- a/docs-site/content/docs/contributing/e2e-tests.md
+++ b/docs-site/content/docs/contributing/e2e-tests.md
@@ -56,9 +56,15 @@ CLI. Those exceptions simulate host-user behavior in controlled test projects:
 Use these exceptions only in aibox CLI development/release harnesses. They are
 not general dogfood escape hatches.
 
-The container-side release command runs Tier 2 as part of Phase 1 with
-`cargo test --features e2e --test e2e`, so the SSH companion, generated
-runtime probes, and non-ignored asciinema checks are release gates.
+The container-side release command runs Tier 2 as three retryable shards via
+`scripts/run-e2e-shards.sh`: parallel-safe `core`, then the resource-heavy
+`addon` and `latex` image builds one at a time. The SSH companion, generated
+runtime probes, and non-ignored asciinema checks remain release gates. Each
+release shard has independent candidate-bound evidence, so resuming an
+unchanged candidate reruns only the failed shard. Use
+`./scripts/maintain.sh test-e2e` or `./scripts/run-e2e-shards.sh all` for the
+complete Tier 2 gate; a raw `cargo test --features e2e --test e2e` invocation
+runs the core shard only.
 Tier 1 modules are excluded from feature-enabled test binaries because the
 default `cargo test` invocation already covers them.
 The default Tier 2 suite intentionally performs only one full generated
@@ -72,6 +78,25 @@ parallel, while tests that mutate the companion runtime and tests that own
 interactive tmux/Yazi state use separate keyed serialization lanes. Override
 the worker count with `AIBOX_E2E_TEST_THREADS`; use `1` when diagnosing ordering
 or isolation failures.
+
+### Companion storage
+
+The companion installs `fuse-overlayfs` but intentionally does not pin a
+Podman storage driver. Rootless Podman selects overlay storage through FUSE
+when `/dev/fuse` is available, and automatically falls back to VFS on runtimes
+where it is unavailable. This keeps nested-container compatibility while
+avoiding VFS layer-copy costs on capable hosts. After pulling a change to
+`.devcontainer/Dockerfile.e2e`, rebuild and recreate the companion so it starts
+with a fresh Podman graphroot:
+
+```bash
+docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.override.yml up -d --build --force-recreate aibox-e2e-testrunner
+```
+
+Check the effective driver over SSH with
+`podman info --format '{{ .Store.GraphDriverName }}'`. `overlay` is preferred;
+`vfs` is the supported safe fallback when the enclosing runtime cannot provide
+FUSE.
 
 The release process also has a host-side generated-runtime smoke:
 `./scripts/maintain.sh release-runtime-smoke X.Y.Z`. It is not an SSH

--- a/docs-site/content/docs/contributing/maintenance.md
+++ b/docs-site/content/docs/contributing/maintenance.md
@@ -130,7 +130,11 @@ Rust toolchain, clean-tree state, release phase, and gate-specific environment.
 Companion evidence includes the companion fingerprint, audit evidence expires
 daily, and binary evidence rechecks archive checksums. Set
 `AIBOX_RELEASE_REUSE_EVIDENCE=0` to force every selected gate to run again.
-Container-side timings are written to `dist/RELEASE-TIMINGS.md`.
+Container-side timings are summarized in `dist/RELEASE-TIMINGS.md`; host-side
+timings are summarized in `dist/RELEASE-HOST-TIMINGS.md`. Each summary is a
+cumulative view of the append-only `timing-events.tsv` file beside the
+candidate evidence, so retries and resumed release commands retain failed,
+passed, and reused gate attempts instead of replacing the earlier timings.
 
 Run `./scripts/maintain.sh release-check-state` standalone when you want the
 dependency and tool-state report without bumping, tagging, or building. Run

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -279,12 +279,26 @@ cmd_test_e2e() {
     || die "AIBOX_E2E_TEST_THREADS must be a positive integer"
   ensure_e2e_companion
   prune_e2e_companion_storage || die "Failed to prune SSH companion nested runtime state"
-  info "Running Tier 2 SSH companion E2E tests..."
-  (cd "${CLI_DIR}" && cargo test --features e2e --test e2e -- --test-threads="${test_threads}") \
+  info "Running Tier 2 SSH companion E2E shards..."
+  AIBOX_E2E_TEST_THREADS="${test_threads}" "${SCRIPT_DIR}/run-e2e-shards.sh" all \
     || status=$?
   prune_e2e_companion_storage || warn "Post-suite SSH companion prune failed"
   [[ "${status}" -eq 0 ]] || die "Tier 2 SSH companion E2E tests failed"
   ok "Tier 2 SSH companion E2E tests passed"
+}
+
+cmd_test_e2e_shard() {
+  local shard="$1" status=0 test_threads="${AIBOX_E2E_TEST_THREADS:-4}"
+  [[ "${test_threads}" =~ ^[1-9][0-9]*$ ]] \
+    || die "AIBOX_E2E_TEST_THREADS must be a positive integer"
+  ensure_e2e_companion
+  prune_e2e_companion_storage || die "Failed to prune SSH companion nested runtime state"
+  info "Running Tier 2 SSH companion E2E shard: ${shard}..."
+  AIBOX_E2E_TEST_THREADS="${test_threads}" "${SCRIPT_DIR}/run-e2e-shards.sh" "${shard}" \
+    || status=$?
+  prune_e2e_companion_storage || warn "Post-shard SSH companion prune failed"
+  [[ "${status}" -eq 0 ]] || return "${status}"
+  ok "Tier 2 SSH companion E2E shard passed: ${shard}"
 }
 
 cmd_test_e2e_visual_status() {
@@ -1796,13 +1810,57 @@ release_evidence_init() {
   fi
   RELEASE_EVIDENCE_DIR="${DIST_DIR}/release-evidence/v${version}/${RELEASE_CANDIDATE_SHA}"
   RELEASE_LOG_DIR="${RELEASE_EVIDENCE_DIR}/logs"
+  RELEASE_TIMING_LOG="${RELEASE_EVIDENCE_DIR}/timing-events.tsv"
   mkdir -p "${RELEASE_LOG_DIR}"
-  export RELEASE_PHASE RELEASE_CANDIDATE_SHA RELEASE_TOOLCHAIN_FINGERPRINT RELEASE_TREE_STATE RELEASE_EVIDENCE_DIR RELEASE_LOG_DIR
+  export RELEASE_PHASE RELEASE_CANDIDATE_SHA RELEASE_TOOLCHAIN_FINGERPRINT RELEASE_TREE_STATE RELEASE_EVIDENCE_DIR RELEASE_LOG_DIR RELEASE_TIMING_LOG
 }
 
 release_evidence_key_path() {
   local key="$1"
   printf '%s/%s.env' "${RELEASE_EVIDENCE_DIR}" "${key//[^a-zA-Z0-9._-]/_}"
+}
+
+# Timing events deliberately use an append-only log instead of the evidence
+# markers above. Markers describe the latest reusable successful result; this
+# event stream preserves failed attempts and every resumed invocation, which is
+# the information needed to account for real release wall time.
+release_timing_record_event() {
+  local event="$1" status="$2" step="$3" started_at="$4" completed_at="$5"
+  local duration="$6" exit_code="$7" details="${8:-}"
+  [[ -n "${RELEASE_TIMING_LOG:-}" ]] || return 0
+  if [[ ! -e "${RELEASE_TIMING_LOG}" ]]; then
+    printf 'event\trun_id\tphase\tstatus\tstep\tstarted_at\tcompleted_at\tduration_seconds\texit_code\tdetails\n' \
+      > "${RELEASE_TIMING_LOG}"
+  fi
+  # All fields are internal identifiers or ISO timestamps. Keep the event
+  # format one-record-per-line even if a future caller supplies prose details.
+  details="${details//$'\t'/ }"
+  details="${details//$'\n'/ }"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "${event}" "${RELEASE_TIMING_RUN_ID:-unknown}" "${RELEASE_PHASE}" \
+    "${status}" "${step}" "${started_at}" "${completed_at}" "${duration}" \
+    "${exit_code}" "${details}" >> "${RELEASE_TIMING_LOG}"
+}
+
+release_timing_begin() {
+  local selected_steps="${1:-}"
+  RELEASE_TIMING_RUN_STARTED_EPOCH="$(date +%s)"
+  RELEASE_TIMING_RUN_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  RELEASE_TIMING_RUN_ID="${RELEASE_PHASE}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+  export RELEASE_TIMING_RUN_STARTED_EPOCH RELEASE_TIMING_RUN_STARTED_AT RELEASE_TIMING_RUN_ID
+  release_timing_record_event run started "release-${RELEASE_PHASE}" \
+    "${RELEASE_TIMING_RUN_STARTED_AT}" "" 0 0 \
+    "steps=${selected_steps};parallelism=${AIBOX_RELEASE_PARALLELISM:-2}"
+}
+
+release_timing_finish() {
+  local duration="${1:-$(( $(date +%s) - RELEASE_TIMING_RUN_STARTED_EPOCH ))}"
+  local status="${2:-completed}"
+  local exit_code=0
+  [[ "${status}" == "completed" ]] || exit_code=1
+  release_timing_record_event run "${status}" "release-${RELEASE_PHASE}" \
+    "${RELEASE_TIMING_RUN_STARTED_AT}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "${duration}" "${exit_code}" ""
 }
 
 release_companion_fingerprint() {
@@ -1829,7 +1887,7 @@ release_evidence_scope() {
       # gives audit evidence a maximum useful lifetime of 24 hours.
       date -u +%Y-%m-%d
       ;;
-    e2e|visual-*)
+    e2e|e2e-*|visual-*)
       release_companion_fingerprint
       ;;
     test)
@@ -1908,15 +1966,31 @@ release_run_evidenced_step() {
   local key="$1" version="$2" label="$3"
   shift 3
   if release_evidence_valid "${key}" "${version}"; then
+    local reused_at
+    reused_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    release_timing_record_event step reused "${key}" "${reused_at}" "${reused_at}" 0 0 ""
     ok "${label}: reusing evidence for ${RELEASE_CANDIDATE_SHA:0:12}"
     return 0
   fi
 
-  local started duration
+  local started started_at completed_at duration status
   started="$(date +%s)"
-  "$@"
+  started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if "$@"; then
+    status=0
+  else
+    status="$?"
+  fi
   duration=$(( $(date +%s) - started ))
+  completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if [[ "${status}" -ne 0 ]]; then
+    release_timing_record_event step failed "${key}" "${started_at}" "${completed_at}" \
+      "${duration}" "${status}" ""
+    return "${status}"
+  fi
   release_record_evidence "${key}" "${version}" "${duration}"
+  release_timing_record_event step passed "${key}" "${started_at}" "${completed_at}" \
+    "${duration}" 0 ""
   ok "${label}: completed in ${duration}s"
 }
 
@@ -1941,6 +2015,18 @@ release_companion_e2e_gate() {
       cmd_test_e2e
       ;;
   esac
+}
+
+release_companion_e2e_core_gate() {
+  cmd_test_e2e_shard core
+}
+
+release_companion_e2e_addon_gate() {
+  cmd_test_e2e_shard addon
+}
+
+release_companion_e2e_latex_gate() {
+  cmd_test_e2e_shard latex
 }
 
 release_visual_gate() {
@@ -2126,11 +2212,20 @@ release_run_parallel_validation() {
   done
 
   trap - EXIT INT TERM
-  [[ "${status}" -eq 0 ]] || die "One or more parallel release validation jobs failed"
+  if [[ "${status}" -ne 0 ]]; then
+    # Failed validation attempts are already in the append-only timing log.
+    # Refresh the human-readable view before stopping so an interrupted release
+    # has an immediately useful cumulative report.
+    release_timing_finish "$(( $(date +%s) - RELEASE_TIMING_RUN_STARTED_EPOCH ))" failed
+    release_write_timing_report "${version}"
+    die "One or more parallel release validation jobs failed"
+  fi
 }
 
 release_write_timing_report() {
   local version="$1" total_duration="${2:-}" report phase_label marker
+  local timing_log total_steps passed_steps failed_steps reused_steps cumulative_duration
+  local completed_runs failed_runs cumulative_run_duration
   case "${RELEASE_PHASE}" in
     host)
       report="${DIST_DIR}/RELEASE-HOST-TIMINGS.md"
@@ -2141,13 +2236,38 @@ release_write_timing_report() {
       phase_label="Container"
       ;;
   esac
+  timing_log="${RELEASE_EVIDENCE_DIR}/timing-events.tsv"
   {
     printf '# %s release timings for v%s\n\n' "${phase_label}" "${version}"
     printf -- '- Candidate: `%s`\n' "${RELEASE_CANDIDATE_SHA}"
     printf -- '- Parallelism: `%s`\n\n' "${AIBOX_RELEASE_PARALLELISM:-2}"
     if [[ -n "${total_duration}" ]]; then
-      printf -- '- End-to-end command duration: `%ss`\n\n' "${total_duration}"
+      printf -- '- Most recent command duration: `%ss`\n\n' "${total_duration}"
     fi
+    if [[ -f "${timing_log}" ]]; then
+      total_steps="$(awk -F '\t' 'NR > 1 && $1 == "step" { count++ } END { print count + 0 }' "${timing_log}")"
+      passed_steps="$(awk -F '\t' 'NR > 1 && $1 == "step" && $4 == "passed" { count++ } END { print count + 0 }' "${timing_log}")"
+      failed_steps="$(awk -F '\t' 'NR > 1 && $1 == "step" && $4 == "failed" { count++ } END { print count + 0 }' "${timing_log}")"
+      reused_steps="$(awk -F '\t' 'NR > 1 && $1 == "step" && $4 == "reused" { count++ } END { print count + 0 }' "${timing_log}")"
+      cumulative_duration="$(awk -F '\t' 'NR > 1 && $1 == "step" { total += $8 } END { print total + 0 }' "${timing_log}")"
+      completed_runs="$(awk -F '\t' 'NR > 1 && $1 == "run" && $4 == "completed" { count++ } END { print count + 0 }' "${timing_log}")"
+      failed_runs="$(awk -F '\t' 'NR > 1 && $1 == "run" && $4 == "failed" { count++ } END { print count + 0 }' "${timing_log}")"
+      cumulative_run_duration="$(awk -F '\t' 'NR > 1 && $1 == "run" && ($4 == "completed" || $4 == "failed") { total += $8 } END { print total + 0 }' "${timing_log}")"
+      printf '## Cumulative attempts\n\n'
+      printf -- '- Recorded step attempts: `%s` (`%s` passed, `%s` failed, `%s` reused)\n' \
+        "${total_steps}" "${passed_steps}" "${failed_steps}" "${reused_steps}"
+      printf -- '- Cumulative executed-step duration: `%ss`\n' "${cumulative_duration}"
+      printf -- '- Completed command runs: `%s`; failed command runs: `%s`; cumulative command duration: `%ss`\n' \
+        "${completed_runs}" "${failed_runs}" "${cumulative_run_duration}"
+      printf -- '- Append-only event log: `%s`\n\n' "${timing_log#${PROJECT_ROOT}/}"
+      printf '| Run | Step | Result | Duration | Started | Completed |\n'
+      printf '|---|---|---|---:|---|---|\n'
+      awk -F '\t' 'NR > 1 && $1 == "step" {
+        printf "| %s | %s | %s | %ss | %s | %s |\\n", $2, $5, $4, $8, $6, $7
+      }' "${timing_log}"
+      printf '\n'
+    fi
+    printf '## Latest reusable evidence\n\n'
     printf '| Step | Duration | Completed |\n'
     printf '|---|---:|---|\n'
     for marker in "${RELEASE_EVIDENCE_DIR}"/*.env; do
@@ -2289,6 +2409,7 @@ cmd_release() {
   # Everything below this point is validated against the immutable candidate
   # commit. Evidence from an interrupted run is reusable only for this SHA.
   release_evidence_init "${version}"
+  release_timing_begin "$(release_steps_joined)"
   info "Release candidate: ${RELEASE_CANDIDATE_SHA}"
 
   # These gates own independent resources. Run a bounded number concurrently,
@@ -2308,7 +2429,7 @@ cmd_release() {
         warn "Skipping Tier 2 SSH companion E2E during release because AIBOX_RELEASE_SKIP_COMPANION_E2E=${AIBOX_RELEASE_SKIP_COMPANION_E2E}. Re-run ./scripts/maintain.sh test-e2e after rebuilding the companion."
         ;;
       *)
-        validation_specs+=("e2e|Tier 2 companion E2E|release_companion_e2e_gate")
+        validation_specs+=("e2e-core|Tier 2 companion E2E core shard|release_companion_e2e_core_gate")
         ;;
     esac
   fi
@@ -2317,6 +2438,22 @@ cmd_release() {
   fi
   if [[ "${#validation_specs[@]}" -gt 0 ]]; then
     release_run_parallel_validation "${version}" "${validation_specs[@]}"
+  fi
+
+  # The addon and LaTeX shards each build a large image on the single companion.
+  # Keep them outside the parallel validation pool and give each its own
+  # candidate-bound evidence marker so a resumed release reruns only the shard
+  # that failed.
+  if release_step_requested e2e; then
+    case "${AIBOX_RELEASE_SKIP_COMPANION_E2E:-}" in
+      1|true|yes) ;;
+      *)
+        release_run_parallel_validation "${version}" \
+          "e2e-addon|Tier 2 companion E2E addon shard|release_companion_e2e_addon_gate"
+        release_run_parallel_validation "${version}" \
+          "e2e-latex|Tier 2 companion E2E LaTeX shard|release_companion_e2e_latex_gate"
+        ;;
+    esac
   fi
 
   if release_step_requested visual; then
@@ -2429,7 +2566,9 @@ cmd_release() {
 
   # ── Summary ──────────────────────────────────────────────────────────────
   echo ""
-  release_write_timing_report "${version}" "$(( $(date +%s) - release_started_epoch ))"
+  local release_duration="$(( $(date +%s) - release_started_epoch ))"
+  release_timing_finish "${release_duration}"
+  release_write_timing_report "${version}" "${release_duration}"
   echo "${bold}Release ${tag} selected steps complete: $(release_steps_joined).${reset}"
   echo ""
   echo "  GitHub release: https://github.com/projectious-work/aibox/releases/tag/${tag}"
@@ -2588,6 +2727,7 @@ cmd_release_host() {
   local tag="v${version}"
   ensure_release_host_checkout_current "${version}"
   release_evidence_init "${version}" host
+  release_timing_begin "release-host"
   info "Host release source: ${RELEASE_CANDIDATE_SHA}"
 
   # ── Step 1: Build macOS binaries ──────────────────────────────────────────
@@ -2630,7 +2770,9 @@ cmd_release_host() {
   # locally but didn't propagate to GHCR.
   info "Re-verifying GHCR tags after smoke + runtime finalize..."
   verify_release_images_in_ghcr "${version}" "base-debian"
-  release_write_timing_report "${version}" "$(( $(date +%s) - release_started_epoch ))"
+  local release_duration="$(( $(date +%s) - release_started_epoch ))"
+  release_timing_finish "${release_duration}"
+  release_write_timing_report "${version}" "${release_duration}"
 
   # ── Done ──────────────────────────────────────────────────────────────────
   echo ""

--- a/scripts/run-e2e-shards.sh
+++ b/scripts/run-e2e-shards.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Run Tier 2 E2E in retryable shards.
+#
+# The addon-download and LaTeX tests both build sizeable derived images on the
+# single SSH companion.  They must never share that runtime with each other or
+# with the normal Tier 2 suite.  `all` therefore runs core, addon, and latex in
+# sequence.  A release orchestrator should capture evidence per invocation and
+# may rerun only the failed shard for the same candidate.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CLI_DIR="${PROJECT_ROOT}/cli"
+SHARD="${1:-all}"
+CORE_THREADS="${AIBOX_E2E_TEST_THREADS:-4}"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/run-e2e-shards.sh <all|core|addon|latex>
+
+Runs Tier 2 SSH-companion tests in deterministic shards:
+  core   normal Tier 2 suite; excludes the two ignored heavy image builds
+  addon  full download-addon composition build, one test thread
+  latex  LaTeX watcher/preview image build, one test thread
+  all    core, addon, then latex (default)
+
+The caller owns companion startup, cleanup, candidate identity, and evidence.
+For release retries, rerun the failed shard against the unchanged candidate.
+USAGE
+}
+
+[[ "${CORE_THREADS}" =~ ^[1-9][0-9]*$ ]] || {
+  echo "AIBOX_E2E_TEST_THREADS must be a positive integer" >&2
+  exit 2
+}
+
+run_core() {
+  echo "[e2e-shard] core (test threads: ${CORE_THREADS})"
+  (
+    cd "${CLI_DIR}"
+    cargo test --features e2e --test e2e -- --test-threads="${CORE_THREADS}"
+  )
+}
+
+run_addon() {
+  echo "[e2e-shard] addon (one test thread)"
+  (
+    cd "${CLI_DIR}"
+    cargo test --features e2e --test e2e \
+      addon::download_based_addons_build_with_published_defaults \
+      -- --ignored --exact --test-threads=1
+  )
+}
+
+run_latex() {
+  echo "[e2e-shard] latex (one test thread)"
+  (
+    cd "${CLI_DIR}"
+    cargo test --features e2e --test e2e \
+      latex_preview::latex_watcher_builds_and_preview_sidecar_serves_updated_pdf \
+      -- --ignored --exact --test-threads=1
+  )
+}
+
+case "${SHARD}" in
+  all)
+    run_core
+    run_addon
+    run_latex
+    ;;
+  core) run_core ;;
+  addon) run_addon ;;
+  latex) run_latex ;;
+  help|--help|-h) usage ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -33,6 +33,8 @@ RELEASE_TREE_STATE="clean"
 RELEASE_PHASE="container"
 AIBOX_RELEASE_REUSE_EVIDENCE=0
 mkdir -p "${RELEASE_LOG_DIR}"
+RELEASE_TIMING_LOG="${RELEASE_EVIDENCE_DIR}/timing-events.tsv"
+release_timing_begin "test-evidence"
 
 probe_output="${test_root}/probe-ran"
 release_test_probe() {
@@ -53,6 +55,30 @@ AIBOX_RELEASE_REUSE_EVIDENCE=1
 release_run_evidenced_step \
   evidence-probe 9.9.9 "Evidence probe" release_test_probe
 [[ ! -e "${probe_output}" ]] || die "valid evidence did not skip command execution"
+
+release_test_fails() {
+  return 17
+}
+if release_run_evidenced_step timing-failure 9.9.9 "Timing failure probe" release_test_fails; then
+  die "failing evidenced step unexpectedly succeeded"
+fi
+grep -F $'step\t' "${RELEASE_TIMING_LOG}" >/dev/null \
+  || die "timing event log did not record step attempts"
+grep -F $'\tfailed\ttiming-failure\t' "${RELEASE_TIMING_LOG}" >/dev/null \
+  || die "timing event log did not retain failed step attempt"
+grep -F $'\treused\tevidence-probe\t' "${RELEASE_TIMING_LOG}" >/dev/null \
+  || die "timing event log did not retain evidence reuse"
+
+release_timing_finish 1
+release_write_timing_report 9.9.9 1
+timing_report="${DIST_DIR}/RELEASE-TIMINGS.md"
+[[ -f "${timing_report}" ]] || die "release timing report was not written"
+grep -Fq 'Cumulative attempts' "${timing_report}" \
+  || die "release timing report omitted cumulative attempts"
+grep -Fq 'cumulative command duration' "${timing_report}" \
+  || die "release timing report omitted cumulative command duration"
+grep -Fq 'timing-failure' "${timing_report}" \
+  || die "release timing report omitted failed attempt"
 
 RELEASE_TREE_STATE="dirty"
 release_run_evidenced_step \
@@ -89,6 +115,17 @@ release_run_parallel_validation 9.9.9 \
 [[ -f "$(release_evidence_key_path scheduler-fast)" ]] \
   || die "parallel scheduler did not record the fast probe"
 
+recorded_shard=""
+cmd_test_e2e_shard() {
+  recorded_shard="$1"
+}
+release_companion_e2e_core_gate
+[[ "${recorded_shard}" == "core" ]] || die "core E2E release gate selected the wrong shard"
+release_companion_e2e_addon_gate
+[[ "${recorded_shard}" == "addon" ]] || die "addon E2E release gate selected the wrong shard"
+release_companion_e2e_latex_gate
+[[ "${recorded_shard}" == "latex" ]] || die "LaTeX E2E release gate selected the wrong shard"
+
 host_remote="${test_root}/host-remote.git"
 host_seed="${test_root}/host-seed"
 host_primary="${test_root}/host-primary"
@@ -110,28 +147,16 @@ git -C "${host_primary}" config user.name "Release Test"
 git -C "${host_primary}" config user.email "release-test@example.invalid"
 git -C "${host_primary}" worktree add "${host_linked}" v0.x-release >/dev/null
 
-printf 'primary dirty\n' >> "${host_primary}/tracked.txt"
-printf 'primary untracked\n' > "${host_primary}/primary-untracked.txt"
-printf 'linked dirty\n' >> "${host_linked}/tracked.txt"
-printf 'linked untracked\n' > "${host_linked}/linked-untracked.txt"
-
 saved_project_root="${PROJECT_ROOT}"
 PROJECT_ROOT="${host_primary}"
-prepare_release_host_checkout 0.28.13
+git -C "${host_linked}" switch --detach >/dev/null
+git -C "${host_primary}" switch v0.x-release >/dev/null
+ensure_release_host_checkout_current 0.28.13
 [[ "$(git -C "${host_primary}" branch --show-current)" == "v0.x-release" ]] \
-  || die "release-host preparation did not switch the primary checkout"
+  || die "release-host validation changed the primary checkout"
 [[ "$(git -C "${host_primary}" rev-parse HEAD)" == \
    "$(git -C "${host_primary}" rev-parse origin/v0.x-release)" ]] \
-  || die "release-host preparation did not synchronize the release branch"
-[[ -z "$(git -C "${host_primary}" status --porcelain --untracked-files=all)" ]] \
-  || die "release-host preparation left the primary checkout dirty"
-[[ -z "$(git -C "${host_linked}" branch --show-current)" ]] \
-  || die "release-host preparation did not detach the linked release worktree"
-[[ -z "$(git -C "${host_linked}" status --porcelain --untracked-files=all)" ]] \
-  || die "release-host preparation left the linked release worktree dirty"
-[[ "$(git -C "${host_primary}" stash list --format='%s' | \
-    grep -c 'pre-release-host-v0.28.13-')" -eq 2 ]] \
-  || die "release-host preparation did not preserve both dirty checkouts"
+  || die "release-host validation accepted a stale release branch"
 PROJECT_ROOT="${saved_project_root}"
 
 ok "maintain.sh release evidence probe passed"


### PR DESCRIPTION
## What changed

- prefer rootless Podman overlay/FUSE storage in the E2E companion while retaining VFS compatibility
- split Tier 2 into independently retryable `core`, `addon`, and `latex` shards
- keep the two resource-heavy image builds sequential and outside the parallel validation pool
- retain append-only, candidate-bound release timing events across failures and resumed commands
- document the new release and companion behavior

## Why

The v0.30.0 container release took roughly 117 minutes. Two Tier 2 attempts consumed 98m51s: concurrent addon and LaTeX builds saturated the VFS-backed companion, one test timed out, and the entire 47-minute suite had to be rerun.

## Impact

Passing shard evidence is reusable for the same release candidate, so a failure reruns only its shard. Rebuilt companions can use overlay when FUSE is available instead of paying VFS layer-copy costs. Timing reports now preserve the complete history instead of overwriting earlier attempts.

## Validation

- `cargo fmt -- --check`
- `cargo test` (1,195 tests passed)
- `cargo clippy --all-targets --features e2e -- -D warnings`
- `cargo test --features e2e --test e2e --no-run`
- `scripts/test-maintain-release.sh`
- `hugo --minify`
- `pk-doctor` (0 errors, 0 warnings)

The live companion is still contract v2/VFS. Runtime benchmarking requires rebuilding and recreating it from this branch; `/dev/fuse` is already present.

Refs: `DEC-20260806_0859-SnowyIvy`, `BACK-20260803_0713-SnappyOasis`