### PR TITLE
fix: repair Starship cache directory collisions

### DIFF
--- a/cli/src/generate.rs
+++ b/cli/src/generate.rs
@@ -1976,6 +1976,7 @@ mod tests {
     #[test]
     fn base_image_prepares_writable_cache_home_and_shell_env() {
         let content = include_str!("../../images/base-debian/Dockerfile");
+        let bashrc = include_str!("../../images/base-debian/config/bashrc");
         assert!(content.contains("SHELL=/bin/bash"));
         assert!(
             content.contains("ENV UV_CACHE_DIR=/tmp/aibox/uv-cache")
@@ -1986,6 +1987,11 @@ mod tests {
                 && content.contains("chown -R aibox:aibox /home/aibox")
                 && content.contains("chown -R aibox:aibox /tmp/aibox"),
             "base image should create writable cache-home and uv cache paths before final ownership fix"
+        );
+        assert!(
+            bashrc.contains("moved file blocking Starship cache")
+                && bashrc.contains("mkdir -p \"$HOME/.cache/starship\""),
+            "interactive Bash must repair a file collision at Starship's cache path before initializing the prompt"
         );
     }
 

--- a/cli/src/seed.rs
+++ b/cli/src/seed.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::config::{AiboxConfig, ConfigLayout, GithubCredentialHelper};
 use crate::output;
@@ -927,11 +927,48 @@ pub fn ensure_runtime_dirs(config: &AiboxConfig) -> Result<()> {
     let root = config.host_root_dir();
     for rel_dir in crate::runtime_home::runtime_home_scaffold_dirs(config) {
         let dir = root.join(rel_dir);
-        fs::create_dir_all(&dir)
-            .with_context(|| format!("Failed to create directory: {}", dir.display()))?;
+        ensure_runtime_dir(&dir)?;
     }
 
     Ok(())
+}
+
+/// Ensure a runtime-home path is a directory, preserving a blocking file.
+///
+/// `.aibox-home` is user-editable and bind-mounted into the container. A file
+/// at a cache/config directory path would otherwise make tools fail on every
+/// shell startup (for example, Starship's log directory). Keep the file under
+/// a deterministic conflict name instead of discarding user data.
+fn ensure_runtime_dir(dir: &Path) -> Result<()> {
+    if fs::symlink_metadata(dir).is_ok() && !dir.is_dir() {
+        let backup = runtime_dir_conflict_backup(dir);
+        fs::rename(dir, &backup).with_context(|| {
+            format!(
+                "Failed to preserve file blocking runtime directory {}",
+                dir.display()
+            )
+        })?;
+        output::warn(&format!(
+            "Moved file blocking runtime directory {} to {}",
+            dir.display(),
+            backup.display()
+        ));
+    }
+    fs::create_dir_all(dir)
+        .with_context(|| format!("Failed to create directory: {}", dir.display()))
+}
+
+fn runtime_dir_conflict_backup(dir: &Path) -> PathBuf {
+    let parent = dir.parent().unwrap_or_else(|| Path::new("."));
+    let name = dir.file_name().unwrap_or_default().to_string_lossy();
+    let base = format!("{name}.aibox-conflict");
+    let mut candidate = parent.join(&base);
+    let mut suffix = 2;
+    while candidate.exists() || candidate.is_symlink() {
+        candidate = parent.join(format!("{base}.{suffix}"));
+        suffix += 1;
+    }
+    candidate
 }
 
 /// Return the managed runtime files that aibox generates inside `.aibox-home/`.
@@ -2285,6 +2322,26 @@ mod tests {
         assert!(root.join(".config").join("yazi").is_dir());
         assert!(root.join(".config").join("git").is_dir());
         assert!(root.join(".claude").is_dir());
+        clear_test_host_root();
+    }
+
+    #[test]
+    #[serial]
+    fn ensure_runtime_dirs_preserves_file_blocking_starship_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        let config = make_config(false, root.clone());
+        let starship_cache = root.join(".cache/starship");
+        fs::create_dir_all(starship_cache.parent().unwrap()).unwrap();
+        fs::write(&starship_cache, "preserve this cache file").unwrap();
+
+        ensure_runtime_dirs(&config).unwrap();
+
+        assert!(starship_cache.is_dir());
+        assert_eq!(
+            fs::read_to_string(root.join(".cache/starship.aibox-conflict")).unwrap(),
+            "preserve this cache file"
+        );
         clear_test_host_root();
     }
 

--- a/images/base-debian/config/bashrc
+++ b/images/base-debian/config/bashrc
@@ -42,6 +42,21 @@ if [ -r "$HOME/.config/aibox/theme-env.sh" ]; then
 fi
 
 # ── Tool integrations ──────────────────────────────────────────────────────
+# Starship writes session logs below this path. The runtime cache is bind-mounted
+# from `.aibox-home` and can contain user-created files, so repair a file
+# collision before Starship initializes instead of printing the same error for
+# every shell prompt. `aibox apply` performs the equivalent persistent repair.
+if [ -e "$HOME/.cache/starship" ] && [ ! -d "$HOME/.cache/starship" ]; then
+    _aibox_starship_backup="$HOME/.cache/starship.aibox-conflict"
+    _aibox_starship_suffix=2
+    while [ -e "$_aibox_starship_backup" ]; do
+        _aibox_starship_backup="$HOME/.cache/starship.aibox-conflict.$_aibox_starship_suffix"
+        _aibox_starship_suffix=$((_aibox_starship_suffix + 1))
+    done
+    mv "$HOME/.cache/starship" "$_aibox_starship_backup"
+    printf 'aibox: moved file blocking Starship cache to %s\n' "$_aibox_starship_backup" >&2
+fi
+mkdir -p "$HOME/.cache/starship"
 eval "$(starship init bash)"
 eval "$(zoxide init bash)"
 eval "$(fzf --bash)"


### PR DESCRIPTION
## Summary

Repairs a derived runtime where `.aibox-home/.cache/starship` is a file rather than a directory.

- `aibox apply` now moves a blocking file to `starship.aibox-conflict[.N]` and recreates the directory.
- Interactive Bash performs the same repair before `starship init bash`, so a stale runtime cannot repeat the error on every prompt.
- The original file is preserved rather than discarded.

## Validation

- `cargo fmt -- --check`
- focused seed and base-image regression tests
- `bash -n images/base-debian/config/bashrc`
- `cargo clippy --all-targets -- -D warnings`