### PR TITLE
chore: record v1 Starship repair port

### DIFF
--- a/context/logs/2026/08/LOG-20260807_0835-BuoyantWillow-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260807_0835-BuoyantWillow-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260807_0835-BuoyantWillow-workitem-created
+  created: '2026-08-07T08:35:43+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-07T08:35:43+00:00'
+  summary: 'Created WorkItem ''BACK-20260807_0835-LucidLeaf-review-deferred-v0-30-1-dependency'':
+    ''Review deferred v0.30.1 dependency updates'''
+  subject: BACK-20260807_0835-LucidLeaf-review-deferred-v0-30-1-dependency
+  subject_kind: WorkItem
+  actor: BACK-20260807_0835-LucidLeaf-review-deferred-v0-30-1-dependency
+---

--- a/context/workitems/2026/08/BACK-20260807_0835-LucidLeaf-review-deferred-v0-30-1-dependency.md
+++ b/context/workitems/2026/08/BACK-20260807_0835-LucidLeaf-review-deferred-v0-30-1-dependency.md
@@ -1,0 +1,20 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260807_0835-LucidLeaf-review-deferred-v0-30-1-dependency
+  created: '2026-08-07T08:35:42+00:00'
+  labels:
+    release: v0.30.1
+    source: release-check-state
+spec:
+  title: Review deferred v0.30.1 dependency updates
+  state: backlog
+  type: task
+  priority: medium
+  description: 'Release-state review identified deferred updates: Zensical 0.0.53,
+    pnpm 11.20.0, Tau 0.3.7, and the resolvable Cargo.lock updates (aho-corasick,
+    android_system_properties, clap family, libredox, minijinja, regex-automata).
+    Review upstream compatibility and security implications, decide which belong in
+    a follow-up release, then implement and validate.'
+---


### PR DESCRIPTION
Records the reverse provenance required by the version-line release gate and tracks the deferred dependency-update review from the release-state report.