### PR TITLE
chore: record session handover

### DIFF
--- a/context/logs/2026/08/LOG-20260807_0908-BraveIvy-session-handover.md
+++ b/context/logs/2026/08/LOG-20260807_0908-BraveIvy-session-handover.md
@@ -1,0 +1,57 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260807_0908-BraveIvy-session-handover
+  created: '2026-08-07T09:08:18+00:00'
+spec:
+  event_type: session.handover
+  timestamp: '2026-08-07T09:08:18+00:00'
+  summary: Session handover — Starship repair merged across maintained lines; v0.30.1
+    awaits companion contract v3
+  actor: TEAMMEMBER-avery
+  details:
+    session_date: '2026-08-07'
+    current_state: 'The Starship cache collision repair is merged and pushed on v0.x-release
+      (PR #343), v1.x-dev (PR #344), and v1.x-pre-release (PR #345). Reverse version-line
+      provenance and the deferred dependency-review WorkItem were merged through PR
+      #346. The repository is clean on v0.x-release at 3c8edd1c4b65, with one worktree
+      and only the six retained long-lived branches. v0.30.1 has not been cut because
+      the live E2E companion still reports contract 2 with Podman vfs; the release
+      requires a rebuilt contract-3 companion and Tier 2 evidence.'
+    open_threads:
+    - BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention is in progress;
+      rebuild the companion and benchmark the new core/addon/latex shard workflow.
+    - v0.30.1 release is operationally blocked until the macOS host rebuilds and force-recreates
+      aibox-e2e-testrunner from v0.x-release, after which full release validation
+      and publishing can resume.
+    - BACK-20260807_0835-LucidLeaf-review-deferred-v0-30-1-dependency is in backlog
+      for Zensical 0.0.53, pnpm 11.20.0, Tau 0.3.7, and resolvable Rust dependency
+      updates.
+    - BACK-20260724_1843-PatientLynx-implement-aibox-v1-orchestration remains in progress.
+    - BACK-20260514_0925-VastHare-tmux-theme-switch-prefix-menu-binding remains in
+      progress.
+    - BACK-20260514_0924-ActiveSummit-tmux-layout-chooser-prefix-menu-binding remains
+      in progress.
+    - BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence and
+      BACK-20260725_1003-GiftedBlossom-implement-m7c-disposable-cluster-e2e-and remain
+      blocked.
+    next_recommended_action: On the macOS host, sync the checkout to origin/v0.x-release,
+      rebuild aibox-e2e-testrunner with both Compose files using --no-cache, and force-recreate
+      the service. Then verify companion contract 3 and run the complete ./scripts/maintain.sh
+      release 0.30.1 workflow without skipping Tier 2.
+    branch: v0.x-release
+    commit: 3c8edd1c4b65
+    git_context: 'Working tree was clean before this handover. One linked worktree
+      exists at /workspace. Local and remote branch inventory is limited to gh-pages,
+      main, v0.x-dev, v0.x-release, v1.x-dev, and v1.x-pre-release. Preserve stash@{0}:
+      On v1.x-pre-release: pre-release-host-v0.29.0-primary-20260801T195034Z.'
+    behavioral_retrospective:
+    - 'The initial v1 cherry-pick lacked a Version-Line-Port trailer, so the v0 release
+      gate correctly blocked. The mapping was repaired through PR #346 and the gate
+      was rerun clean.'
+    - 'No promised entity creation remains deferred: the release-state dependency
+      findings are captured in BACK-20260807_0835-LucidLeaf-review-deferred-v0-30-1-dependency.'
+    - The release was stopped at the stale companion prerequisite instead of bypassing
+      mandatory Tier 2 evidence.
+---


### PR DESCRIPTION
Records the canonical processkit session handover after the Starship repair ports, repository cleanup, and v0.30.1 pre-release gate.