### PR TITLE
fix: resolve latest Codex before container builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -186,7 +186,7 @@ RUN npm install -g pnpm@11.18.0 && \
 # npm package: @openai/codex | Binary: codex | Config: ~/.codex/
 # Auth: OPENAI_API_KEY (or ChatGPT Plus/Pro/Team/Enterprise account)
 # To pin a version: set [ai.harness.codex] version in aibox.toml
-RUN npm install -g @openai/codex
+RUN npm install -g @openai/codex@0.147.0
 
 
 # Addon: docs-docusaurus

--- a/aibox.lock
+++ b/aibox.lock
@@ -11,9 +11,10 @@ installed_at = "2026-07-31T18:57:00.640055+00:00"
 processkit_install_hash = "v2:13e7f239b8daa3e6b497e06fb2b843a511ed3061222dc2bc6654fda13d05d099"
 
 [addons]
-resolved_at = "2026-05-09T10:41:25Z"
+resolved_at = "2026-08-07T09:28:57Z"
 
 [addons.tools]
+codex = "0.147.0"
 
 [addons.previous_selection]
 docs-docusaurus = ["docusaurus"]

--- a/cli/src/container.rs
+++ b/cli/src/container.rs
@@ -3605,55 +3605,7 @@ pub fn cmd_sync(
         ));
     }
 
-    // Resolve "latest" addon tool versions to concrete versions.
-    // The resolved versions are used in Dockerfile generation and recorded
-    // in aibox.lock so builds are reproducible.
-    let mut resolved_tools = std::collections::BTreeMap::new();
-    for (addon_name, addon_tools) in &mut config.addons.addons {
-        for (tool_name, tool_entry) in &mut addon_tools.tools {
-            if tool_entry.version.as_deref() == Some("latest") {
-                // Try upstream resolution for key tools
-                if let Some(resolved) = crate::version_resolve::resolve_latest(tool_name) {
-                    tool_entry.version = Some(resolved.clone());
-                    resolved_tools.insert(tool_name.clone(), resolved);
-                } else if let Some(addon) = crate::addon_loader::get_addon(addon_name)
-                    && let Some(tool_def) = addon.tools.iter().find(|t| &t.name == tool_name)
-                    && !tool_def.default_version.is_empty()
-                {
-                    // Fall back to addon's default_version
-                    let ver = tool_def.default_version.clone();
-                    tool_entry.version = Some(ver.clone());
-                    resolved_tools.insert(tool_name.clone(), ver);
-                }
-            }
-        }
-    }
-    if !resolved_tools.is_empty() {
-        output::info(&format!(
-            "Resolved {} 'latest' tool version(s) to concrete values",
-            resolved_tools.len()
-        ));
-        // Write resolved versions to aibox.lock
-        let project_root = std::env::current_dir().unwrap_or_default();
-        if let Ok(Some(mut lock)) = crate::lock::read_lock(&project_root) {
-            let preserved_previous_selection = lock
-                .addons
-                .as_ref()
-                .map(|a| a.previous_selection.clone())
-                .unwrap_or_default();
-            lock.addons = Some(crate::lock::AddonsLockSection {
-                resolved_at: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
-                tools: resolved_tools,
-                previous_selection: preserved_previous_selection,
-            });
-            if let Err(e) = crate::lock::write_lock(&project_root, &lock) {
-                output::warn(&format!(
-                    "Failed to update aibox.lock with resolved tool versions: {}",
-                    e
-                ));
-            }
-        }
-    }
+    resolve_latest_addon_tool_versions(&mut config, Path::new("."));
 
     // v0.25.6 BR-CLEANUP-ARCH item 1 (DEC-20260508_1515-SilentAsh):
     // Backfill addon/harness `previous_selection` on the lock so future
@@ -4057,6 +4009,7 @@ pub fn cmd_apply_generated_runtime(config_path: &Option<String>) -> Result<()> {
 
     let mut config = AiboxConfig::from_cli_option(config_path)?;
     resolve_aibox_image_version_for_generation(&mut config, &project_root);
+    resolve_latest_addon_tool_versions(&mut config, &project_root);
 
     let added_required_addons = complete_missing_required_addons(&mut config);
     if !added_required_addons.is_empty() {
@@ -4093,6 +4046,56 @@ pub fn cmd_apply_generated_runtime(config_path: &Option<String>) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Resolve addon `version = "latest"` sentinels before rendering so the
+/// generated Dockerfile changes when upstream latest changes instead of
+/// silently reusing a stale Docker build layer.
+fn resolve_latest_addon_tool_versions(config: &mut AiboxConfig, project_root: &Path) {
+    let mut resolved_tools = std::collections::BTreeMap::new();
+    for (addon_name, addon_tools) in &mut config.addons.addons {
+        for (tool_name, tool_entry) in &mut addon_tools.tools {
+            if tool_entry.version.as_deref() == Some("latest") {
+                if let Some(resolved) = crate::version_resolve::resolve_latest(tool_name) {
+                    tool_entry.version = Some(resolved.clone());
+                    resolved_tools.insert(tool_name.clone(), resolved);
+                } else if let Some(addon) = crate::addon_loader::get_addon(addon_name)
+                    && let Some(tool_def) = addon.tools.iter().find(|t| &t.name == tool_name)
+                    && !tool_def.default_version.is_empty()
+                {
+                    let version = tool_def.default_version.clone();
+                    tool_entry.version = Some(version.clone());
+                    resolved_tools.insert(tool_name.clone(), version);
+                }
+            }
+        }
+    }
+    if resolved_tools.is_empty() {
+        return;
+    }
+
+    output::info(&format!(
+        "Resolved {} 'latest' tool version(s) to concrete values",
+        resolved_tools.len()
+    ));
+    if let Ok(Some(mut lock)) = crate::lock::read_lock(project_root) {
+        let preserved_previous_selection = lock
+            .addons
+            .as_ref()
+            .map(|addons| addons.previous_selection.clone())
+            .unwrap_or_default();
+        lock.addons = Some(crate::lock::AddonsLockSection {
+            resolved_at: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            tools: resolved_tools,
+            previous_selection: preserved_previous_selection,
+        });
+        if let Err(error) = crate::lock::write_lock(project_root, &lock) {
+            output::warn(&format!(
+                "Failed to update aibox.lock with resolved tool versions: {}",
+                error
+            ));
+        }
+    }
 }
 
 fn resolve_aibox_image_version_for_generation(config: &mut AiboxConfig, project_root: &Path) {

--- a/cli/src/version_resolve.rs
+++ b/cli/src/version_resolve.rs
@@ -1,6 +1,6 @@
 //! Resolve `version = "latest"` to concrete upstream versions.
 //!
-//! For key tools (rustc, node, python), queries upstream APIs to find the
+//! For key tools (rustc, node, python, Codex), queries upstream APIs to find the
 //! actual latest stable version. Other tools fall back to the addon's
 //! `default_version`. Resolvers fail gracefully — on network error, they
 //! return `None` and the caller falls back to the addon default.
@@ -16,8 +16,33 @@ pub fn resolve_latest(tool_name: &str) -> Option<String> {
         "rustc" => resolve_rustc().ok().flatten(),
         "node" => resolve_node().ok().flatten(),
         "python" => resolve_python().ok().flatten(),
+        "codex" => resolve_npm_latest("@openai/codex", "Codex").ok().flatten(),
         _ => None,
     }
+}
+
+/// Resolve an npm package's `latest` dist-tag to a concrete version.
+fn resolve_npm_latest(package: &str, display_name: &str) -> Result<Option<String>> {
+    let encoded_package = package.replace('/', "%2f");
+    let url = format!("https://registry.npmjs.org/{encoded_package}/latest");
+    output::info(&format!(
+        "Resolving latest stable {display_name} version..."
+    ));
+    let body = ureq::get(&url).call()?.body_mut().read_to_string()?;
+    let version = parse_npm_latest_version(&body)?;
+    if let Some(version) = &version {
+        output::ok(&format!("Resolved {} latest -> {}", display_name, version));
+    }
+    Ok(version)
+}
+
+fn parse_npm_latest_version(body: &str) -> Result<Option<String>> {
+    let metadata: serde_json::Value = serde_json::from_str(body)?;
+    Ok(metadata
+        .get("version")
+        .and_then(|value| value.as_str())
+        .filter(|version| !version.is_empty())
+        .map(str::to_string))
 }
 
 /// Resolve the latest stable Rust version from the release channel manifest.
@@ -90,5 +115,17 @@ mod tests {
     #[test]
     fn unknown_tool_returns_none() {
         assert!(resolve_latest("unknown-tool-xyz").is_none());
+    }
+
+    #[test]
+    fn parses_npm_latest_version() {
+        assert_eq!(
+            parse_npm_latest_version(r#"{"name":"@openai/codex","version":"0.147.0"}"#).unwrap(),
+            Some("0.147.0".to_string())
+        );
+        assert_eq!(
+            parse_npm_latest_version(r#"{"name":"@openai/codex"}"#).unwrap(),
+            None
+        );
     }
 }


### PR DESCRIPTION
## What changed

- resolve the `@openai/codex` npm `latest` dist-tag to a concrete version during `aibox apply`
- run the same resolution for the `generated-runtime` path
- record the resolved Codex version in `aibox.lock`
- regenerate the tracked Dockerfile with Codex 0.147.0

## Why

An unpinned `npm install -g @openai/codex` instruction kept the same Docker cache key when npm's latest release changed. Recreating or rebuilding the container could therefore retain an older Codex layer and still report an available update.

The concrete resolved version changes the Dockerfile whenever npm's latest tag advances, invalidating that layer while preserving reproducible builds.

## Validation

- `cargo test` — 1,075 unit, 90 Tier-1 E2E passed with 1 ignored, 32 integration
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `aibox apply generated-runtime -y --no-container` resolved Codex latest to 0.147.0