### PR TITLE
fix(v0.30.1): refresh security-relevant addon pins

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -177,7 +177,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     rm -f "/tmp/${NODE_ARCHIVE}" /tmp/node-shasums.txt && \
     node --version && npm --version
 
-RUN npm install -g pnpm@11.18.0 && \
+RUN npm install -g pnpm@11.20.0 && \
     npm cache clean --force
 
 

--- a/addons/ai/ai-tau.yaml
+++ b/addons/ai/ai-tau.yaml
@@ -11,8 +11,8 @@ tools:
   - name: tau
     description: "Tau terminal coding agent"
     default_enabled: true
-    default_version: "0.3.5"
-    supported_versions: ["0.3.5"]
+    default_version: "0.3.7"
+    supported_versions: ["0.3.5", "0.3.7"]
 
 builder: null
 

--- a/addons/languages/node.yaml
+++ b/addons/languages/node.yaml
@@ -26,8 +26,8 @@ tools:
   - name: pnpm
     description: "Fast disk-efficient Node package manager"
     default_enabled: true
-    default_version: "11.18.0"
-    supported_versions: ["9", "10", "11.1.3", "11.5.2", "11.10.0", "11.18.0"]
+    default_version: "11.20.0"
+    supported_versions: ["9", "10", "11.1.3", "11.5.2", "11.10.0", "11.18.0", "11.20.0"]
   - name: yarn
     description: "Yarn Node package manager"
     default_enabled: false

--- a/aibox.toml
+++ b/aibox.toml
@@ -334,7 +334,7 @@ hugo = { enabled = true } # Fast Go-based static site generator; default off; op
 # Languages/node — Node.js runtime with pnpm, yarn, or bun
 [addons.node.tools]
 node = { version = "26" } # Node.js JavaScript and TypeScript runtime; default on; options: {}, { enabled = true|false }, { version = "20" | "22" | "24" | "26" (default) or "latest" }
-pnpm = { version = "11.18.0" } # Fast disk-efficient Node package manager; default on; options: {}, { enabled = true|false }, { version = "9" | "10" | "11.1.3" | "11.5.2" | "11.10.0" | "11.18.0" (default) or "latest" }
+pnpm = { version = "11.20.0" } # Fast disk-efficient Node package manager; default on; options: {}, { enabled = true|false }, { version = "9" | "10" | "11.1.3" | "11.5.2" | "11.10.0" | "11.18.0" | "11.20.0" (default) or "latest" }
 # yarn = { enabled = true } # Yarn Node package manager; default off; options: {}, { enabled = true|false }, { version = "4" | "4.16.0" | "4.17.0" (default) or "latest" }
 # bun = { enabled = true } # Bun JavaScript runtime, package manager, and test runner; default off; options: {}, { enabled = true|false }, { version = "1.2" | "1.3.14" (default) or "latest" }
 

--- a/cli/src/addon_registry.rs
+++ b/cli/src/addon_registry.rs
@@ -389,8 +389,8 @@ mod tests {
             !hermes.contains("USER aibox"),
             "Hermes installation must retain root access to /usr/local/bin: {hermes}"
         );
-        let tau = generate_runtime_commands("ai-tau", &tc(&[("tau", true, "0.3.5")]));
-        assert!(tau.contains("tau-ai==0.3.5"), "{tau}");
+        let tau = generate_runtime_commands("ai-tau", &tc(&[("tau", true, "0.3.7")]));
+        assert!(tau.contains("tau-ai==0.3.7"), "{tau}");
         assert!(
             tau.contains("UV_TOOL_DIR=/opt/aibox/uv-tools"),
             "Tau tool environment must use the shared uv path: {tau}"

--- a/cli/src/generate.rs
+++ b/cli/src/generate.rs
@@ -1885,7 +1885,7 @@ mod tests {
         generate_dockerfile(&config, dir.path(), &test_env()).unwrap();
         let content = fs::read_to_string(dir.path().join("Dockerfile")).unwrap();
         assert!(
-            content.contains("UV_TOOL_DIR=/opt/aibox/uv-tools uv tool install tau-ai==0.3.5"),
+            content.contains("UV_TOOL_DIR=/opt/aibox/uv-tools uv tool install tau-ai==0.3.7"),
             "Tau should be installed from its pinned PyPI package: {content}"
         );
         assert!(

--- a/docs-site/content/docs/addons/language-runtimes.md
+++ b/docs-site/content/docs/addons/language-runtimes.md
@@ -35,7 +35,7 @@ Installs the Rust toolchain via rustup with clippy and rustfmt. Uses a multi-sta
 ```toml
 [addons.node.tools]
 node = { version = "26" }       # 20, 22, 24, 26
-pnpm = { version = "11.18.0" }  # 9, 10, 11.1.3, 11.5.2, 11.10.0, 11.18.0
+pnpm = { version = "11.20.0" }  # 9, 10, 11.1.3, 11.5.2, 11.10.0, 11.18.0, 11.20.0
 # yarn = { version = "4.17.0" } # Optional: 4, 4.16.0, 4.17.0
 # bun = { version = "1.3.14" }  # Optional
 ```

--- a/docs-site/content/docs/addons/overview.md
+++ b/docs-site/content/docs/addons/overview.md
@@ -42,7 +42,7 @@ rustfmt = {}
 
 [addons.node.tools]
 node = { version = "26" }
-pnpm = { version = "11.18.0" }
+pnpm = { version = "11.20.0" }
 ```
 
 Each addon has **default-enabled tools** that are included automatically, and **optional tools** you can enable explicitly. Tools with version selection let you pick from curated, tested versions.
@@ -70,7 +70,7 @@ After editing `aibox.toml`, run `aibox apply` to regenerate the Dockerfile and r
 |-------|--------------|----------------|
 | `python` | python (3.12/3.13/3.14), uv (0.7/0.11.10/0.11.11/0.11.15/0.11.19/0.11.26/0.12.0) | poetry (1.8/2.0/2.4.1), pdm (2.22/2.26.9/2.27.0/2.28.0) |
 | `rust` | rustc (1.90/1.91/1.92/1.93/1.94/1.94.1/1.96.0/1.96.1/1.97.1), clippy, rustfmt | — |
-| `node` | node (20/22/24/26), pnpm (9/10/11.1.3/11.5.2/11.10.0/11.18.0) | yarn (4/4.16.0/4.17.0), bun (1.2/1.3.14) |
+| `node` | node (20/22/24/26), pnpm (9/10/11.1.3/11.5.2/11.10.0/11.18.0/11.20.0) | yarn (4/4.16.0/4.17.0), bun (1.2/1.3.14) |
 | `go` | go (1.25/1.26/1.26.3/1.26.4/1.26.5) | — |
 | `go-quality` | goimports, staticcheck, golangci-lint, govulncheck, gosec | — |
 | `typst` | typst (0.13.1/0.14.2/0.15.0) | — |


### PR DESCRIPTION
## Summary

- update the curated pnpm default to 11.20.0 for package-substitution and path-traversal fixes
- update the curated Tau default to 0.3.7 for project-input trust hardening
- retain prior curated versions for explicit pins
- refresh the generated project Dockerfile and addon documentation

## Validation

- cargo fmt -- --check
- cargo test (1075 unit, 90 Tier-1 E2E passed + 1 ignored, 32 integration)
- cargo clippy --all-targets -- -D warnings
- AIBOX_PORT_TARGET_REF=HEAD ./scripts/check-version-line-ports.sh check v0
- ./scripts/maintain.sh release-check-state