### PR TITLE
release: prepare v0.30.1 candidate

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/cli/tests/e2e/addon.rs
+++ b/cli/tests/e2e/addon.rs
@@ -119,7 +119,10 @@ fn addon_rebuild_includes_tools_in_dockerfile() {
 #[test]
 #[serial(companion_runtime)]
 #[ignore = "resource-heavy addon image build; run through scripts/run-e2e-shards.sh addon or all"]
-#[ntest::timeout(1_800_000)]
+// The all-defaults image validates every download-backed installer in one
+// build. On the nested companion, uncached package extraction can legitimately
+// exceed 30 minutes even when the build is making progress.
+#[ntest::timeout(3_600_000)]
 fn download_based_addons_build_with_published_defaults() {
     let runner = E2eRunner::new();
     let test = "addon-download-smoke";


### PR DESCRIPTION
- bump the CLI and lockfile to 0.30.1
- extend the all-defaults addon build timeout after two healthy companion runs reached the prior 30-minute boundary

The timeout remains bounded at one hour and applies only to the ignored, release-sharded aggregate addon build.