### PR TITLE
feat: add optional rootless Podman infrastructure tool

### DIFF
--- a/addons/tools/infrastructure.yaml
+++ b/addons/tools/infrastructure.yaml
@@ -1,6 +1,6 @@
 name: infrastructure
 version: "1.0.0"
-description: "OpenTofu, Ansible, Packer"
+description: "OpenTofu, Ansible, Packer, and optional rootless Podman"
 profile_intent: runtime
 usage_class: automated
 profiles: ["human-dev", "headless-runner"]
@@ -26,6 +26,11 @@ tools:
     default_enabled: true
     default_version: "1.16.0"
     supported_versions: ["1.11.2", "1.15.3", "1.15.4", "1.16.0"]
+  - name: podman
+    description: "Rootless container engine with Compose support"
+    default_enabled: false
+    default_version: ""
+    supported_versions: []
 
 builder: |
   # ── Infrastructure builder ────────────────────────────────────────────
@@ -39,20 +44,19 @@ builder: |
       unzip \
       && rm -rf /var/lib/apt/lists/*
 
-  RUN mkdir -p /build/bin && \
+  RUN mkdir -p /build/bin
   {% if tools.opentofu.enabled %}
-      TOFU_VERSION="{{ tools.opentofu.version }}" && \
+  RUN TOFU_VERSION="{{ tools.opentofu.version }}" && \
       ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && \
       TOFU_ARCHIVE="tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" && \
       curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/${TOFU_ARCHIVE}" -o "/tmp/${TOFU_ARCHIVE}" && \
       curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS" -o /tmp/tofu_SHA256SUMS && \
       (cd /tmp && grep "${TOFU_ARCHIVE}$" tofu_SHA256SUMS | sha256sum -c -) && \
       tar -xz -C /build/bin -f "/tmp/${TOFU_ARCHIVE}" tofu && \
-      rm "/tmp/${TOFU_ARCHIVE}" /tmp/tofu_SHA256SUMS{% if tools.packer.enabled %} && \
-  {% endif %}
+      rm "/tmp/${TOFU_ARCHIVE}" /tmp/tofu_SHA256SUMS
   {% endif %}
   {% if tools.packer.enabled %}
-      ARCH="$(dpkg --print-architecture)" && \
+  RUN ARCH="$(dpkg --print-architecture)" && \
       PACKER_VERSION="{{ tools.packer.version }}" && \
       PACKER_ARCHIVE="packer_${PACKER_VERSION}_linux_${ARCH}.zip" && \
       curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_ARCHIVE}" \
@@ -82,6 +86,22 @@ runtime: |
         ln -sf "$bin" "/usr/local/bin/$(basename "$bin")"; \
       done
   {% endif %}
+  {% if tools.podman.enabled %}
+  USER root
+  RUN apt-get update && apt-get install -y --no-install-recommends \
+      podman \
+      podman-compose \
+      fuse-overlayfs \
+      passt \
+      slirp4netns \
+      uidmap \
+      && rm -rf /var/lib/apt/lists/*
+  RUN grep -q '^aibox:' /etc/subuid || echo 'aibox:100000:65536' >> /etc/subuid; \
+      grep -q '^aibox:' /etc/subgid || echo 'aibox:100000:65536' >> /etc/subgid; \
+      mkdir -p /home/aibox/.config/containers && \
+      printf '[engine]\ncgroup_manager = "cgroupfs"\n' > /home/aibox/.config/containers/containers.conf && \
+      chown -R aibox:aibox /home/aibox/.config/containers
+  {% endif %}
   # ── Variant 1 disable-then-purge guards ───────────────────────────────
   {% if not tools.opentofu.enabled %}
   USER root
@@ -94,4 +114,9 @@ runtime: |
   {% if not tools.ansible.enabled %}
   USER root
   RUN rm -rf /opt/aibox/ansible && rm -f /usr/local/bin/ansible*
+  {% endif %}
+  {% if not tools.podman.enabled %}
+  USER root
+  RUN apt-get purge -y podman podman-compose 2>/dev/null || true; \
+      rm -f /usr/local/bin/podman /usr/bin/podman /usr/local/bin/podman-compose /usr/bin/podman-compose
   {% endif %}

--- a/aibox.toml
+++ b/aibox.toml
@@ -390,11 +390,12 @@ lazygit = { enabled = true } # Interactive terminal UI for Git status, commits, 
 # [addons.go-release.tools]
 # goreleaser = {} # Multi-platform Go release packager; default on; options: {}, { enabled = true|false }, { version = "2.17.1" (default) or "latest" }
 
-# Tools/infrastructure — OpenTofu, Ansible, Packer
+# Tools/infrastructure — OpenTofu, Ansible, Packer, and optional rootless Podman
 # [addons.infrastructure.tools]
 # opentofu = {} # Open-source Terraform-compatible infrastructure as code CLI; default on; options: {}, { enabled = true|false }, { version = "1.9.0" | "1.12.0" | "1.12.1" | "1.12.3" | "1.12.5" (default) or "latest" }
 # ansible = {} # Configuration management and automation engine; default on; options: {}, { enabled = true|false }, { version = "13.7.0" | "14.0.0" | "14.1.0" | "14.2.0" (default) or "latest" }
 # packer = {} # Machine image build automation tool; default on; options: {}, { enabled = true|false }, { version = "1.11.2" | "1.15.3" | "1.15.4" | "1.16.0" (default) or "latest" }
+# podman = { enabled = true } # Rootless container engine with Compose support; default off; options: {}, { enabled = true|false }, { version = "x.y.z" or "latest" }
 
 # Tools/kubernetes — kubectl, Helm, Kustomize, k9s
 # [addons.kubernetes.tools]

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1452,6 +1452,27 @@ runtime: |
     }
 
     #[test]
+    fn infrastructure_runtime_installs_rootless_podman_prerequisites() {
+        let addon = load_repo_addon("infrastructure");
+        let tools = all_enabled_tools(&addon);
+        let rendered = render_runtime(&addon, &tools).unwrap();
+
+        for expected in [
+            "podman-compose",
+            "fuse-overlayfs",
+            "slirp4netns",
+            "uidmap",
+            "aibox:100000:65536",
+            "cgroup_manager = \"cgroupfs\"",
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "Podman runtime must include {expected}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
     fn pip_packaged_runtime_tools_use_isolated_venvs() {
         for (addon_name, venv, command) in [
             ("cloud-azure", "azure-cli", "az"),
@@ -1535,6 +1556,7 @@ runtime: |
         let rendered = render_runtime(&addon, &tools).unwrap();
         assert!(rendered.contains("rm -f /usr/local/bin/tofu"));
         assert!(rendered.contains("rm -f /usr/local/bin/packer"));
+        assert!(rendered.contains("apt-get purge -y podman podman-compose"));
         assert!(rendered.contains("rm -rf /opt/aibox/ansible"));
         assert!(rendered.contains("rm -f /usr/local/bin/ansible*"));
     }

--- a/cli/tests/e2e/addon.rs
+++ b/cli/tests/e2e/addon.rs
@@ -171,6 +171,68 @@ fn download_based_addons_build_with_published_defaults() {
 }
 
 #[test]
+#[serial(companion_runtime)]
+#[ignore = "resource-heavy nested Podman image build; run explicitly on the E2E companion"]
+#[ntest::timeout(900_000)]
+fn infrastructure_podman_runs_rootless_inside_generated_container() {
+    let runner = E2eRunner::new();
+    let test = "infrastructure-podman";
+    runner.cleanup(test);
+
+    let init = runner.aibox(
+        test,
+        &["init", test, "--base", "debian", "--context", "managed"],
+    );
+    assert!(
+        init.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let mut config = runner.read_file(test, "aibox.toml");
+    config.push_str(
+        "\n[addons.infrastructure.tools]\n\
+         opentofu = { enabled = false }\n\
+         ansible = { enabled = false }\n\
+         packer = { enabled = false }\n\
+         podman = {}\n",
+    );
+    runner.write_file(test, "aibox.toml", &config);
+
+    let apply = runner.aibox(test, &["apply"]);
+    assert!(
+        apply.status.success(),
+        "Podman-enabled project failed to build:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+
+    let runtime = runner.runtime_bin();
+    let up = runner.exec(&format!(
+        "{runtime} compose -f /workspaces/{test}/.devcontainer/docker-compose.yml up -d {test}"
+    ));
+    assert!(
+        up.status.success(),
+        "Podman-enabled project failed to start:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&up.stdout),
+        String::from_utf8_lossy(&up.stderr)
+    );
+
+    let probe = runner.container_exec(
+        test,
+        "podman --version && podman-compose --version && podman info --format '{{.Host.Security.Rootless}}'",
+    );
+    assert!(
+        probe.status.success() && String::from_utf8_lossy(&probe.stdout).contains("true"),
+        "rootless Podman probe failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&probe.stdout),
+        String::from_utf8_lossy(&probe.stderr)
+    );
+
+    runner.cleanup(test);
+}
+
+#[test]
 fn get_addon_shows_available() {
     let runner = E2eRunner::new();
     let test = "addon-list";

--- a/docs-site/content/docs/addons/language-runtimes.md
+++ b/docs-site/content/docs/addons/language-runtimes.md
@@ -66,6 +66,13 @@ staticcheck = { enabled = false } # optional per-tool override
 [addons.go.supply-chain]
 
 [addons.go.release]
+
+# Optional nested container engine without the other infrastructure defaults:
+[addons.go.infrastructure.tools]
+opentofu = { enabled = false }
+ansible = { enabled = false }
+packer = { enabled = false }
+podman = {}
 ```
 
 `quality` installs `goimports`, `staticcheck`, `golangci-lint`,
@@ -74,6 +81,9 @@ by `go test -race ./...`. `supply-chain` adds `gitleaks`, `osv-scanner`,
 `syft`, `grype`, and `cosign`. `release` adds GoReleaser, ShellCheck, and
 Hadolint. The built-in `gofmt`, `go vet`, `go test`, fuzzing, and coverage
 commands remain part of the Go toolchain and need no extra binary.
+The optional `podman` selection installs a rootless container engine and its
+Compose provider. The explicit disables keep OpenTofu, Ansible, and Packer out
+when the project only needs nested container operations.
 
 The same `infrastructure`, `security`/`supply-chain`, and `release` group names
 are accepted below every language addon. Go additionally exposes `quality`

--- a/docs-site/content/docs/addons/overview.md
+++ b/docs-site/content/docs/addons/overview.md
@@ -80,7 +80,7 @@ After editing `aibox.toml`, run `aibox apply` to regenerate the Dockerfile and r
 
 | Addon | Default Tools | Optional Tools |
 |-------|--------------|----------------|
-| `infrastructure` | opentofu, ansible, packer | — |
+| `infrastructure` | opentofu, ansible, packer | podman (rootless engine and Compose) |
 | `supply-chain` | gitleaks, osv-scanner, syft, grype, cosign | — |
 | `release` | shellcheck, hadolint | — |
 | `go-release` | goreleaser (requires `go` and `release`) | — |

--- a/docs-site/content/docs/addons/tool-bundles.md
+++ b/docs-site/content/docs/addons/tool-bundles.md
@@ -99,10 +99,16 @@ automatically when `[audio] enabled = true` and `install = true`; projects norma
 opentofu = {}      # Infrastructure-as-code (Terraform alternative)
 ansible = {}       # Configuration management
 packer = {}        # Machine image builder
+podman = {}        # Optional rootless container engine + Compose
 ```
 
 OpenTofu defaults to 1.12.5, Packer to 1.16.0, and Ansible to 14.2.0.
 OpenTofu and Packer are installed in a multi-stage builder. Ansible is installed via pip.
+Podman is optional and installs the Debian-packaged rootless engine, Compose
+provider, user-namespace helpers, and overlay/networking prerequisites. Nested
+containers still depend on the outer runtime allowing user namespaces; FUSE
+overlay is used when `/dev/fuse` is available, with Podman's normal fallback
+otherwise.
 
 ## Kubernetes
 


### PR DESCRIPTION
## Summary

- expose optional rootless Podman and Compose support through the infrastructure addon
- keep Podman disabled by default and document a Podman-only Go group configuration
- retain supply-chain tools in the language-neutral Go supply-chain/release mappings
- fix infrastructure builder rendering when OpenTofu and Packer are both disabled
- add unit coverage and a companion-backed nested Podman runtime probe

## Validation

- cargo fmt -- --check
- cargo test (1076 unit, 90 Tier-1 E2E + 1 ignored, 32 integration)
- cargo clippy --all-targets -- -D warnings
- companion E2E rootless Podman build/probe
- v0 version-line port gate