### PR TITLE
docs(v0.31.0): prepare release metadata

### DIFF
--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -653,6 +653,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.5",
         note: "Patch release: refreshes the companion E2E contract, repairs Starship cache isolation, resolves Codex latest pins before container builds, and updates security-relevant pnpm and Tau curated defaults.",
     },
+    CompatEntry {
+        aibox_version: "0.31.0",
+        processkit_version: "v0.28.5",
+        note: "Minor release: adds optional rootless Podman and Podman Compose tooling to the infrastructure addon, documents the Go supply-chain and release bundles, and repairs minimal infrastructure addon rendering.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/dist/RELEASE-NOTES.md
+++ b/dist/RELEASE-NOTES.md
@@ -1,20 +1,19 @@
-# aibox v0.30.1 — 2026-08-07
+# aibox v0.31.0 — 2026-08-07
 
-**Summary:** This patch release makes container rebuilds honor Codex `latest`, hardens curated pnpm and Tau installations, and improves runtime and release validation reliability. Projects using `latest` or curated defaults should run `aibox apply` and rebuild their container.
+**Summary:** This minor release lets derived projects opt into rootless Podman and Podman Compose inside their development container, alongside the existing curated Go supply-chain and release bundles. Projects that need an internal container runtime can enable the new infrastructure tool and rebuild.
 
 ## Added
 
-- Add candidate-bound, independently retryable release validation evidence and sharded Tier-2 E2E execution.
+- Add an optional `podman` infrastructure tool with Podman Compose and rootless runtime prerequisites.
+- Add companion-backed E2E coverage that starts a generated container and verifies nested rootless Podman operation.
 
 ## Changed
 
-- Update the curated pnpm default to 11.20.0 and Tau default to 0.3.7 while retaining earlier versions as explicit pins.
-- Refresh the E2E companion contract and validation for its current tmux, Yazi, Podman, and bubblewrap runtime.
+- Document the existing Go `supply-chain` bundle (`gitleaks`, `osv-scanner`, `syft`, `grype`, and `cosign`) and `release` bundle (`goreleaser`, `shellcheck`, and `hadolint`).
 
 ## Fixed
 
-- Resolve Codex `latest` to a concrete upstream version before Docker generation so rebuilds do not reuse a stale cached npm layer.
-- Isolate Starship cache files per shell to prevent cache-directory collisions in generated and image runtime configurations.
+- Render a valid infrastructure builder stage when OpenTofu and Packer are both disabled.
 
 ## Removed
 
@@ -22,6 +21,6 @@
 
 ## Upgrade notes
 
-Run `aibox apply` and rebuild the container to receive newly resolved `latest` pins and curated addon defaults. Existing explicit addon pins remain unchanged.
+Enable the runtime with `[addons.go.infrastructure.tools] podman = {}` (or the equivalent language group), then run `aibox apply` and rebuild the container. Existing projects remain unchanged because Podman is disabled by default.
 
-[v0.30.1]: https://github.com/projectious-work/aibox/compare/v0.30.0...v0.30.1
+[v0.31.0]: https://github.com/projectious-work/aibox/compare/v0.30.1...v0.31.0

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.31.0 | v0.28.5 | adds optional rootless Podman and Podman Compose tooling to the infrastructure addon, documents the Go supply-chain and release bundles, and repairs minimal infrastructure addon rendering |
 | 0.30.1 | v0.28.5 | refreshes the companion E2E contract, repairs Starship cache isolation, resolves Codex `latest` pins before container builds, and updates security-relevant pnpm and Tau curated defaults |
 | 0.30.0 | v0.28.5 | adds nested language addon groups, production Go quality tooling, and language-neutral supply-chain and release bundles with pinned versions, checksum verification, and per-tool overrides |
 | 0.29.0 | v0.28.5 | adds Tau as a first-class multi-provider coding-agent harness with pinned installation, persistent runtime state, AGENTS.md discovery, Agent Skills projection, and explicit reporting that Tau does not currently expose a built-in MCP client |


### PR DESCRIPTION
Prepare the compatibility metadata and curated release notes for the v0.31.0 minor release.\n\nValidation: cargo test compat::tests::cargo_pkg_version_has_compat_entry