### PR TITLE
fix(docs): refresh aibox tab icon

### DIFF
--- a/docs-site/layouts/_partials/favicons.html
+++ b/docs-site/layouts/_partials/favicons.html
@@ -1,14 +1,16 @@
 {{/*
-  aibox favicons generated from the canonical project logo assets.
+  aibox hex-mark favicons, shared with the v1.x documentation workstream.
 
   Overrides the Docsy default, which references an icongen file set this
-  project does not ship. Source assets live under assets/logo/.
+  project does not ship. Keep the revision query in sync when artwork changes,
+  because browsers cache site icons especially aggressively.
 */ -}}
-<link rel="icon" href="{{ "favicons/favicon.ico" | relURL }}" sizes="any">
-<link rel="icon" type="image/svg+xml" href="{{ "favicons/favicon.svg" | relURL }}">
-<link rel="icon" type="image/png" href="{{ "favicons/favicon-16x16.png" | relURL }}" sizes="16x16">
-<link rel="icon" type="image/png" href="{{ "favicons/favicon-32x32.png" | relURL }}" sizes="32x32">
-<link rel="icon" type="image/png" href="{{ "favicons/favicon-48x48.png" | relURL }}" sizes="48x48">
-<link rel="icon" type="image/png" href="{{ "favicons/icon-128x128.png" | relURL }}" sizes="128x128">
-<link rel="icon" type="image/png" href="{{ "favicons/icon-256x256.png" | relURL }}" sizes="256x256">
-<link rel="apple-touch-icon" href="{{ "favicons/apple-touch-icon-180x180.png" | relURL }}" sizes="180x180">
+{{- $faviconRevision := "aibox-hex-1" -}}
+<link rel="icon" type="image/svg+xml" href="{{ printf "%s?v=%s" ("favicons/favicon.svg" | relURL) $faviconRevision }}">
+<link rel="icon" type="image/png" href="{{ printf "%s?v=%s" ("favicons/favicon-32x32.png" | relURL) $faviconRevision }}" sizes="32x32">
+<link rel="icon" type="image/png" href="{{ printf "%s?v=%s" ("favicons/favicon-16x16.png" | relURL) $faviconRevision }}" sizes="16x16">
+<link rel="icon" type="image/png" href="{{ printf "%s?v=%s" ("favicons/favicon-48x48.png" | relURL) $faviconRevision }}" sizes="48x48">
+<link rel="icon" type="image/png" href="{{ printf "%s?v=%s" ("favicons/icon-128x128.png" | relURL) $faviconRevision }}" sizes="128x128">
+<link rel="icon" type="image/png" href="{{ printf "%s?v=%s" ("favicons/icon-256x256.png" | relURL) $faviconRevision }}" sizes="256x256">
+<link rel="shortcut icon" href="{{ printf "%s?v=%s" ("favicons/favicon.ico" | relURL) $faviconRevision }}">
+<link rel="apple-touch-icon" href="{{ printf "%s?v=%s" ("favicons/apple-touch-icon-180x180.png" | relURL) $faviconRevision }}" sizes="180x180">


### PR DESCRIPTION
## Changes
- prefer the v1 hex-mark SVG for modern browser tabs
- retain ICO fallback for legacy browsers
- add a revision query to every favicon URL to invalidate stale browser caches

## Verification
- Hugo build passes (147 pages)
- generated head lists the versioned SVG first and versioned PNG/ICO fallbacks