### PR TITLE
chore: record v0.31.0 session handover

### DIFF
--- a/context/logs/2026/08/LOG-20260807_1815-AmberRobin-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260807_1815-AmberRobin-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260807_1815-AmberRobin-workitem-created
+  created: '2026-08-07T18:15:20+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-07T18:15:20+00:00'
+  summary: 'Created WorkItem ''BACK-20260807_1815-SilentBeacon-canonicalize-v1-aibox-logo-assets'':
+    ''Make the v1 aibox logo the cross-line canonical asset source'''
+  subject: BACK-20260807_1815-SilentBeacon-canonicalize-v1-aibox-logo-assets
+  subject_kind: WorkItem
+  actor: BACK-20260807_1815-SilentBeacon-canonicalize-v1-aibox-logo-assets
+---

--- a/context/logs/2026/08/LOG-20260807_1815-FairAtlas-session-handover.md
+++ b/context/logs/2026/08/LOG-20260807_1815-FairAtlas-session-handover.md
@@ -1,0 +1,55 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260807_1815-FairAtlas-session-handover
+  created: '2026-08-07T18:15:38+00:00'
+spec:
+  event_type: session.handover
+  timestamp: '2026-08-07T18:15:38+00:00'
+  summary: Session handover — v0.31.0 fully released and v0.x documentation rebranded
+    with the v1 hex mark
+  actor: TEAMMEMBER-avery
+  details:
+    session_date: '2026-08-07'
+    current_state: 'aibox v0.31.0 is fully released: repo-side and host-side phases
+      completed, release runtime smoke passed, macOS/Linux assets are published, generated
+      runtime refresh PR #363 is merged, and current plus versioned v0.31.0 documentation
+      is deployed. The v0.x landing page was visually repaired and the approved v1
+      hexagonal aibox mark is now used for the navbar and all browser favicon variants;
+      cache-busted icon metadata shipped in PR #362. Branch v0.x-release is aligned
+      with origin at bf10f7ac. Three unrelated processkit files remain modified and
+      were deliberately preserved.'
+    open_threads:
+    - BACK-20260724_1843-PatientLynx-implement-aibox-v1-orchestration remains in progress
+      and is the principal product workstream.
+    - BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence and
+      child BACK-20260725_1003-GiftedBlossom-implement-m7c-disposable-cluster-e2e-and
+      remain blocked pending candidate-bound v1 M7c companion evidence.
+    - BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention remains
+      in progress; release Tier 2 needs deterministic scheduling without the serialized
+      operator override.
+    - BACK-20260514_0924-ActiveSummit-tmux-layout-chooser-prefix-menu-binding and
+      BACK-20260514_0925-VastHare-tmux-theme-switch-prefix-menu-binding remain in
+      progress.
+    - 'BACK-20260807_1815-SilentBeacon-canonicalize-v1-aibox-logo-assets was created
+      from this session''s correction: promote the owner-approved v1 hex mark into
+      the cross-line canonical asset bundle and prevent drift.'
+    - 'Uncommitted preserved changes: context/.processkit-mcp-manifest.json, context/.processkit-provenance.toml,
+      and context/skills/processkit/pk-doctor/scripts/checks/supply_chain.py.'
+    - 'Preserved stash: stash@{0} on v1.x-pre-release, pre-release-host-v0.29.0-primary-20260801T195034Z.'
+    next_recommended_action: Run pk-resume, then return to BACK-20260724_1843-PatientLynx
+      on v1.x-pre-release and reconcile the blocked M7c companion/evidence prerequisites
+      before attempting any further v1 release candidate publication.
+    branch: v0.x-release
+    commit: bf10f7ac
+    behavioral_retrospective:
+    - The first logo correction selected the older assets/logo bundle without comparing
+      the v1.x workstream; the owner corrected this. BACK-20260807_1815-SilentBeacon
+      now tracks making the approved v1 mark the true cross-line canonical source.
+    - 'After the newer logo was ported, browser icon caching still showed the prior
+      favicon. PR #362 encoded SVG-first, revisioned favicon URLs so future artwork
+      updates invalidate tab-icon caches.'
+    - No promised release, merge, deployment, or verification action remains deferred;
+      v0.31.0 host completion was confirmed by the owner.
+---

--- a/context/workitems/2026/08/BACK-20260807_1815-SilentBeacon-canonicalize-v1-aibox-logo-assets.md
+++ b/context/workitems/2026/08/BACK-20260807_1815-SilentBeacon-canonicalize-v1-aibox-logo-assets.md
@@ -1,0 +1,18 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260807_1815-SilentBeacon-canonicalize-v1-aibox-logo-assets
+  created: '2026-08-07T18:15:20+00:00'
+spec:
+  title: Make the v1 aibox logo the cross-line canonical asset source
+  state: backlog
+  type: task
+  priority: medium
+  description: The v0.x assets/logo bundle still contains the older terminal/spark
+    mark while the v1.x documentation workstream contains the owner-preferred hexagonal
+    AI-box mark. Promote the approved v1 mark into the canonical cross-line asset
+    bundle, regenerate every SVG/ICO/PNG/touch-icon variant from that source, align
+    v0.x and v1.x documentation consumers, and add a check that prevents navbar/favicon
+    assets from drifting across maintained lines.
+---


### PR DESCRIPTION
Records the completed v0.31.0 release/session handover and tracks canonicalization of the approved v1 aibox logo assets across maintained lines.