### PR TITLE
fix(processkit): reconcile incomplete upgrades

### DIFF
--- a/cli/src/content_init.rs
+++ b/cli/src/content_init.rs
@@ -119,6 +119,7 @@ pub fn build_effective_skill_set(
         } else {
             config.skills.include.iter().cloned().collect()
         };
+        expand_skill_dependencies(&skills_dir, &mut effective);
         for skill in &config.skills.exclude {
             effective.remove(skill);
         }
@@ -169,6 +170,15 @@ pub fn build_effective_skill_set(
         effective.insert(skill.clone());
     }
 
+    let skills_for_core =
+        mirror_skills_dir(project_root, &config.processkit.version).unwrap_or_default();
+
+    // Package manifests select the top-level capability surface. Close that
+    // selection over each skill's declared dependencies before honoring
+    // explicit excludes, otherwise derived projects can install skills whose
+    // DAG references point at absent prerequisites.
+    expand_skill_dependencies(&skills_for_core, &mut effective);
+
     // Step 3: remove user excludes.
     for skill in &config.skills.exclude {
         effective.remove(skill);
@@ -179,8 +189,6 @@ pub fn build_effective_skill_set(
     // are added back unconditionally after the exclude pass. `aibox doctor`
     // warns separately when a core skill appears in [skills].exclude.
     // See processkit/aibox#36 for the proposed convention.
-    let skills_for_core =
-        mirror_skills_dir(project_root, &config.processkit.version).unwrap_or_default();
     let core_skills = collect_core_skills(&skills_for_core);
     for skill in core_skills {
         effective.insert(skill);
@@ -219,6 +227,55 @@ fn collect_available_skill_names_inner(root: &Path, names: &mut HashSet<String>)
             names.insert(name.to_string());
         } else {
             collect_available_skill_names_inner(&path, names);
+        }
+    }
+}
+
+fn expand_skill_dependencies(skills_dir: &Path, effective: &mut HashSet<String>) {
+    let mut dependencies = HashMap::<String, Vec<String>>::new();
+    collect_skill_dependencies_inner(skills_dir, &mut dependencies);
+
+    let mut queue: VecDeque<String> = effective.iter().cloned().collect();
+    while let Some(skill) = queue.pop_front() {
+        let Some(required) = dependencies.get(&skill) else {
+            continue;
+        };
+        for dependency in required {
+            if dependencies.contains_key(dependency) && effective.insert(dependency.clone()) {
+                queue.push_back(dependency.clone());
+            }
+        }
+    }
+}
+
+fn collect_skill_dependencies_inner(root: &Path, dependencies: &mut HashMap<String, Vec<String>>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let skill_md = path.join(SKILL_FILENAME);
+        if skill_md.is_file() {
+            let frontmatter =
+                processkit_vocab::parse_skill_frontmatter(&skill_md).unwrap_or_default();
+            let name = if frontmatter.name.is_empty() {
+                path.file_name()
+                    .and_then(|value| value.to_str())
+                    .unwrap_or_default()
+                    .to_string()
+            } else {
+                frontmatter.name.clone()
+            };
+            let uses = frontmatter
+                .processkit_meta()
+                .map(|meta| meta.uses.iter().map(|item| item.skill.clone()).collect())
+                .unwrap_or_default();
+            dependencies.insert(name, uses);
+        } else {
+            collect_skill_dependencies_inner(&path, dependencies);
         }
     }
 }
@@ -413,18 +470,27 @@ pub fn install_content_source(project_root: &Path, config: &AiboxConfig) -> Resu
         )
     })?;
 
-    // 3. Walk cache and install live files. Templated files are
+    // 3. Materialize the new immutable mirror before selecting skills. Skill
+    //    packages and dependency declarations must come from the version being
+    //    installed, not from the previous version's mirror. Using the old
+    //    mirror during an upgrade can omit newly required skills and leave a
+    //    derived project with dangling DAG references.
+    let template_vars = context::build_substitution_map(config);
+    copy_templates_from_cache_with_vars(
+        &fetched.src_path,
+        project_root,
+        install_version,
+        &template_vars,
+    )
+    .context("failed to copy cache to templates dir")?;
+
+    // 4. Walk cache and install live files. Templated files are
     //    rendered through the Class A substitution vocabulary at copy
     //    time — see DEC-032. Skill files are filtered through the
     //    effective skill set computed from [context].packages plus
     //    [skills].include/exclude — see DEC-035 / BACK-118.
-    let template_vars = context::build_substitution_map(config);
-    // The effective skill set requires the templates mirror, which
-    // doesn't exist on the FIRST install (it's about to be created
-    // below). For the very first install, we install ALL skills the
-    // cache ships and let the next sync's filter take effect once the
-    // mirror is in place. Subsequent installs read the OLD mirror
-    // (still on disk from the previous install) for filtering.
+    // The effective skill set now reads the just-fetched version's complete
+    // mirror, including its package manifests and declared skill dependencies.
     let effective_skills = build_effective_skill_set(project_root, config)
         .ok()
         .flatten();
@@ -434,20 +500,6 @@ pub fn install_content_source(project_root: &Path, config: &AiboxConfig) -> Resu
         &template_vars,
         effective_skills.as_ref(),
     )?;
-
-    // 4. Copy the full cache into context/templates/processkit/<version>/
-    //    so the 3-way diff has an immutable "as-installed" reference.
-    //    Templated files (e.g. scaffolding/AGENTS.md) are rendered
-    //    through the SAME Class A vocabulary that the live install
-    //    used, so the mirror's templated content matches the live
-    //    file SHA-for-SHA. See DEC-034.
-    copy_templates_from_cache_with_vars(
-        &fetched.src_path,
-        project_root,
-        install_version,
-        &template_vars,
-    )
-    .context("failed to copy cache to templates dir")?;
 
     // 5. Write the top-level aibox.lock — but only when something actually
     //    changed. v0.18.7: previously this regenerated `synced_at` and
@@ -1280,6 +1332,36 @@ mod tests {
         assert_eq!(set.len(), 2);
         assert!(set.contains("workitem-management"));
         assert!(set.contains("decision-record"));
+    }
+
+    #[test]
+    fn effective_skill_set_expands_declared_skill_dependencies() {
+        let tmp = TempDir::new().unwrap();
+        let version = crate::processkit_vocab::PROCESSKIT_DEFAULT_VERSION;
+        write_synth_packages_dir(tmp.path(), version, &[("software", &[], &["changelog"])]);
+        write_synth_skills_dir(tmp.path(), version, &["changelog", "release-semver"]);
+
+        let changelog = tmp
+            .path()
+            .join(TEMPLATES_PROCESSKIT_DIR)
+            .join(version)
+            .join(processkit_vocab::src::CONTEXT_DIR)
+            .join(processkit_vocab::src::SKILLS)
+            .join("processkit/changelog/SKILL.md");
+        fs::write(
+            changelog,
+            "---\nname: changelog\nmetadata:\n  processkit:\n    uses:\n      - skill: release-semver\n        purpose: release notes\n---\n",
+        )
+        .unwrap();
+
+        let config = config_with_packages_and_skills(version, &["software"], &[], &[]);
+        let set = build_effective_skill_set(tmp.path(), &config)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(set.len(), 2);
+        assert!(set.contains("changelog"));
+        assert!(set.contains("release-semver"));
     }
 
     #[test]

--- a/cli/src/content_source.rs
+++ b/cli/src/content_source.rs
@@ -460,15 +460,27 @@ pub fn fetch(
                 cache_root.display()
             )
         })?;
-        let (commit, sha256) = read_marker(&marker);
-        return Ok(FetchedSource {
-            cache_root,
-            src_path: resolved_src,
-            resolved_commit: commit,
-            release_asset_sha256: sha256,
-            source: source.to_string(),
-            version: version.to_string(),
-        });
+        if cached_inventory_complete(&resolved_src) {
+            let (commit, sha256) = read_marker(&marker);
+            return Ok(FetchedSource {
+                cache_root,
+                src_path: resolved_src,
+                resolved_commit: commit,
+                release_asset_sha256: sha256,
+                source: source.to_string(),
+                version: version.to_string(),
+            });
+        }
+        output::warn(&format!(
+            "cached content source at {} is incomplete against PROVENANCE.toml; refetching",
+            cache_root.display()
+        ));
+        fs::remove_dir_all(&cache_root).with_context(|| {
+            format!(
+                "failed to remove incomplete cache dir {}",
+                cache_root.display()
+            )
+        })?;
     }
 
     // Make a clean target directory. If a previous attempt left a
@@ -626,6 +638,34 @@ pub fn fetch(
         source: source.to_string(),
         version: version.to_string(),
     })
+}
+
+/// Validate a release extraction against its shipped provenance inventory.
+/// Older aibox versions could leave a filtered processkit tree in the shared
+/// version cache while retaining `.fetch-complete`; shape-only validation then
+/// reused that partial tree indefinitely. Releases without a provenance file
+/// retain the historical shape-only behavior.
+fn cached_inventory_complete(resolved_src: &Path) -> bool {
+    #[derive(serde::Deserialize)]
+    struct ProvenanceInventory {
+        #[serde(default)]
+        files: std::collections::HashMap<String, String>,
+    }
+
+    let provenance = resolved_src.join("PROVENANCE.toml");
+    if !provenance.is_file() {
+        return true;
+    }
+    let Ok(body) = fs::read_to_string(&provenance) else {
+        return false;
+    };
+    let Ok(parsed) = toml::from_str::<ProvenanceInventory>(&body) else {
+        return false;
+    };
+    parsed
+        .files
+        .keys()
+        .all(|relative| resolved_src.join(relative).is_file())
 }
 
 // ---------------------------------------------------------------------------
@@ -1662,4 +1702,20 @@ mod tests {
             "5xx error message must not contain 'HTTP 404'"
         );
     }
+}
+#[test]
+fn cached_inventory_detects_missing_provenance_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(
+        tmp.path().join("PROVENANCE.toml"),
+        "[files]\n\"context/skills/one/SKILL.md\" = \"v0.1.0\"\n",
+    )
+    .unwrap();
+
+    assert!(!cached_inventory_complete(tmp.path()));
+
+    let skill = tmp.path().join("context/skills/one/SKILL.md");
+    fs::create_dir_all(skill.parent().unwrap()).unwrap();
+    fs::write(skill, "# one\n").unwrap();
+    assert!(cached_inventory_complete(tmp.path()));
 }

--- a/cli/src/harness_commands.rs
+++ b/cli/src/harness_commands.rs
@@ -320,13 +320,18 @@ fn sync_one_profile(
             continue;
         }
         let remove_current_managed = universe.contains(&source_md_name);
+        // The pk-* command namespace is reserved for processkit. Remove an
+        // unwanted adapter even when its old source is no longer present in a
+        // retained template mirror; otherwise package changes can strand
+        // generated commands indefinitely in derived projects.
+        let remove_reserved_processkit = source_md_name.starts_with("pk-");
         let remove_historical_generated = deployed_matches_historical_source(
             profile,
             &source_md_name,
             &path,
             historical_sources,
         )?;
-        if remove_current_managed || remove_historical_generated {
+        if remove_current_managed || remove_reserved_processkit || remove_historical_generated {
             remove_deployed_command(profile, &path)?;
             removed += 1;
         }
@@ -1825,6 +1830,40 @@ mod tests {
                 .join(".agents/skills/morning-briefing-generate/SKILL.md")
                 .exists()
         );
+        assert!(project.join(".agents/skills/pk-resume/SKILL.md").exists());
+        assert!(project.join(".agents/skills/user-skill/SKILL.md").exists());
+    }
+
+    #[test]
+    fn stale_reserved_codex_command_removed_without_historical_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+        let live = project.join("context/skills");
+        make_skill_commands(
+            &live,
+            "processkit",
+            "status-briefing",
+            &["pk-resume.md"],
+            "---\ndescription: Resume\n---\n\n# Resume\n",
+        );
+
+        fs::create_dir_all(project.join(".agents/skills/pk-release")).unwrap();
+        fs::write(
+            project.join(".agents/skills/pk-release/SKILL.md"),
+            "---\nname: pk-release\ndescription: stale generated command\n---\n",
+        )
+        .unwrap();
+        fs::create_dir_all(project.join(".agents/skills/user-skill")).unwrap();
+        fs::write(
+            project.join(".agents/skills/user-skill/SKILL.md"),
+            "---\nname: user-skill\ndescription: user\n---\n",
+        )
+        .unwrap();
+
+        let config = config_with("v0.20.0", vec![AiHarness::Codex]);
+        sync_harness_commands(project, &config).unwrap();
+
+        assert!(!project.join(".agents/skills/pk-release").exists());
         assert!(project.join(".agents/skills/pk-resume/SKILL.md").exists());
         assert!(project.join(".agents/skills/user-skill/SKILL.md").exists());
     }

--- a/cli/src/processkit_vocab.rs
+++ b/cli/src/processkit_vocab.rs
@@ -515,6 +515,11 @@ pub struct SkillCommand {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+pub struct SkillUse {
+    pub skill: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct SkillProcesskitMeta {
     #[serde(default)]
     pub category: String,
@@ -532,6 +537,10 @@ pub struct SkillProcesskitMeta {
     /// Introduced in processkit v0.7.0; see projectious-work/aibox#37 and #53.
     #[serde(default)]
     pub commands: Vec<SkillCommand>,
+    /// Skills required by this skill. Package selection expands this graph so
+    /// a filtered installation cannot leave dangling processkit DAG edges.
+    #[serde(default)]
+    pub uses: Vec<SkillUse>,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- validate cached processkit releases against their provenance inventory and refetch incomplete caches
- expand selected skills over transitive `metadata.processkit.uses` dependencies
- remove stale reserved `pk-*` harness command projections even when an older mirror is incomplete

The companion processkit manifest fix shipped in [processkit v0.28.6](https://github.com/projectious-work/processkit/releases/tag/v0.28.6).

## Verification

- `cargo fmt -- --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo audit`
- exact fresh ainfra upgrade to processkit v0.28.6
- focused pk-doctor: 0 ERROR / 0 WARN / 3 INFO, 0 actionable

Fixes #365.