### PR TITLE
docs(release): prepare v0.31.1

### DIFF
--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -658,6 +658,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.5",
         note: "Minor release: adds optional rootless Podman and Podman Compose tooling to the infrastructure addon, documents the Go supply-chain and release bundles, and repairs minimal infrastructure addon rendering.",
     },
+    CompatEntry {
+        aibox_version: "0.31.1",
+        processkit_version: "v0.28.6",
+        note: "Patch release: repairs incomplete processkit upgrade caches, installs declared skill dependencies, removes stale pk command projections, and consumes source-specific MCP header manifests.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/dist/RELEASE-NOTES.md
+++ b/dist/RELEASE-NOTES.md
@@ -1,20 +1,21 @@
-# aibox v0.31.0 — 2026-08-07
+# aibox v0.31.1 — 2026-08-07
 
-**Summary:** This minor release lets derived projects opt into rootless Podman and Podman Compose inside their development container, alongside the existing curated Go supply-chain and release bundles. Projects that need an internal container runtime can enable the new infrastructure tool and rebuild.
+**Summary:** This patch makes processkit upgrades self-healing when an old shared cache is incomplete and eliminates the stale commands, missing skill dependencies, and false MCP header drift reported after `aibox apply`. Projects using `processkit.version = "latest"` receive the paired processkit v0.28.6 manifest fix automatically.
 
 ## Added
 
-- Add an optional `podman` infrastructure tool with Podman Compose and rootless runtime prerequisites.
-- Add companion-backed E2E coverage that starts a generated container and verifies nested rootless Podman operation.
+- Add provenance-inventory validation for cached processkit releases.
+- Add transitive installation of dependencies declared through `metadata.processkit.uses`.
 
 ## Changed
 
-- Document the existing Go `supply-chain` bundle (`gitleaks`, `osv-scanner`, `syft`, `grype`, and `cosign`) and `release` bundle (`goreleaser`, `shellcheck`, and `hadolint`).
-- Refresh curated fzf, uv, and Zensical versions and apply compatible Rust dependency updates after a clean security audit.
+- Consume processkit v0.28.6, whose release manifest records the shipped source tree's MCP dependency headers independently from the upstream dogfood tree.
 
 ## Fixed
 
-- Render a valid infrastructure builder stage when OpenTofu and Packer are both disabled.
+- Refetch a signed processkit release when its shared cache is missing files declared by `PROVENANCE.toml`.
+- Remove stale generated `pk-*` harness commands even when the older processkit mirror is incomplete.
+- Install referenced skills such as `release-semver` when selected skills declare them as dependencies.
 
 ## Removed
 
@@ -22,6 +23,6 @@
 
 ## Upgrade notes
 
-Enable the runtime with `[addons.go.infrastructure.tools] podman = {}` (or the equivalent language group), then run `aibox apply` and rebuild the container. Existing projects remain unchanged because Podman is disabled by default.
+Run `aibox apply`. Incomplete cached processkit releases are detected and replaced automatically.
 
-[v0.31.0]: https://github.com/projectious-work/aibox/compare/v0.30.1...v0.31.0
+[v0.31.1]: https://github.com/projectious-work/aibox/compare/v0.31.0...v0.31.1

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.31.1 | v0.28.6 | repairs incomplete processkit upgrade caches, installs declared skill dependencies, removes stale `pk-*` command projections, and consumes source-specific MCP header manifests |
 | 0.31.0 | v0.28.5 | adds optional rootless Podman and Podman Compose tooling to the infrastructure addon, documents the Go supply-chain and release bundles, and repairs minimal infrastructure addon rendering |
 | 0.30.1 | v0.28.5 | refreshes the companion E2E contract, repairs Starship cache isolation, resolves Codex `latest` pins before container builds, and updates security-relevant pnpm and Tau curated defaults |
 | 0.30.0 | v0.28.5 | adds nested language addon groups, production Go quality tooling, and language-neutral supply-chain and release bundles with pinned versions, checksum verification, and per-tool overrides |


### PR DESCRIPTION
Adds the v0.31.1 compatibility contract for processkit v0.28.6 and curated release notes for the issue #365 upgrade repair.