### PR TITLE
perf(release): optimize heavy E2E validation

### DIFF
--- a/cli/tests/e2e/addon.rs
+++ b/cli/tests/e2e/addon.rs
@@ -116,42 +116,22 @@ fn addon_rebuild_includes_tools_in_dockerfile() {
     runner.cleanup(test);
 }
 
-#[test]
-#[serial(companion_runtime)]
-#[ignore = "resource-heavy addon image build; run through scripts/run-e2e-shards.sh addon or all"]
-// The all-defaults image validates every download-backed installer in one
-// build. On the nested companion, uncached package extraction can legitimately
-// exceed 30 minutes even when the build is making progress.
-#[ntest::timeout(3_600_000)]
-fn download_based_addons_build_with_published_defaults() {
+fn download_based_addons_build_with_published_defaults(test: &str, addons: &[&str]) {
     let runner = E2eRunner::new();
-    let test = "addon-download-smoke";
     runner.cleanup(test);
 
     let mut args = vec!["init", test, "--base", "debian", "--context", "managed"];
-    for addon in [
-        "ai-claude",
-        "ai-opencode",
-        "cloud-aws",
-        "cloud-gcp",
-        "cloudflare",
-        "docs-hugo",
-        "docs-mdbook",
-        "go",
-        "go-quality",
-        "go-release",
-        "infrastructure",
-        "kubernetes",
-        "node",
-        "preview-archive",
-        "rust",
-        "supply-chain",
-        "typst",
-    ] {
+    for addon in addons {
         args.extend(["--addon", addon]);
     }
 
+    let started = std::time::Instant::now();
+    eprintln!("[e2e-stage] {test}: init started");
     let init = runner.aibox(test, &args);
+    eprintln!(
+        "[e2e-stage] {test}: init completed in {}s",
+        started.elapsed().as_secs()
+    );
     assert!(
         init.status.success(),
         "initializing the download-based add-on smoke project failed:\nstdout:\n{}\nstderr:\n{}",
@@ -159,7 +139,25 @@ fn download_based_addons_build_with_published_defaults() {
         String::from_utf8_lossy(&init.stderr)
     );
 
+    let apply_started = std::time::Instant::now();
+    eprintln!("[e2e-stage] {test}: apply/build started");
     let apply = runner.aibox(test, &["apply"]);
+    eprintln!(
+        "[e2e-stage] {test}: apply/build completed in {}s",
+        apply_started.elapsed().as_secs()
+    );
+    if !apply.stdout.is_empty() {
+        eprintln!(
+            "[e2e-stage] {test}: apply stdout:\n{}",
+            String::from_utf8_lossy(&apply.stdout)
+        );
+    }
+    if !apply.stderr.is_empty() {
+        eprintln!(
+            "[e2e-stage] {test}: apply stderr:\n{}",
+            String::from_utf8_lossy(&apply.stderr)
+        );
+    }
     assert!(
         apply.status.success(),
         "one or more published add-on defaults cannot build:\nstdout:\n{}\nstderr:\n{}",
@@ -168,6 +166,56 @@ fn download_based_addons_build_with_published_defaults() {
     );
 
     runner.cleanup(test);
+}
+
+#[test]
+#[ignore = "resource-heavy addon image build; run through scripts/run-e2e-shards.sh addon or all"]
+#[ntest::timeout(3_600_000)]
+fn download_based_addons_build_with_published_defaults_languages() {
+    download_based_addons_build_with_published_defaults(
+        "addon-download-languages",
+        &[
+            "docs-hugo",
+            "docs-mdbook",
+            "go",
+            "go-quality",
+            "go-release",
+            "node",
+            "rust",
+            "typst",
+        ],
+    );
+}
+
+#[test]
+#[ignore = "resource-heavy addon image build; run through scripts/run-e2e-shards.sh addon or all"]
+#[ntest::timeout(3_600_000)]
+fn download_based_addons_build_with_published_defaults_platforms() {
+    download_based_addons_build_with_published_defaults(
+        "addon-download-platforms",
+        &[
+            "cloud-aws",
+            "cloud-gcp",
+            "cloudflare",
+            "infrastructure",
+            "kubernetes",
+        ],
+    );
+}
+
+#[test]
+#[ignore = "resource-heavy addon image build; run through scripts/run-e2e-shards.sh addon or all"]
+#[ntest::timeout(3_600_000)]
+fn download_based_addons_build_with_published_defaults_tools() {
+    download_based_addons_build_with_published_defaults(
+        "addon-download-tools",
+        &[
+            "ai-claude",
+            "ai-opencode",
+            "preview-archive",
+            "supply-chain",
+        ],
+    );
 }
 
 #[test]

--- a/context/logs/2026/08/LOG-20260808_0311-StoutWren-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260808_0311-StoutWren-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260808_0311-StoutWren-workitem-created
+  created: '2026-08-08T03:11:56+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-08T03:11:56+00:00'
+  summary: 'Created WorkItem ''BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and'':
+    ''Optimize release E2E gate selection and observability'''
+  subject: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+  subject_kind: WorkItem
+  actor: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+---

--- a/context/logs/2026/08/LOG-20260808_0312-SleekLynx-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260808_0312-SleekLynx-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260808_0312-SleekLynx-workitem-transitioned
+  created: '2026-08-08T03:12:00+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-08T03:12:00+00:00'
+  summary: Transitioned WorkItem 'BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+  subject_kind: WorkItem
+  actor: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+---

--- a/context/logs/2026/08/LOG-20260808_0321-GracefulStar-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260808_0321-GracefulStar-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260808_0321-GracefulStar-workitem-archive-moved
+  created: '2026-08-08T03:21:18+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-08T03:21:18+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and'
+    to /workspace/context/workitems/done/2026/08/BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and.md
+  subject: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+  subject_kind: WorkItem
+  actor: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and.md
+---

--- a/context/logs/2026/08/LOG-20260808_0321-ResoluteHearth-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260808_0321-ResoluteHearth-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260808_0321-ResoluteHearth-workitem-transitioned
+  created: '2026-08-08T03:21:11+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-08T03:21:11+00:00'
+  summary: Transitioned WorkItem 'BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and'
+    from 'in-progress' to 'review'
+  subject: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+  subject_kind: WorkItem
+  actor: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+---

--- a/context/logs/2026/08/LOG-20260808_0321-VividTrail-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260808_0321-VividTrail-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260808_0321-VividTrail-workitem-transitioned
+  created: '2026-08-08T03:21:18+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-08T03:21:18+00:00'
+  summary: Transitioned WorkItem 'BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and'
+    from 'review' to 'done'
+  subject: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+  subject_kind: WorkItem
+  actor: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+---

--- a/context/workitems/done/2026/08/BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and.md
+++ b/context/workitems/done/2026/08/BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and.md
@@ -1,0 +1,35 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and
+  created: '2026-08-08T03:11:56+00:00'
+  labels:
+    area: release-tooling
+    requested_by: owner
+  updated: '2026-08-08T03:21:18+00:00'
+spec:
+  title: Optimize release E2E gate selection and observability
+  state: done
+  type: task
+  priority: high
+  description: Implement path-aware heavy release gates, parallel isolated addon shards,
+    per-stage timing/progress artifacts, and regression coverage for candidate-SHA
+    evidence reuse on the maintained v0.x release line.
+  started_at: '2026-08-08T03:12:00+00:00'
+  completed_at: '2026-08-08T03:21:18+00:00'
+---
+
+## Transition note (2026-08-08T03:12:00+00:00)
+
+Implementation started on v0.x-release.
+
+
+## Transition note (2026-08-08T03:21:11+00:00)
+
+Implementation and validation complete; ready for final integration review.
+
+
+## Transition note (2026-08-08T03:21:18+00:00)
+
+Implemented and validated change-aware heavy E2E selection, parallel addon shards, progress timing events, and candidate-bound evidence safeguards.

--- a/docs-site/content/docs/contributing/e2e-tests.md
+++ b/docs-site/content/docs/contributing/e2e-tests.md
@@ -56,15 +56,30 @@ CLI. Those exceptions simulate host-user behavior in controlled test projects:
 Use these exceptions only in aibox CLI development/release harnesses. They are
 not general dogfood escape hatches.
 
-The container-side release command runs Tier 2 as three retryable shards via
-`scripts/run-e2e-shards.sh`: parallel-safe `core`, then the resource-heavy
-`addon` and `latex` image builds one at a time. The SSH companion, generated
-runtime probes, and non-ignored asciinema checks remain release gates. Each
-release shard has independent candidate-bound evidence, so resuming an
-unchanged candidate reruns only the failed shard. Use
-`./scripts/maintain.sh test-e2e` or `./scripts/run-e2e-shards.sh all` for the
-complete Tier 2 gate; a raw `cargo test --features e2e --test e2e` invocation
-runs the core shard only.
+The container-side release command runs Tier 2 as retryable shards via
+`scripts/run-e2e-shards.sh`: parallel-safe `core`, three independently bounded
+addon groups (`addon-languages`, `addon-platforms`, and `addon-tools`), and the
+resource-heavy `latex` image build. The addon groups run concurrently with a
+single suite-wide companion cleanup. The SSH companion, generated runtime
+probes, and non-ignored asciinema checks remain release gates. Each release
+shard has independent candidate-bound evidence keyed by the candidate commit,
+toolchain, phase, and scope, so resuming an unchanged candidate reruns only a
+failed or missing shard. Evidence from a different candidate is never reused.
+Use `./scripts/maintain.sh test-e2e` or
+`./scripts/run-e2e-shards.sh all` for the complete Tier 2 gate; a raw
+`cargo test --features e2e --test e2e` invocation runs the core shard only.
+
+Release runs select the heavy addon and LaTeX gates from the paths changed
+since the previous version-line tag. Changes to release orchestration,
+generated container templates, images, or addon generation run both gates;
+addon-only and LaTeX-only changes run their respective gate; documentation and
+processkit-only changes skip both. If no trustworthy comparison tag exists,
+both gates run. Set `AIBOX_RELEASE_HEAVY_E2E=all` to force the complete heavy
+suite, or `AIBOX_RELEASE_IMPACT_BASE_REF=<ref>` to compare against an explicit
+base. `AIBOX_RELEASE_ADDON_PARALLELISM` controls the addon evidence scheduler
+(default `2`), and `AIBOX_RELEASE_PROGRESS_INTERVAL_SECONDS` controls periodic
+long-running-step progress events (default `30`).
+
 Tier 1 modules are excluded from feature-enabled test binaries because the
 default `cargo test` invocation already covers them.
 The default Tier 2 suite intentionally performs only one full generated

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -301,6 +301,21 @@ cmd_test_e2e_shard() {
   ok "Tier 2 SSH companion E2E shard passed: ${shard}"
 }
 
+# Run an isolated shard without suite-wide pruning. The caller must prune once
+# before and after a parallel batch; each test owns a unique workspace and
+# Compose project name, so shard-local cleanup remains safe under concurrency.
+cmd_test_e2e_shard_without_global_prune() {
+  local shard="$1" status=0 test_threads="${AIBOX_E2E_TEST_THREADS:-4}"
+  [[ "${test_threads}" =~ ^[1-9][0-9]*$ ]] \
+    || die "AIBOX_E2E_TEST_THREADS must be a positive integer"
+  ensure_e2e_companion
+  info "Running isolated Tier 2 SSH companion E2E shard: ${shard}..."
+  AIBOX_E2E_TEST_THREADS="${test_threads}" "${SCRIPT_DIR}/run-e2e-shards.sh" "${shard}" \
+    || status=$?
+  [[ "${status}" -eq 0 ]] || return "${status}"
+  ok "Isolated Tier 2 SSH companion E2E shard passed: ${shard}"
+}
+
 cmd_test_e2e_visual_status() {
   ensure_e2e_companion
   info "Running opt-in visual E2E: generated tmux layouts, themes, and status line..."
@@ -1641,6 +1656,12 @@ Examples:
   ./scripts/maintain.sh release 0.25.15 --skip e2e,visual
   ./scripts/maintain.sh release 0.25.15 --steps phase0
   ./scripts/maintain.sh release 0.25.15 --steps publish,prompt
+
+Heavy E2E controls:
+  AIBOX_RELEASE_HEAVY_E2E=auto|all             Select by changed paths or force all (default: auto)
+  AIBOX_RELEASE_IMPACT_BASE_REF=<ref>          Override the comparison base for auto selection
+  AIBOX_RELEASE_ADDON_PARALLELISM=<count>      Concurrent addon shard limit (default: 2)
+  AIBOX_RELEASE_PROGRESS_INTERVAL_SECONDS=<s>  Long-running-step progress interval (default: 30)
 STEPS
 }
 
@@ -2021,12 +2042,105 @@ release_companion_e2e_core_gate() {
   cmd_test_e2e_shard core
 }
 
-release_companion_e2e_addon_gate() {
-  cmd_test_e2e_shard addon
+release_companion_e2e_addon_languages_gate() {
+  cmd_test_e2e_shard_without_global_prune addon-languages
+}
+
+release_companion_e2e_addon_platforms_gate() {
+  cmd_test_e2e_shard_without_global_prune addon-platforms
+}
+
+release_companion_e2e_addon_tools_gate() {
+  cmd_test_e2e_shard_without_global_prune addon-tools
 }
 
 release_companion_e2e_latex_gate() {
   cmd_test_e2e_shard latex
+}
+
+release_classify_heavy_e2e_paths() {
+  local path addon=0 latex=0
+  for path in "$@"; do
+    case "${path}" in
+      cli/src/content_source.rs)
+        # Content acquisition does not participate in generated image builds.
+        ;;
+      scripts/maintain.sh|scripts/run-e2e-shards.sh|scripts/test-maintain-release.sh|\
+      .devcontainer/Dockerfile|.devcontainer/Dockerfile.e2e|\
+      images/*|cli/src/addon_cmd.rs|cli/src/addon_loader.rs|\
+      cli/src/addon_registry.rs|cli/src/addons.rs|cli/src/generate.rs|\
+      cli/src/templates/Dockerfile.j2|cli/src/templates/docker-compose.yml.j2|\
+      cli/tests/e2e/runner.rs)
+        addon=1
+        latex=1
+        ;;
+      addons/languages/latex.yaml|cli/tests/e2e/latex_preview.rs)
+        latex=1
+        ;;
+      addons/*|cli/tests/e2e/addon.rs)
+        addon=1
+        ;;
+      cli/src/*|cli/Cargo.toml|cli/Cargo.lock|aibox.toml)
+        # Unclassified production/config changes are treated conservatively:
+        # they can alter generated files or runtime behavior indirectly.
+        addon=1
+        latex=1
+        ;;
+    esac
+  done
+  printf 'addon=%s latex=%s\n' "${addon}" "${latex}"
+}
+
+release_previous_tag_for_version() {
+  local version="$1" pattern
+  case "${version}" in
+    0.*) pattern='v0.*' ;;
+    1.*) pattern='v1.*' ;;
+    *) return 1 ;;
+  esac
+  git describe --tags --abbrev=0 --match "${pattern}" HEAD 2>/dev/null
+}
+
+release_select_heavy_e2e() {
+  local version="$1" mode="${AIBOX_RELEASE_HEAVY_E2E:-auto}"
+  local base_ref path classification
+  local changed_paths=()
+
+  case "${mode}" in
+    all)
+      RELEASE_RUN_ADDON_E2E=1
+      RELEASE_RUN_LATEX_E2E=1
+      RELEASE_HEAVY_E2E_REASON='forced by AIBOX_RELEASE_HEAVY_E2E=all'
+      ;;
+    auto)
+      base_ref="${AIBOX_RELEASE_IMPACT_BASE_REF:-}"
+      if [[ -z "${base_ref}" ]]; then
+        base_ref="$(release_previous_tag_for_version "${version}" || true)"
+      fi
+      if [[ -z "${base_ref}" ]] || ! git rev-parse --verify "${base_ref}^{commit}" >/dev/null 2>&1; then
+        RELEASE_RUN_ADDON_E2E=1
+        RELEASE_RUN_LATEX_E2E=1
+        RELEASE_HEAVY_E2E_REASON='no trustworthy previous release tag; running conservatively'
+      else
+        while IFS= read -r path; do
+          [[ -n "${path}" ]] && changed_paths+=("${path}")
+        done < <(git diff --name-only "${base_ref}^{commit}" HEAD)
+        classification="$(release_classify_heavy_e2e_paths "${changed_paths[@]}")"
+        RELEASE_RUN_ADDON_E2E="${classification#addon=}"
+        RELEASE_RUN_ADDON_E2E="${RELEASE_RUN_ADDON_E2E%% *}"
+        RELEASE_RUN_LATEX_E2E="${classification##*latex=}"
+        RELEASE_HEAVY_E2E_REASON="auto-selected from ${base_ref}..${RELEASE_CANDIDATE_SHA:0:12} (${#changed_paths[@]} changed path(s))"
+      fi
+      ;;
+    *)
+      die "AIBOX_RELEASE_HEAVY_E2E must be 'auto' or 'all' (got: ${mode})"
+      ;;
+  esac
+  export RELEASE_RUN_ADDON_E2E RELEASE_RUN_LATEX_E2E RELEASE_HEAVY_E2E_REASON
+  info "Heavy E2E selection: addon=${RELEASE_RUN_ADDON_E2E}, latex=${RELEASE_RUN_LATEX_E2E} — ${RELEASE_HEAVY_E2E_REASON}"
+  release_timing_record_event selection selected heavy-e2e \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    0 0 "addon=${RELEASE_RUN_ADDON_E2E};latex=${RELEASE_RUN_LATEX_E2E};${RELEASE_HEAVY_E2E_REASON}"
 }
 
 release_visual_gate() {
@@ -2145,12 +2259,16 @@ release_run_parallel_validation() {
   local version="$1"
   shift
   local max_jobs="${AIBOX_RELEASE_PARALLELISM:-2}"
+  local progress_interval="${AIBOX_RELEASE_PROGRESS_INTERVAL_SECONDS:-30}"
   [[ "${max_jobs}" =~ ^[1-9][0-9]*$ ]] \
     || die "AIBOX_RELEASE_PARALLELISM must be a positive integer"
+  [[ "${progress_interval}" =~ ^[1-9][0-9]*$ ]] \
+    || die "AIBOX_RELEASE_PROGRESS_INTERVAL_SECONDS must be a positive integer"
 
-  local specs=("$@") active=0 status=0 next=0 total="${#specs[@]}"
-  local spec key label command log pid index completed job_status status_file
-  local pids=() labels=() logs=() status_files=()
+  local specs=("$@") active=0 status=0 next=0 total="${#specs[@]}" now elapsed
+  local spec key label command log pid index completed job_status status_file started_at
+  local pids=() keys=() labels=() logs=() status_files=()
+  local started_epochs=() started_ats=() last_progress_epochs=()
 
   trap 'release_cleanup_parallel_children' EXIT
   trap 'release_cleanup_parallel_children; exit 130' INT TERM
@@ -2162,6 +2280,8 @@ release_run_parallel_validation() {
       log="${RELEASE_LOG_DIR}/${key}.log"
       status_file="${log}.status"
       rm -f "${status_file}"
+      now="$(date +%s)"
+      started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
       (
         trap - EXIT INT TERM
         set +e
@@ -2174,9 +2294,13 @@ release_run_parallel_validation() {
       ) &
       pid="$!"
       pids+=("${pid}")
+      keys+=("${key}")
       labels+=("${label}")
       logs+=("${log}")
       status_files+=("${status_file}")
+      started_epochs+=("${now}")
+      started_ats+=("${started_at}")
+      last_progress_epochs+=("${now}")
       active=$((active + 1))
       next=$((next + 1))
     done
@@ -2202,12 +2326,27 @@ release_run_parallel_validation() {
           status=1
         fi
         rm -f "${status_file}"
-        unset 'pids[index]' 'labels[index]' 'logs[index]' 'status_files[index]'
+        unset 'pids[index]' 'keys[index]' 'labels[index]' 'logs[index]' \
+          'status_files[index]' 'started_epochs[index]' 'started_ats[index]' \
+          'last_progress_epochs[index]'
         active=$((active - 1))
         completed=1
         break
       done
-      [[ "${completed}" -eq 1 ]] || sleep 0.2
+      if [[ "${completed}" -eq 0 ]]; then
+        now="$(date +%s)"
+        for index in "${!pids[@]}"; do
+          if (( now - last_progress_epochs[index] >= progress_interval )); then
+            elapsed=$(( now - started_epochs[index] ))
+            info "${labels[$index]} still running (${elapsed}s); log: ${logs[$index]}"
+            release_timing_record_event progress running "${keys[$index]}" \
+              "${started_ats[$index]}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              "${elapsed}" 0 "log=${logs[$index]}"
+            last_progress_epochs[$index]="${now}"
+          fi
+        done
+        sleep 0.2
+      fi
     done
   done
 
@@ -2412,6 +2551,15 @@ cmd_release() {
   release_timing_begin "$(release_steps_joined)"
   info "Release candidate: ${RELEASE_CANDIDATE_SHA}"
 
+  RELEASE_RUN_ADDON_E2E=0
+  RELEASE_RUN_LATEX_E2E=0
+  if release_step_requested e2e; then
+    case "${AIBOX_RELEASE_SKIP_COMPANION_E2E:-}" in
+      1|true|yes) ;;
+      *) release_select_heavy_e2e "${version}" ;;
+    esac
+  fi
+
   # These gates own independent resources. Run a bounded number concurrently,
   # retain separate logs, wait for every job, then fail as a group. The default
   # of two avoids oversubscribing developer laptops; override locally with
@@ -2440,18 +2588,44 @@ cmd_release() {
     release_run_parallel_validation "${version}" "${validation_specs[@]}"
   fi
 
-  # The addon and LaTeX shards each build a large image on the single companion.
-  # Keep them outside the parallel validation pool and give each its own
-  # candidate-bound evidence marker so a resumed release reruns only the shard
-  # that failed.
+  # Heavy addon coverage is split into isolated candidate-bound shards. Prune
+  # suite-wide state once around the batch; shard-local cleanup and unique
+  # Compose project names make bounded concurrency safe. LaTeX remains separate
+  # because it owns a different large image lifecycle.
   if release_step_requested e2e; then
     case "${AIBOX_RELEASE_SKIP_COMPANION_E2E:-}" in
       1|true|yes) ;;
       *)
-        release_run_parallel_validation "${version}" \
-          "e2e-addon|Tier 2 companion E2E addon shard|release_companion_e2e_addon_gate"
-        release_run_parallel_validation "${version}" \
-          "e2e-latex|Tier 2 companion E2E LaTeX shard|release_companion_e2e_latex_gate"
+        if [[ "${RELEASE_RUN_ADDON_E2E}" == "1" ]]; then
+          local saved_release_parallelism="${AIBOX_RELEASE_PARALLELISM:-}"
+          local addon_batch_status=0
+          prune_e2e_companion_storage \
+            || die "Failed to prune SSH companion state before addon shards"
+          AIBOX_RELEASE_PARALLELISM="${AIBOX_RELEASE_ADDON_PARALLELISM:-2}"
+          release_run_parallel_validation "${version}" \
+            "e2e-addon-languages|Tier 2 addon languages shard|release_companion_e2e_addon_languages_gate" \
+            "e2e-addon-platforms|Tier 2 addon platforms shard|release_companion_e2e_addon_platforms_gate" \
+            "e2e-addon-tools|Tier 2 addon tools shard|release_companion_e2e_addon_tools_gate" \
+            || addon_batch_status=$?
+          if [[ -n "${saved_release_parallelism}" ]]; then
+            AIBOX_RELEASE_PARALLELISM="${saved_release_parallelism}"
+          else
+            unset AIBOX_RELEASE_PARALLELISM
+          fi
+          prune_e2e_companion_storage \
+            || warn "Post-addon-batch SSH companion prune failed"
+          [[ "${addon_batch_status}" -eq 0 ]] \
+            || die "One or more addon E2E shards failed"
+        else
+          ok "Skipping addon image E2E: no addon/image/generator inputs changed"
+        fi
+
+        if [[ "${RELEASE_RUN_LATEX_E2E}" == "1" ]]; then
+          release_run_parallel_validation "${version}" \
+            "e2e-latex|Tier 2 companion E2E LaTeX shard|release_companion_e2e_latex_gate"
+        else
+          ok "Skipping LaTeX image E2E: no LaTeX/image/generator inputs changed"
+        fi
         ;;
     esac
   fi

--- a/scripts/run-e2e-shards.sh
+++ b/scripts/run-e2e-shards.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Run Tier 2 E2E in retryable shards.
 #
-# The addon-download and LaTeX tests both build sizeable derived images on the
-# single SSH companion.  They must never share that runtime with each other or
-# with the normal Tier 2 suite.  `all` therefore runs core, addon, and latex in
-# sequence.  A release orchestrator should capture evidence per invocation and
-# may rerun only the failed shard for the same candidate.
+# The addon-download tests use isolated workspace and Compose project names, so
+# their three groups may run concurrently. LaTeX still runs after them because
+# it owns a separate sizeable image lifecycle. A release orchestrator captures
+# evidence per invocation and may rerun only a failed shard for the same
+# candidate.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,11 +16,14 @@ CORE_THREADS="${AIBOX_E2E_TEST_THREADS:-4}"
 
 usage() {
   cat <<'USAGE'
-Usage: ./scripts/run-e2e-shards.sh <all|core|addon|latex>
+Usage: ./scripts/run-e2e-shards.sh <all|core|addon|addon-languages|addon-platforms|addon-tools|latex>
 
 Runs Tier 2 SSH-companion tests in deterministic shards:
   core   normal Tier 2 suite; excludes the two ignored heavy image builds
-  addon  full download-addon composition build, one test thread
+  addon  all three isolated download-addon groups in parallel
+  addon-languages  language and documentation toolchains
+  addon-platforms  cloud, infrastructure, and Kubernetes tools
+  addon-tools      AI, preview, and supply-chain tools
   latex  LaTeX watcher/preview image build, one test thread
   all    core, addon, then latex (default)
 
@@ -42,14 +45,31 @@ run_core() {
   )
 }
 
-run_addon() {
-  echo "[e2e-shard] addon (one test thread)"
+run_addon_test() {
+  local group="$1"
+  echo "[e2e-shard] addon-${group} started at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
   (
     cd "${CLI_DIR}"
     cargo test --features e2e --test e2e \
-      addon::download_based_addons_build_with_published_defaults \
-      -- --ignored --exact --test-threads=1
+      "addon::download_based_addons_build_with_published_defaults_${group}" \
+      -- --ignored --exact --nocapture --test-threads=1
   )
+  echo "[e2e-shard] addon-${group} completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+
+run_addon() {
+  local group pid status=0
+  local groups=(languages platforms tools)
+  local pids=()
+  echo "[e2e-shard] addon groups (parallelism: ${#groups[@]})"
+  for group in "${groups[@]}"; do
+    run_addon_test "${group}" &
+    pids+=("$!")
+  done
+  for pid in "${pids[@]}"; do
+    wait "${pid}" || status=1
+  done
+  return "${status}"
 }
 
 run_latex() {
@@ -70,6 +90,9 @@ case "${SHARD}" in
     ;;
   core) run_core ;;
   addon) run_addon ;;
+  addon-languages) run_addon_test languages ;;
+  addon-platforms) run_addon_test platforms ;;
+  addon-tools) run_addon_test tools ;;
   latex) run_latex ;;
   help|--help|-h) usage ;;
   *)

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -56,6 +56,14 @@ release_run_evidenced_step \
   evidence-probe 9.9.9 "Evidence probe" release_test_probe
 [[ ! -e "${probe_output}" ]] || die "valid evidence did not skip command execution"
 
+RELEASE_CANDIDATE_SHA="different-candidate"
+release_run_evidenced_step \
+  evidence-probe 9.9.9 "Changed-candidate evidence probe" release_test_probe
+[[ -f "${probe_output}" ]] \
+  || die "evidence from a different candidate SHA was incorrectly reused"
+RELEASE_CANDIDATE_SHA="test-candidate"
+rm -f "${probe_output}"
+
 release_test_fails() {
   return 17
 }
@@ -101,12 +109,13 @@ if release_evidence_valid build-linux 9.9.9; then
 fi
 
 release_test_slow() {
-  sleep 0.2
+  sleep 1.2
 }
 release_test_fast() {
   sleep 0.05
 }
 AIBOX_RELEASE_PARALLELISM=2
+AIBOX_RELEASE_PROGRESS_INTERVAL_SECONDS=1
 release_run_parallel_validation 9.9.9 \
   "scheduler-slow|Scheduler slow probe|release_test_slow" \
   "scheduler-fast|Scheduler fast probe|release_test_fast"
@@ -114,17 +123,46 @@ release_run_parallel_validation 9.9.9 \
   || die "parallel scheduler did not record the slow probe"
 [[ -f "$(release_evidence_key_path scheduler-fast)" ]] \
   || die "parallel scheduler did not record the fast probe"
+grep -F $'progress\t' "${RELEASE_TIMING_LOG}" | grep -F $'\trunning\tscheduler-slow\t' >/dev/null \
+  || die "parallel scheduler did not emit a progress timing event"
+unset AIBOX_RELEASE_PROGRESS_INTERVAL_SECONDS
 
 recorded_shard=""
 cmd_test_e2e_shard() {
   recorded_shard="$1"
 }
+cmd_test_e2e_shard_without_global_prune() {
+  recorded_shard="$1"
+}
 release_companion_e2e_core_gate
 [[ "${recorded_shard}" == "core" ]] || die "core E2E release gate selected the wrong shard"
-release_companion_e2e_addon_gate
-[[ "${recorded_shard}" == "addon" ]] || die "addon E2E release gate selected the wrong shard"
+release_companion_e2e_addon_languages_gate
+[[ "${recorded_shard}" == "addon-languages" ]] \
+  || die "addon languages release gate selected the wrong shard"
+release_companion_e2e_addon_platforms_gate
+[[ "${recorded_shard}" == "addon-platforms" ]] \
+  || die "addon platforms release gate selected the wrong shard"
+release_companion_e2e_addon_tools_gate
+[[ "${recorded_shard}" == "addon-tools" ]] \
+  || die "addon tools release gate selected the wrong shard"
 release_companion_e2e_latex_gate
 [[ "${recorded_shard}" == "latex" ]] || die "LaTeX E2E release gate selected the wrong shard"
+
+[[ "$(release_classify_heavy_e2e_paths cli/src/content_source.rs docs-site/content/docs/index.md)" == \
+   "addon=0 latex=0" ]] \
+  || die "processkit/docs-only changes must not select heavy image E2E"
+[[ "$(release_classify_heavy_e2e_paths addons/tools/supply-chain.yaml)" == \
+   "addon=1 latex=0" ]] \
+  || die "addon changes must select addon image E2E"
+[[ "$(release_classify_heavy_e2e_paths addons/languages/latex.yaml)" == \
+   "addon=0 latex=1" ]] \
+  || die "LaTeX addon changes must select LaTeX image E2E"
+[[ "$(release_classify_heavy_e2e_paths cli/src/generate.rs)" == \
+   "addon=1 latex=1" ]] \
+  || die "Dockerfile generator changes must select every heavy image gate"
+[[ "$(release_classify_heavy_e2e_paths cli/src/config.rs)" == \
+   "addon=1 latex=1" ]] \
+  || die "unclassified production changes must conservatively select every heavy image gate"
 
 host_remote="${test_root}/host-remote.git"
 host_seed="${test_root}/host-seed"


### PR DESCRIPTION
## Changes
- select addon and LaTeX image gates from paths changed since the previous version-line tag, with conservative and forced-full fallbacks
- split the download-backed addon build into three independently evidenced shards with bounded concurrency
- emit periodic progress timing events for long-running validation jobs
- verify evidence cannot be reused across candidate SHAs and document release controls

## Validation
- `./scripts/test-maintain-release.sh`
- `cargo fmt -- --check`
- `cargo test` (1079 unit, 90 Tier 1 E2E, 32 integration passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --features e2e --test e2e --no-run`
- `bash -n scripts/maintain.sh scripts/run-e2e-shards.sh scripts/test-maintain-release.sh`

Refs: BACK-20260808_0311-NeatDaisy-optimize-release-e2e-gate-selection-and