### PR TITLE
chore: release v0.31.3

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.31.2"
+version = "0.31.3"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -668,6 +668,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.6",
         note: "Patch release: replaces privileged companion E2E coverage with isolated local contracts and an owner-controlled, evidence-producing macOS host gate.",
     },
+    CompatEntry {
+        aibox_version: "0.31.3",
+        processkit_version: "v0.28.6",
+        note: "Patch release: adds a locked Textual dashboard and reviewed content-addressed cache reuse to the restricted macOS host gate.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,8 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.31.3 | v0.28.6 | adds a locked Textual dashboard and reviewed content-addressed cache reuse to the restricted macOS host gate |
+| 0.31.2 | v0.28.6 | replaces privileged companion E2E coverage with isolated local contracts and an owner-controlled, evidence-producing macOS host gate |
 | 0.31.1 | v0.28.6 | repairs incomplete processkit upgrade caches, installs declared skill dependencies, removes stale `pk-*` command projections, and consumes source-specific MCP header manifests |
 | 0.31.0 | v0.28.5 | adds optional rootless Podman and Podman Compose tooling to the infrastructure addon, documents the Go supply-chain and release bundles, and repairs minimal infrastructure addon rendering |
 | 0.30.1 | v0.28.5 | refreshes the companion E2E contract, repairs Starship cache isolation, resolves Codex `latest` pins before container builds, and updates security-relevant pnpm and Tau curated defaults |


### PR DESCRIPTION
Promotes the validated v0.31.3 release candidate to v0.x-release.