### PR TITLE
fix(release): finalize evidence before publication

### DIFF
--- a/scripts/release_host_gate.py
+++ b/scripts/release_host_gate.py
@@ -1338,6 +1338,15 @@ def run_gate(renderer: object | None = None) -> None:
 
     manifest_started = time.monotonic()
     runner._step("running", "Assemble evidence manifest", 0.0)
+    # Finalize every step-log state before hashing it. Publication writes only
+    # to evidence/publication/, which is deliberately outside this manifest.
+    runner._step("passed", "Assemble evidence manifest", time.monotonic() - manifest_started)
+    if dry_run:
+        runner._step("passed", "Dry-run completion", 0.0)
+        runner._step("skipped", "Publication", 0.0)
+    else:
+        runner._step("running", "Publication", 0.0)
+        runner._step("skipped", "Dry-run completion", 0.0)
     manifest = {
         "schema_version": 2, "repository": REPOSITORY, "version": version,
         "tag": provenance["tag"], "commit": provenance["commit"],
@@ -1355,7 +1364,6 @@ def run_gate(renderer: object | None = None) -> None:
     manifest_path = evidence / "release-manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     (evidence / "release-manifest.sha256").write_text(f"{sha256(manifest_path)}  release-manifest.json\n", encoding="utf-8")
-    runner._step("passed", "Assemble evidence manifest", time.monotonic() - manifest_started)
 
     if dry_run:
         runner._emit(PresentationEvent(
@@ -1363,13 +1371,20 @@ def run_gate(renderer: object | None = None) -> None:
             text="release-host validation complete; publication was not invoked\n"
                  f"To publish this verified run: {shlex.join(publisher_command)}\n",
         ))
-        runner._step("passed", "Dry-run completion", 0.0)
-        runner._step("skipped", "Publication", 0.0)
         return
 
-    subprocess.run(publisher_command, check=True)
-    runner._step("passed", "Publication", 0.0)
-    runner._step("skipped", "Dry-run completion", 0.0)
+    publisher_process = subprocess.Popen(
+        publisher_command, text=True, stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+    )
+    assert publisher_process.stdout is not None
+    for line in publisher_process.stdout:
+        renderer.emit(PresentationEvent("output", task="Publication", text=line))
+    publisher_returncode = publisher_process.wait()
+    if publisher_returncode:
+        renderer.emit(PresentationEvent("failed", task="Publication", state="failed"))
+        raise subprocess.CalledProcessError(publisher_returncode, publisher_command)
+    renderer.emit(PresentationEvent("passed", task="Publication", state="passed"))
 
 
 def main() -> None:

--- a/scripts/release_host_publish.py
+++ b/scripts/release_host_publish.py
@@ -34,6 +34,9 @@ IMPACT_EVIDENCE = {
     "rootless-podman": "evidence/container-e2e/rootless-podman.json",
 }
 LOCAL_CANDIDATE_EVIDENCE = "evidence/container-e2e/local-candidate-substitution.env"
+LEGACY_FINAL_STEP = re.compile(
+    rb"^\xe2\x9c\x93 Assemble evidence manifest \[passed; [0-9]+(?:\.[0-9]+)?s\]\n$"
+)
 
 
 def fail(message: str) -> "None":
@@ -42,6 +45,28 @@ def fail(message: str) -> "None":
 
 def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def evidence_checksum_matches(path: Path, relative: str, expected: str) -> bool:
+    """Accept exact evidence, plus the bounded v0.31.3 final-step defect.
+
+    The first dashboard validator hashed ``steps.log`` while the manifest task
+    was still running, then appended exactly one successful completion line.
+    Removing only that recognized final line must recover the attested digest;
+    no other mismatch is tolerated.
+    """
+    content = path.read_bytes()
+    if hashlib.sha256(content).hexdigest() == expected:
+        return True
+    if relative != "evidence/steps.log":
+        return False
+    prefix, separator, final = content.rpartition(b"\n")
+    if not separator or not final:
+        # A normal trailing newline makes the first split return an empty tail.
+        prefix, separator, final = content.rstrip(b"\n").rpartition(b"\n")
+    candidate_line = final + b"\n"
+    return bool(separator and LEGACY_FINAL_STEP.fullmatch(candidate_line)
+                and hashlib.sha256(prefix + b"\n").hexdigest() == expected)
 
 
 def run(command: list[str], log: Path) -> str:
@@ -133,7 +158,8 @@ def main() -> None:
         fail("manifest does not enumerate the complete required evidence set")
     for relative, expected in evidence_entries.items():
         path = (run_dir / relative).resolve(strict=True)
-        if evidence.resolve() not in path.parents or sha256(path) != expected:
+        if (evidence.resolve() not in path.parents
+                or not evidence_checksum_matches(path, relative, expected)):
             fail(f"required evidence path or checksum is invalid: {relative}")
 
     publication = evidence / "publication"

--- a/scripts/test-release-host-gate.sh
+++ b/scripts/test-release-host-gate.sh
@@ -259,6 +259,14 @@ assert set(gate.select_impact_checks(["*"])) == gate.ALL_IMPACT_CHECKS
 assert set(publisher.IMPACT_EVIDENCE) == gate.ALL_IMPACT_CHECKS
 assert publisher.LOCAL_CANDIDATE_EVIDENCE == "evidence/container-e2e/local-candidate-substitution.env"
 assert "evidence/container-e2e/impact-selection.json" in publisher.BASE_REQUIRED_EVIDENCE
+with tempfile.TemporaryDirectory() as temporary:
+    steps = Path(temporary) / "steps.log"
+    attested = "… Assemble evidence manifest [running; 0.0s]\n".encode()
+    expected = __import__("hashlib").sha256(attested).hexdigest()
+    steps.write_bytes(attested + "✓ Assemble evidence manifest [passed; 0.1s]\n".encode())
+    assert publisher.evidence_checksum_matches(steps, "evidence/steps.log", expected)
+    steps.write_bytes(attested + "✓ Publication [passed; 0.1s]\n".encode())
+    assert not publisher.evidence_checksum_matches(steps, "evidence/steps.log", expected)
 PY
 
 echo "release host gate contract tests passed"


### PR DESCRIPTION
## What changed

- finalize every manifest-covered step state before hashing evidence
- stream publisher output into the Textual and plain renderers
- accept only the exact single legacy manifest-completion suffix produced by the v0.31.3 validator
- reject every other evidence mismatch

## Validation

- `./scripts/test-release-host-gate.sh`
- Python byte-compilation
- `cargo fmt -- --check`
- `git diff --check`

Refs #372