### PR TITLE
chore(processkit): close issue 372 release work

### DIFF
--- a/context/logs/2026/08/LOG-20260812_1626-PluckyValley-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260812_1626-PluckyValley-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260812_1626-PluckyValley-workitem-created
+  created: '2026-08-12T16:26:28+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-12T16:26:28+00:00'
+  summary: 'Created WorkItem ''BACK-20260812_1626-NobleFox-improve-textual-error-yanking-progress'':
+    ''Improve release-host Textual selection, error yanking, and progress clarity'''
+  subject: BACK-20260812_1626-NobleFox-improve-textual-error-yanking-progress
+  subject_kind: WorkItem
+  actor: BACK-20260812_1626-NobleFox-improve-textual-error-yanking-progress
+---

--- a/context/logs/2026/08/LOG-20260812_1628-RoyalPath-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260812_1628-RoyalPath-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260812_1628-RoyalPath-workitem-transitioned
+  created: '2026-08-12T16:28:31+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-12T16:28:31+00:00'
+  summary: Transitioned WorkItem 'BACK-20260808_1709-CuriousAnt' from 'review' to
+    'done'
+  subject: BACK-20260808_1709-CuriousAnt
+  subject_kind: WorkItem
+  actor: BACK-20260808_1709-CuriousAnt
+---

--- a/context/logs/2026/08/LOG-20260812_1628-ShinyGarden-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260812_1628-ShinyGarden-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260812_1628-ShinyGarden-workitem-transitioned
+  created: '2026-08-12T16:28:31+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-12T16:28:31+00:00'
+  summary: Transitioned WorkItem 'BACK-20260808_1709-CuriousAnt' from 'in-progress'
+    to 'review'
+  subject: BACK-20260808_1709-CuriousAnt
+  subject_kind: WorkItem
+  actor: BACK-20260808_1709-CuriousAnt
+---

--- a/context/logs/2026/08/LOG-20260812_1628-SpryStone-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260812_1628-SpryStone-workitem-archive-moved.md
@@ -1,0 +1,16 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260812_1628-SpryStone-workitem-archive-moved
+  created: '2026-08-12T16:28:31+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-12T16:28:31+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260808_1709-CuriousAnt' to /workspace/context/workitems/done/2026/08/BACK-20260808_1709-CuriousAnt-replace-privileged-e2e-companion-with-restricted.md
+  subject: BACK-20260808_1709-CuriousAnt
+  subject_kind: WorkItem
+  actor: BACK-20260808_1709-CuriousAnt
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260808_1709-CuriousAnt-replace-privileged-e2e-companion-with-restricted.md
+---

--- a/context/workitems/2026/08/BACK-20260812_1626-NobleFox-improve-textual-error-yanking-progress.md
+++ b/context/workitems/2026/08/BACK-20260812_1626-NobleFox-improve-textual-error-yanking-progress.md
@@ -1,0 +1,29 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260812_1626-NobleFox-improve-textual-error-yanking-progress
+  created: '2026-08-12T16:26:28+00:00'
+spec:
+  title: Improve release-host Textual selection, error yanking, and progress clarity
+  state: backlog
+  type: story
+  priority: medium
+  description: |
+    Improve the release-host Textual dashboard based on the v0.31.3 host run.
+
+    Acceptance criteria:
+    - The log widget supports ordinary mouse drag selection as well as keyboard selection.
+    - Keep Select All, and add a documented hotkey that selects approximately the last 20 visible/logical log lines (use a named constant so the count is testable and adjustable).
+    - The normal yank/copy action copies only the current marked selection. It must not silently copy the complete task log when there is no selection; instead show a concise no-selection notification.
+    - Add a dedicated Yank Errors hotkey. It copies a concise chronological error bundle containing failed task states, warning task states where relevant, and captured diagnostic/error lines, with enough task context to report the failure. It must not copy unrelated successful build output.
+    - Define and test error-line classification so ANSI/control sequences, candidate markup, ordinary progress output, and warning-only policy results cannot cause misleading copied text.
+    - Make overall progress determinate from application startup: show completed/total task count and percentage immediately. Conditional tasks may begin as pending and later become skipped; dynamic cleanup tasks must not make the denominator move backward or produce a misleading percentage.
+    - Replace unexplained task glyphs with a documented legend and accessible text/state. Distinguish pending circle, running spinner, passed, warning/exclamation, skipped, and failed.
+    - Add a compact Problems summary surface listing warnings and failures. Selecting a problem navigates or filters to the relevant task log. Yank Errors uses this same canonical problem model rather than a separate parser.
+    - Warning states such as accepted no-fix vulnerabilities remain visibly distinct from failures and explain why publication may continue.
+    - Headless tests cover mouse/selection behavior where Textual supports it, Select All, last-20 selection, selection-only yank, empty-selection handling, error-only yank, initial numeric progress, conditional skips, and warning/failure summaries at narrow and wide terminal sizes.
+    - Plain UI behavior and authoritative evidence files remain unchanged; clipboard/UI state is never release evidence.
+
+    Related implementation: scripts/release_host_gate.py and scripts/test-release-host-gate.sh. Related decision/spec: DEC-20260812_1004-CordialFlute and NOTE-20260812_1013-AmpleTulip.
+---

--- a/context/workitems/done/2026/08/BACK-20260808_1709-CuriousAnt-replace-privileged-e2e-companion-with-restricted.md
+++ b/context/workitems/done/2026/08/BACK-20260808_1709-CuriousAnt-replace-privileged-e2e-companion-with-restricted.md
@@ -7,18 +7,29 @@ metadata:
   labels:
     github_issue: '372'
     release_line: v0.x
-  updated: '2026-08-08T17:09:54+00:00'
+  updated: '2026-08-12T16:28:31+00:00'
 spec:
   title: Replace privileged E2E companion with restricted host release testing
-  state: in-progress
+  state: done
   type: task
   priority: critical
   description: 'Implement GitHub issue #372 in staged slices. First slice: define
     E2E execution classification and migrate companion-independent lifecycle contracts
     to a local temporary-workspace harness without weakening asserted behavior.'
   started_at: '2026-08-08T17:09:54+00:00'
+  completed_at: '2026-08-12T16:28:31+00:00'
 ---
 
 ## Transition note (2026-08-08T17:09:54+00:00)
 
 Beginning first implementation slice: local E2E execution classification and migration of companion-independent lifecycle contracts.
+
+
+## Transition note (2026-08-12T16:28:31+00:00)
+
+PR #373 merged; v0.31.2 and v0.31.3 completed the restricted host validation and publication cycle. Serialized local E2E, Textual headless tests, doctor, release audit, Darwin/Linux assets, GHCR pushes, and manifest-constrained publication verified.
+
+
+## Transition note (2026-08-12T16:28:31+00:00)
+
+Owner-run v0.31.3 host gate and retry-safe publisher completed. GitHub release contains Linux and Darwin assets with checksums; foundation, versioned runtime, and runtime-latest images were pushed and inspected. Issue #372 acceptance is complete.


### PR DESCRIPTION
## What changed

- archive the completed issue #372 WorkItem after verified v0.31.3 host publication
- record the follow-up Textual selection, yank-errors, determinate-progress, and problem-summary backlog story
- retain processkit state-transition audit events

Refs #372