### PR TITLE
chore(processkit): record v0.31.3 session handover

### DIFF
--- a/context/logs/2026/08/LOG-20260812_1632-SpryJewel-session-handover.md
+++ b/context/logs/2026/08/LOG-20260812_1632-SpryJewel-session-handover.md
@@ -1,0 +1,55 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260812_1632-SpryJewel-session-handover
+  created: '2026-08-12T16:32:00+00:00'
+spec:
+  event_type: session.handover
+  timestamp: '2026-08-12T16:32:00+00:00'
+  summary: 'Session handover - v0.31.3 published, issue #372 closed, and follow-up
+    work recorded'
+  actor: codex
+  subject: v0.31.3-release-and-issue-372
+  subject_kind: release
+  details:
+    session_date: '2026-08-12'
+    current_state: 'aibox v0.31.3 is published with Linux and macOS artifacts and
+      the GHCR runtime image, and issue #372 is closed after PR #373. Follow-up fixes
+      for host evidence finalization and publisher streaming were merged in PR #376,
+      while PR #377 recorded completion and the accepted Textual UI backlog. The v0.x-release
+      checkout is synchronized and clean at d285ee26 before this handover entry.'
+    open_threads:
+    - BACK-20260812_1626-NobleFox-improve-textual-error-yanking-progress - accepted
+      Textual UI improvements for selection, yanking errors, determinate progress,
+      glyph semantics, and a Problems panel.
+    - BACK-20260803_0713-SnappyOasis-prevent-tier2-release-e2e-contention - in progress;
+      concurrent visual tests reproduced contention, while serialized execution passed.
+    - BACK-20260724_1843-PatientLynx-implement-aibox-v1-orchestration - in-progress
+      v1 orchestration epic.
+    - BACK-20260514_0925-VastHare-tmux-theme-switch-prefix-menu-binding - in progress.
+    - BACK-20260514_0924-ActiveSummit-tmux-layout-chooser-prefix-menu-binding - in
+      progress.
+    - BACK-20260728_1004-GracefulSea-rebuild-companion-produce-live-m7c-evidence -
+      blocked critical M7c evidence work.
+    - BACK-20260725_1003-GiftedBlossom-implement-m7c-disposable-cluster-e2e-and -
+      blocked v1 M7c child story.
+    next_recommended_action: Implement BACK-20260812_1626-NobleFox before the next
+      host release, preserving the evidence/plain-output contract while adding selection-aware
+      yanking, canonical error extraction, determinate progress, and headless Textual
+      tests.
+    branch: v0.x-release
+    commit: d285ee26
+    git_status: clean and synchronized with origin/v0.x-release
+    stashes: none
+    behavioral_retrospective:
+    - 'The first Textual manifest finalization hashed steps.log before the terminal
+      task state; PR #376 corrected the ordering and added regression coverage.'
+    - Concurrent visual E2E execution caused resource contention; the serialized rerun
+      passed without killing tmux, reinforcing the existing contention WorkItem.
+    - Host-run caches under the repository caused processkit health traversal and
+      consumed substantial space; obsolete runs were removed and successful evidence
+      was retained outside the repository.
+    - The release-host UI feedback was captured as a dedicated WorkItem, and company-standard
+      learnings were added to the existing private internal issue rather than duplicated.
+---


### PR DESCRIPTION
Records the canonical processkit session handover after publishing v0.31.3 and closing issue #372.\n\nIncludes remaining WorkItems, the next recommended Textual UI action, Git state, and behavioral retrospective.