### PR TITLE
feat: add browser testing addon and refine release TUI

### DIFF
--- a/addons/tools/browser-testing.yaml
+++ b/addons/tools/browser-testing.yaml
@@ -1,0 +1,76 @@
+name: browser-testing
+version: "1.0.0"
+description: "Playwright visual and accessibility testing with Chromium by default"
+profile_intent: build
+usage_class: automated
+profiles: ["human-dev", "headless-runner"]
+exported_surfaces: ["cli-binary", "config-files"]
+builder_weight: "heavy"
+requires:
+  - node
+
+tools:
+  - name: playwright
+    description: "Pinned Playwright Test runner and browser automation library"
+    default_enabled: true
+    default_version: "1.62.1"
+    supported_versions: ["1.62.1"]
+  - name: axe-playwright
+    description: "Pinned axe-core accessibility checks for Playwright pages"
+    default_enabled: true
+    default_version: "4.13.0"
+    supported_versions: ["4.13.0"]
+  - name: chromium
+    description: "Playwright-managed full Chromium browser (enabled by default)"
+    default_enabled: true
+    default_version: ""
+    supported_versions: []
+  - name: firefox
+    description: "Optional Playwright-managed Firefox browser"
+    default_enabled: false
+    default_version: ""
+    supported_versions: []
+  - name: webkit
+    description: "Optional Playwright-managed WebKit browser"
+    default_enabled: false
+    default_version: ""
+    supported_versions: []
+
+builder: null
+
+runtime: |
+  # Addon: browser-testing — pinned Playwright Test + axe-core integration.
+  # Browser revisions are coupled to the pinned Playwright package version.
+  USER root
+  ENV NODE_PATH=/usr/local/lib/node_modules
+  ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+  {% if tools.playwright.enabled or tools["axe-playwright"].enabled %}
+  RUN npm install -g --no-fund --no-audit \
+  {% if tools.playwright.enabled %}
+      @playwright/test@{{ tools.playwright.version }} \
+  {% endif %}
+  {% if tools["axe-playwright"].enabled %}
+      @axe-core/playwright@{{ tools["axe-playwright"].version }} \
+      axe-core@{{ tools["axe-playwright"].version }} \
+  {% endif %}
+      && npm cache clean --force
+  {% endif %}
+  {% if not tools.playwright.enabled %}
+  RUN npm uninstall -g @playwright/test playwright || true
+  {% endif %}
+  {% if not tools["axe-playwright"].enabled %}
+  RUN npm uninstall -g @axe-core/playwright axe-core || true
+  {% endif %}
+  {% if tools.playwright.enabled and (tools.chromium.enabled or tools.firefox.enabled or tools.webkit.enabled) %}
+  RUN mkdir -p /ms-playwright && playwright install --with-deps --no-shell \
+  {% if tools.chromium.enabled %}
+      chromium \
+  {% endif %}
+  {% if tools.firefox.enabled %}
+      firefox \
+  {% endif %}
+  {% if tools.webkit.enabled %}
+      webkit \
+  {% endif %}
+      && chmod -R a+rX /ms-playwright
+  {% endif %}

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -759,6 +759,88 @@ runtime: |
     }
 
     #[test]
+    fn browser_testing_addon_pins_stack_and_defaults_to_full_chromium() {
+        let addon = load_repo_addon("browser-testing");
+        assert_eq!(addon.requires, vec!["node"]);
+
+        let playwright = addon
+            .tools
+            .iter()
+            .find(|tool| tool.name == "playwright")
+            .expect("browser-testing should define the Playwright tool");
+        assert_eq!(playwright.default_version, "1.62.1");
+        assert_eq!(playwright.supported_versions, vec!["1.62.1"]);
+
+        let axe = addon
+            .tools
+            .iter()
+            .find(|tool| tool.name == "axe-playwright")
+            .expect("browser-testing should define the axe adapter tool");
+        assert_eq!(axe.default_version, "4.13.0");
+        assert_eq!(axe.supported_versions, vec!["4.13.0"]);
+
+        let chromium = addon
+            .tools
+            .iter()
+            .find(|tool| tool.name == "chromium")
+            .expect("browser-testing should define Chromium");
+        assert!(chromium.default_enabled);
+        assert!(
+            !addon
+                .tools
+                .iter()
+                .find(|tool| tool.name == "firefox")
+                .unwrap()
+                .default_enabled
+        );
+        assert!(
+            !addon
+                .tools
+                .iter()
+                .find(|tool| tool.name == "webkit")
+                .unwrap()
+                .default_enabled
+        );
+
+        let rendered = render_runtime(&addon, &all_enabled_tools(&addon)).unwrap();
+        assert!(rendered.contains("@playwright/test@1.62.1"));
+        assert!(rendered.contains("@axe-core/playwright@4.13.0"));
+        assert!(rendered.contains("axe-core@4.13.0"));
+        assert!(rendered.contains("PLAYWRIGHT_BROWSERS_PATH=/ms-playwright"));
+        assert!(rendered.contains("--no-shell"));
+        assert!(rendered.contains("chromium"));
+        assert!(rendered.contains("firefox"));
+        assert!(rendered.contains("webkit"));
+        assert!(!rendered.contains("chromium-headless-shell"));
+
+        let rendered_defaults = render_runtime(
+            &addon,
+            &addon
+                .tools
+                .iter()
+                .map(|tool| {
+                    (
+                        tool.name.clone(),
+                        ToolConfig {
+                            enabled: tool.default_enabled,
+                            version: tool.default_version.clone(),
+                        },
+                    )
+                })
+                .collect(),
+        )
+        .unwrap();
+        assert!(rendered_defaults.contains("chromium \\"));
+        assert!(!rendered_defaults.contains("      firefox \\"));
+        assert!(!rendered_defaults.contains("      webkit \\"));
+
+        let rendered_disabled = render_runtime(&addon, &all_disabled_tools(&addon)).unwrap();
+        assert!(rendered_disabled.contains("npm uninstall -g @playwright/test playwright"));
+        assert!(rendered_disabled.contains("npm uninstall -g @axe-core/playwright axe-core"));
+        assert!(!rendered_disabled.contains("playwright install --with-deps"));
+    }
+
+    #[test]
     fn every_language_exposes_consistent_shared_groups() {
         for language in ["go", "rust", "python", "node", "typst", "latex"] {
             let addon = load_repo_addon(language);

--- a/cli/tests/e2e/config_coverage.rs
+++ b/cli/tests/e2e/config_coverage.rs
@@ -468,6 +468,49 @@ node = { version = "22" }
     );
 }
 
+#[test]
+fn browser_testing_addon_renders_chromium_first_playwright_and_axe_contract() {
+    let dir = tempfile::tempdir().unwrap();
+    init_project(dir.path(), "addon-browser-testing");
+    patch_toml(
+        dir.path(),
+        r#"
+[addons.browser-testing.tools]
+"#,
+    );
+    sync_project(dir.path());
+    let dockerfile = read_generated(dir.path(), ".devcontainer/Dockerfile");
+    assert!(
+        dockerfile.contains("@playwright/test") && dockerfile.contains("@axe-core/playwright"),
+        "browser-testing must install the coherent Playwright Test and axe adapter packages:\n{dockerfile}"
+    );
+    assert!(
+        dockerfile.contains("playwright install --with-deps --no-shell")
+            && dockerfile.contains("chromium \\"),
+        "browser-testing must provision full Chromium by default:\n{dockerfile}"
+    );
+}
+
+#[test]
+fn browser_testing_addon_renders_optional_firefox_and_webkit() {
+    let dir = tempfile::tempdir().unwrap();
+    init_project(dir.path(), "addon-browser-testing-cross-engine");
+    patch_toml(
+        dir.path(),
+        r#"
+[addons.browser-testing.tools]
+firefox = { enabled = true }
+webkit = { enabled = true }
+"#,
+    );
+    sync_project(dir.path());
+    let dockerfile = read_generated(dir.path(), ".devcontainer/Dockerfile");
+    assert!(
+        dockerfile.contains("firefox \\") && dockerfile.contains("webkit \\"),
+        "browser-testing must render optional Firefox and WebKit installation when enabled:\n{dockerfile}"
+    );
+}
+
 // ─── processkit package selection tests ──────────────────────────────────────
 //
 // Since v0.16.0 aibox no longer scaffolds context-doc files (BACKLOG.md,

--- a/context/decisions/DEC-20260813_1417-FastTrail-provide-a-chromium-first-playwright-and.md
+++ b/context/decisions/DEC-20260813_1417-FastTrail-provide-a-chromium-first-playwright-and.md
@@ -1,0 +1,46 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: DecisionRecord
+metadata:
+  id: DEC-20260813_1417-FastTrail-provide-a-chromium-first-playwright-and
+  created: '2026-08-13T14:17:27+00:00'
+spec:
+  title: Provide a Chromium-first Playwright and axe browser-testing addon
+  state: accepted
+  decision: Add a v0.x `browser-testing` tool addon built around a pinned, coherent
+    Playwright Test and `@axe-core/playwright` installation with Playwright-managed
+    full Chromium enabled by default. Firefox and WebKit are optional tools. The aibox
+    repository will validate installation, rendering, browser launch, configuration
+    toggles, and a minimal fixture; derived projects own their application-specific
+    viewport, color-scheme, motion, keyboard, accessibility, and screenshot matrix.
+  context: Derived projects need reproducible headless testing for responsive layouts,
+    keyboard focus, light and dark color schemes, reduced motion, visual regression
+    screenshots, and automated accessibility checks. The addon must minimize dependencies
+    while keeping upstream-supported integration and reproducible browser/tool version
+    coupling. aibox itself owns the addon contract, not each derived application's
+    visual coverage matrix.
+  rationale: The Node Playwright stack is the smallest maintained stack that combines
+    a runner, browser isolation, emulation, keyboard control, traces, screenshot baselines,
+    and Deque's maintained axe adapter. Python or Selenium alternatives avoid npm
+    only superficially while requiring more independent packages and weaker visual-regression
+    integration. Keeping aibox tests to a minimal contract avoids turning the CLI
+    repository into a sample web application's screenshot suite.
+  alternatives:
+  - option: Python Playwright plus pytest and separate image/axe integrations
+    reason_rejected: More independent dependencies and no equally integrated official
+      golden-screenshot plus axe stack.
+  - option: Selenium or raw Chromium CLI
+    reason_rejected: Requires more driver/assertion/diff infrastructure and provides
+      weaker integrated emulation, traces, and visual baselines.
+  - option: Run a full responsive/theme/motion screenshot matrix in aibox
+    reason_rejected: That matrix validates a derived application, while aibox should
+      validate only the addon installation and configuration contract.
+  consequences: The addon introduces an accepted npm/Node dependency and a sizable
+    Chromium browser layer. Browser revisions must remain coupled to the pinned Playwright
+    version. aibox must provide focused addon rendering and launch smoke tests, plus
+    optional-browser enable/disable coverage. Documentation should show a representative
+    derived-project matrix without requiring that matrix in aibox CI.
+  deciders:
+  - TEAMMEMBER-thrifty-otter
+  decided_at: '2026-08-13T14:17:27+00:00'
+---

--- a/context/logs/2026/08/LOG-20260813_1403-FirmSpark-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1403-FirmSpark-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1403-FirmSpark-workitem-transitioned
+  created: '2026-08-13T14:03:47+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T14:03:47+00:00'
+  summary: Transitioned WorkItem 'BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels
+  subject_kind: WorkItem
+  actor: BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels
+---

--- a/context/logs/2026/08/LOG-20260813_1404-AdeptPlum-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1404-AdeptPlum-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1404-AdeptPlum-workitem-transitioned
+  created: '2026-08-13T14:04:30+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T14:04:30+00:00'
+  summary: Transitioned WorkItem 'BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels'
+    from 'in-progress' to 'review'
+  subject: BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels
+  subject_kind: WorkItem
+  actor: BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels
+---

--- a/context/logs/2026/08/LOG-20260813_1404-FaithfulMelody-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260813_1404-FaithfulMelody-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1404-FaithfulMelody-workitem-archive-moved
+  created: '2026-08-13T14:04:37+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-13T14:04:37+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels'
+    to /workspace/context/workitems/done/2026/08/BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels.md
+  subject: BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels
+  subject_kind: WorkItem
+  actor: BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels.md
+---

--- a/context/logs/2026/08/LOG-20260813_1404-NimbleFjord-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1404-NimbleFjord-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1404-NimbleFjord-workitem-transitioned
+  created: '2026-08-13T14:04:37+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T14:04:37+00:00'
+  summary: Transitioned WorkItem 'BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels'
+    from 'review' to 'done'
+  subject: BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels
+  subject_kind: WorkItem
+  actor: BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels
+---

--- a/context/logs/2026/08/LOG-20260813_1417-CheerfulDaisy-decision-created.md
+++ b/context/logs/2026/08/LOG-20260813_1417-CheerfulDaisy-decision-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1417-CheerfulDaisy-decision-created
+  created: '2026-08-13T14:17:27+00:00'
+spec:
+  event_type: decision.created
+  timestamp: '2026-08-13T14:17:27+00:00'
+  summary: 'Created DecisionRecord ''DEC-20260813_1417-FastTrail-provide-a-chromium-first-playwright-and'':
+    ''Provide a Chromium-first Playwright and axe browser-testing addon'''
+  subject: DEC-20260813_1417-FastTrail-provide-a-chromium-first-playwright-and
+  subject_kind: DecisionRecord
+  actor: DEC-20260813_1417-FastTrail-provide-a-chromium-first-playwright-and
+---

--- a/context/logs/2026/08/LOG-20260813_1420-AmpleFlute-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260813_1420-AmpleFlute-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1420-AmpleFlute-workitem-created
+  created: '2026-08-13T14:20:41+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-13T14:20:41+00:00'
+  summary: 'Created WorkItem ''BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon'':
+    ''Add browser visual testing addon for v0.x'''
+  subject: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+  subject_kind: WorkItem
+  actor: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+---

--- a/context/logs/2026/08/LOG-20260813_1420-VastSpring-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1420-VastSpring-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1420-VastSpring-workitem-transitioned
+  created: '2026-08-13T14:20:45+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T14:20:45+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+  subject_kind: WorkItem
+  actor: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+---

--- a/context/logs/2026/08/LOG-20260813_1442-CapableFern-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1442-CapableFern-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1442-CapableFern-workitem-transitioned
+  created: '2026-08-13T14:42:20+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T14:42:20+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon'
+    from 'review' to 'done'
+  subject: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+  subject_kind: WorkItem
+  actor: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+---

--- a/context/logs/2026/08/LOG-20260813_1442-CapablePath-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1442-CapablePath-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1442-CapablePath-workitem-transitioned
+  created: '2026-08-13T14:42:17+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T14:42:17+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon'
+    from 'in-progress' to 'review'
+  subject: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+  subject_kind: WorkItem
+  actor: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+---

--- a/context/logs/2026/08/LOG-20260813_1442-DeftStone-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260813_1442-DeftStone-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1442-DeftStone-workitem-archive-moved
+  created: '2026-08-13T14:42:20+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-13T14:42:20+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon'
+    to /workspace/context/workitems/done/2026/08/BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon.md
+  subject: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+  subject_kind: WorkItem
+  actor: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon.md
+---

--- a/context/workitems/done/2026/08/BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels.md
+++ b/context/workitems/done/2026/08/BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels.md
@@ -4,9 +4,10 @@ kind: WorkItem
 metadata:
   id: BACK-20260812_1851-ArtfulHorizon-fix-textual-duplicate-empty-panels
   created: '2026-08-12T18:51:51+00:00'
+  updated: '2026-08-13T14:04:37+00:00'
 spec:
   title: Fix duplicated and empty panels in the Textual release-host UI
-  state: backlog
+  state: done
   type: bug
   priority: medium
   assignee: TEAMMEMBER-cora
@@ -24,4 +25,20 @@ spec:
     - Place the `Problems` heading and its panel directly beneath the task list, without an empty intermediate widget or border.
     - Preserve the recently added Problems filtering, selection, copy, and error-bundle behavior.
     - Add a headless Textual layout/widget-tree regression test that fails if redundant visible containers return.
+  started_at: '2026-08-13T14:03:47+00:00'
+  completed_at: '2026-08-13T14:04:37+00:00'
 ---
+
+## Transition note (2026-08-13T14:03:47+00:00)
+
+Implementing the confirmed Textual layout regression fix: one log border and an unboxed legend directly above Problems.
+
+
+## Transition note (2026-08-13T14:04:29+00:00)
+
+Removed the redundant log-panel border, rendered the legend as a single unboxed line, and made the progress region viewport-wide. Headless geometry tests pass at 80x24 and 140x40.
+
+
+## Transition note (2026-08-13T14:04:37+00:00)
+
+Verified by release-host contract tests and Textual headless geometry assertions at narrow and wide terminal sizes.

--- a/context/workitems/done/2026/08/BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon.md
+++ b/context/workitems/done/2026/08/BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon.md
@@ -1,0 +1,33 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260813_1420-CleverPearl-add-browser-visual-testing-addon
+  created: '2026-08-13T14:20:41+00:00'
+  updated: '2026-08-13T14:42:20+00:00'
+spec:
+  title: Add browser visual testing addon for v0.x
+  state: done
+  type: task
+  priority: medium
+  description: 'Implement the accepted v0.x browser-testing addon: pinned coherent
+    Playwright Test and axe-core stack, full Chromium by default, optional Firefox/WebKit,
+    focused aibox contract and fixture coverage, and user documentation. Derived projects
+    remain responsible for application-specific browser matrices.'
+  started_at: '2026-08-13T14:20:45+00:00'
+  completed_at: '2026-08-13T14:42:20+00:00'
+---
+
+## Transition note (2026-08-13T14:20:45+00:00)
+
+Accepted by the owner; implementation started with bounded parallel addon and documentation/test work.
+
+
+## Transition note (2026-08-13T14:42:17+00:00)
+
+Implementation complete. Focused addon/render tests, release-host contract/UI tests, full serialized Rust suite, clippy, formatting, shell syntax, and pk-doctor all pass. Browser launch and axe fixture remain host-gated.
+
+
+## Transition note (2026-08-13T14:42:20+00:00)
+
+Accepted addon slice implemented and locally verified; macOS release-host now supplies the remaining live Chromium and axe execution evidence when this reaches a release.

--- a/docs-site/content/docs/addons/overview.md
+++ b/docs-site/content/docs/addons/overview.md
@@ -5,7 +5,7 @@ title: "Overview"
 
 # Addons
 
-aibox uses the Debian runtime image family (`base-debian-v0.26.x` for legacy releases, `base-debian-runtime-v0.27.0+` after the image-tag cutover) with **35 composable addons** that install language runtimes, tool bundles, documentation frameworks, and AI coding agents into your container.
+aibox uses the Debian runtime image family (`base-debian-v0.26.x` for legacy releases, `base-debian-runtime-v0.27.0+` after the image-tag cutover) with **36 composable addons** that install language runtimes, tool bundles, documentation frameworks, and AI coding agents into your container.
 
 ## Managing Addons
 
@@ -93,6 +93,7 @@ After editing `aibox.toml`, run `aibox apply` to regenerate the Dockerfile and r
 | `cloud-aws` | aws-cli | — |
 | `cloud-gcp` | gcloud-cli | — |
 | `cloud-azure` | azure-cli | — |
+| `browser-testing` | @playwright/test, @axe-core/playwright, Chromium | Firefox, WebKit |
 
 ### Documentation Frameworks
 

--- a/docs-site/content/docs/addons/tool-bundles.md
+++ b/docs-site/content/docs/addons/tool-bundles.md
@@ -48,6 +48,66 @@ tools. This aibox repo may enable it for maintenance workflows such as release
 checks and GitHub issue/release work, but downstream projects do not need it by
 default.
 
+## Browser Visual Testing
+
+The `browser-testing` addon provides a pinned Node-based Playwright Test stack
+(`@playwright/test` plus `@axe-core/playwright`) for headless browser checks.
+Playwright-managed full Chromium is enabled by default; Firefox and WebKit are
+opt-in so a project can keep its image smaller when cross-engine coverage is
+not required.
+
+```toml
+[addons.browser-testing.tools]
+# Playwright Test and @axe-core/playwright are enabled by default.
+# Optional cross-engine coverage:
+firefox = { enabled = true }
+webkit = { enabled = true }
+```
+
+The v0.x catalog currently couples Playwright `1.62.1` with
+`@axe-core/playwright` `4.13.0` and the matching browser revisions. The addon
+provides that pinned runner/browser environment; keep the derived project's
+`package.json` and lockfile authoritative, and install the packages locally
+when the project's package manager does not resolve the environment's global
+packages. After applying the configuration, a derived project can keep its
+tests and baselines beside the application, for example:
+
+```ts
+// playwright.config.ts
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/browser",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    ...devices["Desktop Chrome"],
+    colorScheme: "light",
+    reducedMotion: "reduce",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});
+```
+
+```ts
+// tests/browser/home.spec.ts
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test("home page is keyboard reachable and accessible", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("main")).toBeVisible();
+  await page.keyboard.press("Tab");
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});
+```
+
+The example is only a starting point. The derived project owns the responsive
+viewport set, focus and keyboard flows, light/dark themes, reduced-motion
+behavior, accessibility assertions, and screenshot-baseline matrix. aibox
+tests validate the addon installation, generated contract, browser launch, and
+a minimal fixture; they do not prescribe an application's visual matrix.
+
 ## Preview and Archive Tools
 
 ```toml

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -228,6 +228,7 @@ main() {
     languages/latex.yaml
     tools/infrastructure.yaml
     tools/supply-chain.yaml
+    tools/browser-testing.yaml
     tools/release.yaml
     tools/go-release.yaml
     tools/kubernetes.yaml
@@ -258,15 +259,18 @@ main() {
     ai/ai-opencode.yaml
   "
   local failed=0
+  local installed=0
   for file in ${addon_files}; do
     if ! curl -fsSL -o "${addons_dir}/${file}" "${addons_base_url}/${file}" 2>/dev/null; then
       warn "Failed to download addon: ${file}"
       failed=$((failed + 1))
+    else
+      installed=$((installed + 1))
     fi
   done
 
   if [[ "${failed}" -eq 0 ]]; then
-    ok "Installed 32 addon definitions"
+    ok "Installed ${installed} addon definitions"
   else
     warn "Installed with ${failed} addon download failures — re-run to retry"
   fi

--- a/scripts/release_host_gate.py
+++ b/scripts/release_host_gate.py
@@ -179,16 +179,16 @@ def run_textual_dashboard(run_argument: str, dry_run: bool) -> int:
         CSS = """
         Screen { layout: vertical; }
         #summary { height: 3; border: round $accent; padding: 0 1; }
-        #progress-box { height: 4; margin: 0 1; }
-        #progress { height: 3; }
+        #progress-box { width: 100%; height: 4; padding: 0 1; }
+        #progress { width: 100%; height: 3; }
         #progress-label { height: 1; color: $text-muted; }
         #body { height: 1fr; }
         #tasks-panel { width: 34%; min-width: 28; }
         #tasks { height: 1fr; border: round $accent; }
-        #legend { height: 2; border: round $accent; padding: 0 1; }
+        #legend { height: 1; padding: 0 1; color: $text-muted; }
         #problems-title { height: 1; padding: 0 1; color: $warning; }
         #problems { height: 7; border: round $warning; }
-        #log-panel { width: 66%; border: round $accent; }
+        #log-panel { width: 66%; }
         #log { height: 1fr; border: round $accent; }
         #log-status { height: 1; color: $text-muted; }
         ListItem { padding: 0 1; }
@@ -505,7 +505,7 @@ def run_textual_dashboard(run_argument: str, dry_run: bool) -> int:
 ADDON_GROUPS = {
     "addon-languages": ["docs-hugo", "docs-mdbook", "go", "go-quality", "go-release", "node", "rust", "typst"],
     "addon-platforms": ["cloud-aws", "cloud-gcp", "cloudflare", "infrastructure", "kubernetes"],
-    "addon-tools": ["ai-claude", "ai-opencode", "preview-archive", "supply-chain"],
+    "addon-tools": ["ai-claude", "ai-opencode", "browser-testing", "preview-archive", "supply-chain"],
 }
 ADDON_GROUP_TRIGGERS = {
     **ADDON_GROUPS,
@@ -942,9 +942,31 @@ def run_addon_group(runner: Runner, profile: Path, env: dict[str, str], candidat
     try:
         prepare_project_build(runner, profile, env, candidate_bin, container_runtime,
                               project, version)
+        browser_fixture = None
+        if group == "addon-tools":
+            runner.run([container_runtime, "compose", "-f", str(compose_file), "up", "-d", name],
+                       cwd=project)
+            fixture_script = (
+                'const { chromium } = require("@playwright/test"); '
+                'const AxeBuilder = require("@axe-core/playwright").default; '
+                '(async () => { const browser = await chromium.launch({ headless: true }); '
+                'const page = await browser.newPage(); '
+                'await page.setContent("<!doctype html><html lang=\\"en\\"><head><title>Fixture</title></head>'
+                '<body><main><button type=\\"button\\">Ready</button></main></body></html>"); '
+                'const results = await new AxeBuilder({ page }).analyze(); '
+                'console.log(JSON.stringify({ title: await page.title(), violations: results.violations.length })); '
+                'await browser.close(); })().catch(error => { console.error(error); process.exit(1); });'
+            )
+            output = runner.capture([container_runtime, "exec", "--user", "aibox", name,
+                                     "node", "-e", fixture_script])
+            browser_fixture = json.loads(output.strip().splitlines()[-1])
+            if browser_fixture != {"title": "Fixture", "violations": 0}:
+                fail(f"browser-testing fixture returned unexpected evidence: {browser_fixture}")
         marker = evidence / "container-e2e" / f"{group}.json"
-        marker.write_text(json.dumps({"status": "passed", "addons": ADDON_GROUPS[group]},
-                                     indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        payload = {"status": "passed", "addons": ADDON_GROUPS[group]}
+        if browser_fixture is not None:
+            payload["browser_fixture"] = browser_fixture
+        marker.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         return marker
     finally:
         if compose_file.exists():

--- a/scripts/test-release-host-gate.sh
+++ b/scripts/test-release-host-gate.sh
@@ -164,6 +164,10 @@ assert gate.dry_run_enabled("1") is True
 assert gate.cache_reuse_enabled(None) is False
 assert gate.cache_reuse_enabled("0") is False
 assert gate.cache_reuse_enabled("1") is True
+assert "browser-testing" in gate.ADDON_GROUPS["addon-tools"]
+assert "@axe-core/playwright" in source
+assert 'chromium.launch({ headless: true })' in source
+assert '"browser_fixture"' in source
 assert gate.parse_ui_mode(None) == "auto"
 assert gate.parse_ui_mode("textual") == "textual"
 assert gate.sanitize_display("[bold]literal[/bold]\x1b[31m red\x1b[0m\x1b]0;title\x07") == "[bold]literal[/bold] red"
@@ -179,6 +183,11 @@ assert 'Binding("Y", "copy_task_log", "Yank task log")' in source
 assert 'No log selection to copy' in source
 assert 'id="problems"' in source
 assert 'total=len(TASK_PLAN)' in source
+assert '#progress-box { width: 100%;' in source
+assert '#progress { width: 100%;' in source
+assert '#log-panel { width: 66%; }' in source
+assert '#log-panel { width: 66%; border:' not in source
+assert '#legend { height: 1; padding: 0 1; color: $text-muted; }' in source
 class FakeTTY:
     def __init__(self, tty): self.tty = tty
     def isatty(self): return self.tty
@@ -320,6 +329,18 @@ def headless_run(self, *args, **kwargs):
             # the synthetic gate worker exits faster than the 10 ms timer.
             self._flush_log_render()
             await pilot.pause(0.05)
+            screen_width = self.screen.size.width
+            progress_region = self.query_one("#progress-box").region
+            tasks_region = self.query_one("#tasks-panel").region
+            log_panel = self.query_one("#log-panel")
+            log = self.query_one("#log")
+            legend = self.query_one("#legend")
+            assert progress_region.width == screen_width, (progress_region, self.screen.size)
+            assert progress_region.width > tasks_region.width
+            assert log_panel.styles.border_top[0] == ""
+            assert log.styles.border_top[0] == "round"
+            assert legend.styles.border_top[0] == ""
+            assert legend.region.height == 1
             assert "[bold]literal[/bold] red" in self.query_one("#log").text, repr(self.query_one("#log").text)
             assert self.query_one("#progress").total == len(gate.TASK_PLAN), self.query_one("#progress").total
             assert "3/" in str(self.query_one("#progress-label").render()), self.query_one("#progress-label").render()


### PR DESCRIPTION
## Outcome

- add a pinned browser-testing addon with Playwright Test 1.62.1 and axe 4.13.0
- install full Chromium by default, with optional Firefox and WebKit
- validate generated contracts locally and launch Chromium plus a minimal axe fixture in the macOS release-host gate
- remove redundant Textual log/legend panels and widen progress to the viewport
- document why application-specific browser matrices stay in derived projects

## Validation

- cargo test -- --test-threads=1
- cargo clippy --all-targets -- -D warnings
- cargo fmt -- --check
- cargo audit
- bash scripts/test-release-host-gate.sh
- bash -n scripts/install.sh
- pk-doctor: 0 errors, 0 warnings, 0 actionable findings

Refs: DEC-20260813_1417-FastTrail, BACK-20260813_1420-CleverPearl, BACK-20260812_1851-ArtfulHorizon