### PR TITLE
chore: track v0.32.0 release

### DIFF
--- a/context/logs/2026/08/LOG-20260813_1454-CleverCharm-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1454-CleverCharm-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1454-CleverCharm-workitem-transitioned
+  created: '2026-08-13T14:54:48+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T14:54:48+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+  subject_kind: WorkItem
+  actor: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+---

--- a/context/logs/2026/08/LOG-20260813_1454-LivelyPrairie-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260813_1454-LivelyPrairie-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1454-LivelyPrairie-workitem-created
+  created: '2026-08-13T14:54:44+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-13T14:54:44+00:00'
+  summary: 'Created WorkItem ''BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0'':
+    ''Release aibox v0.32.0'''
+  subject: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+  subject_kind: WorkItem
+  actor: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+---

--- a/context/workitems/2026/08/BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0.md
+++ b/context/workitems/2026/08/BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0.md
@@ -1,0 +1,21 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+  created: '2026-08-13T14:54:44+00:00'
+  updated: '2026-08-13T14:54:48+00:00'
+spec:
+  title: Release aibox v0.32.0
+  state: in-progress
+  type: task
+  priority: high
+  description: Prepare, validate, publish, and verify the v0.32.0 minor release from
+    v0.x-release. Complete repository-side Phase 1 and provide the owner with the
+    exact macOS release-host Phase 2 command.
+  started_at: '2026-08-13T14:54:48+00:00'
+---
+
+## Transition note (2026-08-13T14:54:48+00:00)
+
+Owner requested the next v0.x minor release; target resolved to v0.32.0 and release preflight started.


### PR DESCRIPTION
Track the owner-requested v0.32.0 minor release before the clean-tree release workflow begins.