### PR TITLE
docs(release): prepare v0.32.0

### DIFF
--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -683,6 +683,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.6",
         note: "Patch release: retries OpenCode release downloads and makes Textual yanks selection-aware while preserving actionable failed-task diagnostics.",
     },
+    CompatEntry {
+        aibox_version: "0.32.0",
+        processkit_version: "v0.28.6",
+        note: "Minor release: adds a pinned Chromium-first Playwright and axe browser-testing addon with optional Firefox/WebKit, live release-host browser evidence, and a cleaner full-width Textual release dashboard.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/dist/RELEASE-NOTES.md
+++ b/dist/RELEASE-NOTES.md
@@ -1,19 +1,21 @@
-# aibox v0.31.5 — 2026-08-13
+# aibox v0.32.0 — 2026-08-13
 
-**Summary:** This patch makes OpenCode-enabled container builds tolerate transient GitHub download failures and corrects Textual log-yank behavior in the macOS release gate. Operators can yank only the marked log range and receive useful diagnostic tails for failures that do not print an explicit error line; no configuration change is required.
+**Summary:** This minor release adds an opt-in, reproducible browser-testing environment for projects that need responsive, keyboard, theme, reduced-motion, accessibility, and screenshot checks. Existing projects require no changes; enable the new addon when browser testing is wanted.
 
 ## Added
 
-- Add bounded failed-task output tails to the canonical Textual Problems bundle when command output lacks an explicit error classifier.
+- Add the `browser-testing` addon with pinned Playwright Test 1.62.1 and `@axe-core/playwright` 4.13.0.
+- Install Playwright-managed full Chromium by default, with Firefox and WebKit available as opt-in tools.
+- Exercise a minimal Chromium launch and axe accessibility fixture in the macOS release-host gate.
 
 ## Changed
 
-- Bind lowercase `y` to the active Textual log selection, matching Vim visual-mode semantics; retain full selected-task copying on uppercase `Y`.
+- Make the release-host progress bar span the viewport instead of matching only the task-list width.
+- Document that derived projects own their application-specific responsive, keyboard-focus, light/dark, reduced-motion, accessibility, and visual-regression matrices.
 
 ## Fixed
 
-- Retry pinned OpenCode release archive and checksum downloads across transient connection failures, including curl exit 56.
-- Retry both release discovery and archive downloads in the unpinned OpenCode fallback path.
-- Preserve useful task output in Problems when a failed command exits non-zero without printing `error`, `fatal`, or a similar classifier.
+- Remove the redundant outer border around the Textual log and the empty bordered legend row above Problems.
+- Keep browser-testing package and browser installation consistent when individual addon tools are disabled.
 
-[v0.31.5]: https://github.com/projectious-work/aibox/compare/v0.31.4...v0.31.5
+[v0.32.0]: https://github.com/projectious-work/aibox/compare/v0.31.5...v0.32.0

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.32.0 | v0.28.6 | adds a pinned Chromium-first Playwright and axe browser-testing addon with optional Firefox/WebKit, live release-host browser evidence, and a cleaner full-width Textual release dashboard |
 | 0.31.5 | v0.28.6 | retries transient OpenCode release downloads and makes Textual yanks selection-aware while preserving actionable failed-task diagnostics |
 | 0.31.4 | v0.28.6 | makes Hugo downloads resilient to transient network failures, improves the release-host Textual problem workflow, and serializes contention-sensitive E2E gates |
 | 0.31.3 | v0.28.6 | adds a locked Textual dashboard and reviewed content-addressed cache reuse to the restricted macOS host gate |


### PR DESCRIPTION
Prepare the compatibility metadata and curated release notes for the next v0.x minor release.\n\nTarget: v0.32.0\nMinimum processkit: v0.28.6