### PR TITLE
fix(release): launch installed Chromium channel

### DIFF
--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -806,8 +806,11 @@ runtime: |
         assert!(rendered.contains("@playwright/test@1.62.1"));
         assert!(rendered.contains("@axe-core/playwright@4.13.0"));
         assert!(rendered.contains("axe-core@4.13.0"));
-        assert!(rendered.contains("PLAYWRIGHT_BROWSERS_PATH=/ms-playwright"));
         assert!(rendered.contains("--no-shell"));
+        assert!(
+            rendered.contains("PLAYWRIGHT_BROWSERS_PATH=/ms-playwright"),
+            "full Chromium must be installed in a shared browser path"
+        );
         assert!(rendered.contains("chromium"));
         assert!(rendered.contains("firefox"));
         assert!(rendered.contains("webkit"));

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -688,6 +688,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.6",
         note: "Minor release: adds a pinned Chromium-first Playwright and axe browser-testing addon with optional Firefox/WebKit, live release-host browser evidence, and a cleaner full-width Textual release dashboard.",
     },
+    CompatEntry {
+        aibox_version: "0.32.1",
+        processkit_version: "v0.28.6",
+        note: "Patch release: makes the browser-testing host gate launch the full Chromium channel installed by Playwright --no-shell instead of requesting the omitted headless-shell executable.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/context/logs/2026/08/LOG-20260813_1609-FinePond-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1609-FinePond-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1609-FinePond-workitem-transitioned
+  created: '2026-08-13T16:09:47+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T16:09:47+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+  subject_kind: WorkItem
+  actor: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+---

--- a/context/logs/2026/08/LOG-20260813_1609-ResoluteBird-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260813_1609-ResoluteBird-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1609-ResoluteBird-workitem-created
+  created: '2026-08-13T16:09:41+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-13T16:09:41+00:00'
+  summary: 'Created WorkItem ''BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe'':
+    ''Fix full-Chromium release-host probe and release v0.32.1'''
+  subject: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+  subject_kind: WorkItem
+  actor: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+---

--- a/context/logs/2026/08/LOG-20260813_1610-CoolPrairie-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260813_1610-CoolPrairie-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1610-CoolPrairie-workitem-archive-moved
+  created: '2026-08-13T16:10:45+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-13T16:10:45+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe'
+    to /workspace/context/workitems/done/2026/08/BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe.md
+  subject: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+  subject_kind: WorkItem
+  actor: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe.md
+---

--- a/context/logs/2026/08/LOG-20260813_1610-SunnyForge-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1610-SunnyForge-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1610-SunnyForge-workitem-transitioned
+  created: '2026-08-13T16:10:45+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T16:10:45+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe'
+    from 'review' to 'done'
+  subject: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+  subject_kind: WorkItem
+  actor: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+---

--- a/context/logs/2026/08/LOG-20260813_1610-TallHorizon-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1610-TallHorizon-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1610-TallHorizon-workitem-transitioned
+  created: '2026-08-13T16:10:41+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T16:10:41+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe'
+    from 'in-progress' to 'review'
+  subject: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+  subject_kind: WorkItem
+  actor: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+---

--- a/context/workitems/done/2026/08/BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe.md
+++ b/context/workitems/done/2026/08/BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe.md
@@ -1,0 +1,33 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260813_1609-NimbleOtter-fix-chromium-host-probe
+  created: '2026-08-13T16:09:41+00:00'
+  updated: '2026-08-13T16:10:45+00:00'
+spec:
+  title: Fix full-Chromium release-host probe and release v0.32.1
+  state: done
+  type: bug
+  priority: high
+  description: The v0.32.0 addon-tools host gate installed Playwright full Chromium
+    with --no-shell but launched Playwright's default headless-shell executable. Launch
+    channel chromium instead, add regression coverage, and publish v0.32.1; v0.32.0
+    remains immutable and host-incomplete.
+  started_at: '2026-08-13T16:09:47+00:00'
+  completed_at: '2026-08-13T16:10:45+00:00'
+---
+
+## Transition note (2026-08-13T16:09:47+00:00)
+
+Owner supplied v0.32.0 release-host failure evidence; root cause identified as headless-shell/full-Chromium launch mismatch.
+
+
+## Transition note (2026-08-13T16:10:41+00:00)
+
+Source probe now explicitly launches channel chromium; release-host contract, focused addon test, formatting, and diff checks pass.
+
+
+## Transition note (2026-08-13T16:10:45+00:00)
+
+Fix accepted by test evidence and prepared for immutable v0.32.1 patch publication.

--- a/dist/RELEASE-NOTES.md
+++ b/dist/RELEASE-NOTES.md
@@ -1,21 +1,10 @@
-# aibox v0.32.0 — 2026-08-13
+# aibox v0.32.1 — 2026-08-13
 
-**Summary:** This minor release adds an opt-in, reproducible browser-testing environment for projects that need responsive, keyboard, theme, reduced-motion, accessibility, and screenshot checks. Existing projects require no changes; enable the new addon when browser testing is wanted.
-
-## Added
-
-- Add the `browser-testing` addon with pinned Playwright Test 1.62.1 and `@axe-core/playwright` 4.13.0.
-- Install Playwright-managed full Chromium by default, with Firefox and WebKit available as opt-in tools.
-- Exercise a minimal Chromium launch and axe accessibility fixture in the macOS release-host gate.
-
-## Changed
-
-- Make the release-host progress bar span the viewport instead of matching only the task-list width.
-- Document that derived projects own their application-specific responsive, keyboard-focus, light/dark, reduced-motion, accessibility, and visual-regression matrices.
+**Summary:** This patch completes the browser-testing release by aligning the macOS host probe with the full Chromium binary installed by the addon. Projects using the addon need no configuration change.
 
 ## Fixed
 
-- Remove the redundant outer border around the Textual log and the empty bordered legend row above Problems.
-- Keep browser-testing package and browser installation consistent when individual addon tools are disabled.
+- Launch Playwright with `channel: "chromium"` in the release-host fixture so `--no-shell` installations use full Chromium rather than searching for the intentionally omitted headless-shell executable.
+- Add a contract assertion that prevents the host probe from drifting back to the default headless-shell launch mode.
 
-[v0.32.0]: https://github.com/projectious-work/aibox/compare/v0.31.5...v0.32.0
+[v0.32.1]: https://github.com/projectious-work/aibox/compare/v0.32.0...v0.32.1

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.32.1 | v0.28.6 | makes the browser-testing host gate launch the full Chromium channel installed by Playwright `--no-shell` instead of requesting the omitted headless-shell executable |
 | 0.32.0 | v0.28.6 | adds a pinned Chromium-first Playwright and axe browser-testing addon with optional Firefox/WebKit, live release-host browser evidence, and a cleaner full-width Textual release dashboard |
 | 0.31.5 | v0.28.6 | retries transient OpenCode release downloads and makes Textual yanks selection-aware while preserving actionable failed-task diagnostics |
 | 0.31.4 | v0.28.6 | makes Hugo downloads resilient to transient network failures, improves the release-host Textual problem workflow, and serializes contention-sensitive E2E gates |

--- a/scripts/release_host_gate.py
+++ b/scripts/release_host_gate.py
@@ -949,7 +949,7 @@ def run_addon_group(runner: Runner, profile: Path, env: dict[str, str], candidat
             fixture_script = (
                 'const { chromium } = require("@playwright/test"); '
                 'const AxeBuilder = require("@axe-core/playwright").default; '
-                '(async () => { const browser = await chromium.launch({ headless: true }); '
+                '(async () => { const browser = await chromium.launch({ headless: true, channel: "chromium" }); '
                 'const page = await browser.newPage(); '
                 'await page.setContent("<!doctype html><html lang=\\"en\\"><head><title>Fixture</title></head>'
                 '<body><main><button type=\\"button\\">Ready</button></main></body></html>"); '

--- a/scripts/test-release-host-gate.sh
+++ b/scripts/test-release-host-gate.sh
@@ -166,7 +166,7 @@ assert gate.cache_reuse_enabled("0") is False
 assert gate.cache_reuse_enabled("1") is True
 assert "browser-testing" in gate.ADDON_GROUPS["addon-tools"]
 assert "@axe-core/playwright" in source
-assert 'chromium.launch({ headless: true })' in source
+assert 'chromium.launch({ headless: true, channel: "chromium" })' in source
 assert '"browser_fixture"' in source
 assert gate.parse_ui_mode(None) == "auto"
 assert gate.parse_ui_mode("textual") == "textual"


### PR DESCRIPTION
Fix the v0.32.0 host-gate failure by launching Playwright's full Chromium channel, matching the addon's intentional --no-shell installation. Includes regression coverage and v0.32.1 release metadata.\n\nRefs: BACK-20260813_1609-NimbleOtter