### PR TITLE
chore: release v0.32.1

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.32.0"
+version = "0.32.1"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"


### PR DESCRIPTION
Promotes the validated v0.32.1 release candidate to v0.x-release.