### PR TITLE
fix: accelerate release-host and repair axe probe

### DIFF
--- a/context/decisions/DEC-20260813_1636-TidyLynx-default-release-host-to-safe-cache.md
+++ b/context/decisions/DEC-20260813_1636-TidyLynx-default-release-host-to-safe-cache.md
@@ -1,0 +1,23 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: DecisionRecord
+metadata:
+  id: DEC-20260813_1636-TidyLynx-default-release-host-to-safe-cache
+  created: '2026-08-13T16:36:19+00:00'
+spec:
+  title: Default release-host to safe cache reuse with authenticated retry
+  state: accepted
+  decision: Release-host will reuse safe content-addressed build caches by default,
+    retain fresh runtime and security validation, and support scoped retries only
+    when completed evidence is cryptographically bound to the same immutable candidate
+    and step inputs.
+  context: Repeated macOS Phase 2 release runs rebuild all expensive surfaces after
+    a late failure, even when prior outputs remain valid.
+  rationale: This reduces host duration while preserving immutable candidate provenance
+    and fresh evidence for changed or dependent surfaces.
+  consequences: Introduce an explicit cold-cache mode, persistent isolated caches,
+    step fingerprints and retry validation; unknown impact remains fail-safe.
+  related_workitems:
+  - BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+  decided_at: '2026-08-13T16:36:19+00:00'
+---

--- a/context/logs/2026/08/LOG-20260813_1621-AlertMesa-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1621-AlertMesa-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1621-AlertMesa-workitem-transitioned
+  created: '2026-08-13T16:21:55+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T16:21:55+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0'
+    from 'review' to 'done'
+  subject: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+  subject_kind: WorkItem
+  actor: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+---

--- a/context/logs/2026/08/LOG-20260813_1621-AstuteBeam-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260813_1621-AstuteBeam-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1621-AstuteBeam-workitem-archive-moved
+  created: '2026-08-13T16:21:55+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-13T16:21:55+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0'
+    to /workspace/context/workitems/done/2026/08/BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0.md
+  subject: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+  subject_kind: WorkItem
+  actor: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0.md
+---

--- a/context/logs/2026/08/LOG-20260813_1621-LucidBloom-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1621-LucidBloom-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1621-LucidBloom-workitem-transitioned
+  created: '2026-08-13T16:21:50+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T16:21:50+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0'
+    from 'in-progress' to 'review'
+  subject: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+  subject_kind: WorkItem
+  actor: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
+---

--- a/context/logs/2026/08/LOG-20260813_1636-BoldBloom-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1636-BoldBloom-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1636-BoldBloom-workitem-transitioned
+  created: '2026-08-13T16:36:23+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T16:36:23+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1636-StableArch-optimize-release-host-cache-retry'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+  subject_kind: WorkItem
+  actor: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+---

--- a/context/logs/2026/08/LOG-20260813_1636-FairTower-decision-created.md
+++ b/context/logs/2026/08/LOG-20260813_1636-FairTower-decision-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1636-FairTower-decision-created
+  created: '2026-08-13T16:36:19+00:00'
+spec:
+  event_type: decision.created
+  timestamp: '2026-08-13T16:36:19+00:00'
+  summary: 'Created DecisionRecord ''DEC-20260813_1636-TidyLynx-default-release-host-to-safe-cache'':
+    ''Default release-host to safe cache reuse with authenticated retry'''
+  subject: DEC-20260813_1636-TidyLynx-default-release-host-to-safe-cache
+  subject_kind: DecisionRecord
+  actor: DEC-20260813_1636-TidyLynx-default-release-host-to-safe-cache
+---

--- a/context/logs/2026/08/LOG-20260813_1636-FaithfulPath-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260813_1636-FaithfulPath-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1636-FaithfulPath-workitem-created
+  created: '2026-08-13T16:36:11+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-13T16:36:11+00:00'
+  summary: 'Created WorkItem ''BACK-20260813_1636-StableArch-optimize-release-host-cache-retry'':
+    ''Optimize release-host caching and scoped retries'''
+  subject: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+  subject_kind: WorkItem
+  actor: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+---

--- a/context/logs/2026/08/LOG-20260813_1651-JollyMoon-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1651-JollyMoon-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1651-JollyMoon-workitem-transitioned
+  created: '2026-08-13T16:51:02+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T16:51:02+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1636-StableArch-optimize-release-host-cache-retry'
+    from 'in-progress' to 'review'
+  subject: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+  subject_kind: WorkItem
+  actor: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+---

--- a/context/logs/2026/08/LOG-20260813_1651-RoyalMoss-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1651-RoyalMoss-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1651-RoyalMoss-workitem-transitioned
+  created: '2026-08-13T16:51:02+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T16:51:02+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1636-StableArch-optimize-release-host-cache-retry'
+    from 'review' to 'done'
+  subject: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+  subject_kind: WorkItem
+  actor: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+---

--- a/context/logs/2026/08/LOG-20260813_1651-StrongFjord-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260813_1651-StrongFjord-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1651-StrongFjord-workitem-archive-moved
+  created: '2026-08-13T16:51:02+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-13T16:51:02+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260813_1636-StableArch-optimize-release-host-cache-retry'
+    to /workspace/context/workitems/done/2026/08/BACK-20260813_1636-StableArch-optimize-release-host-cache-retry.md
+  subject: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+  subject_kind: WorkItem
+  actor: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260813_1636-StableArch-optimize-release-host-cache-retry.md
+---

--- a/context/logs/2026/08/LOG-20260813_1728-AmberCrow-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260813_1728-AmberCrow-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1728-AmberCrow-workitem-created
+  created: '2026-08-13T17:28:04+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-13T17:28:04+00:00'
+  summary: 'Created WorkItem ''BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe'':
+    ''Fix axe Playwright explicit context host probe'''
+  subject: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+  subject_kind: WorkItem
+  actor: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+---

--- a/context/logs/2026/08/LOG-20260813_1728-AmberOrchard-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1728-AmberOrchard-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1728-AmberOrchard-workitem-transitioned
+  created: '2026-08-13T17:28:32+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T17:28:32+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe'
+    from 'in-progress' to 'review'
+  subject: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+  subject_kind: WorkItem
+  actor: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+---

--- a/context/logs/2026/08/LOG-20260813_1728-DeepTower-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1728-DeepTower-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1728-DeepTower-workitem-transitioned
+  created: '2026-08-13T17:28:32+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T17:28:32+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe'
+    from 'review' to 'done'
+  subject: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+  subject_kind: WorkItem
+  actor: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+---

--- a/context/logs/2026/08/LOG-20260813_1728-RadiantSage-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260813_1728-RadiantSage-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1728-RadiantSage-workitem-transitioned
+  created: '2026-08-13T17:28:08+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-13T17:28:08+00:00'
+  summary: Transitioned WorkItem 'BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+  subject_kind: WorkItem
+  actor: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+---

--- a/context/logs/2026/08/LOG-20260813_1728-StoutFlame-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260813_1728-StoutFlame-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260813_1728-StoutFlame-workitem-archive-moved
+  created: '2026-08-13T17:28:32+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-13T17:28:32+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe'
+    to /workspace/context/workitems/done/2026/08/BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe.md
+  subject: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+  subject_kind: WorkItem
+  actor: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe.md
+---

--- a/context/workitems/done/2026/08/BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0.md
+++ b/context/workitems/done/2026/08/BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0.md
@@ -4,18 +4,29 @@ kind: WorkItem
 metadata:
   id: BACK-20260813_1454-LucidAtlas-release-aibox-v0-32-0
   created: '2026-08-13T14:54:44+00:00'
-  updated: '2026-08-13T14:54:48+00:00'
+  updated: '2026-08-13T16:21:55+00:00'
 spec:
   title: Release aibox v0.32.0
-  state: in-progress
+  state: done
   type: task
   priority: high
   description: Prepare, validate, publish, and verify the v0.32.0 minor release from
     v0.x-release. Complete repository-side Phase 1 and provide the owner with the
     exact macOS release-host Phase 2 command.
   started_at: '2026-08-13T14:54:48+00:00'
+  completed_at: '2026-08-13T16:21:55+00:00'
 ---
 
 ## Transition note (2026-08-13T14:54:48+00:00)
 
 Owner requested the next v0.x minor release; target resolved to v0.32.0 and release preflight started.
+
+
+## Transition note (2026-08-13T16:21:50+00:00)
+
+v0.32.0 Phase 1 published, but host completion exposed a full-Chromium/headless-shell probe mismatch. The immutable correction was released as v0.32.1.
+
+
+## Transition note (2026-08-13T16:21:55+00:00)
+
+Superseded for host completion by v0.32.1; v0.32.0 remains published and immutable, while the corrected patch release is the supported completion target.

--- a/context/workitems/done/2026/08/BACK-20260813_1636-StableArch-optimize-release-host-cache-retry.md
+++ b/context/workitems/done/2026/08/BACK-20260813_1636-StableArch-optimize-release-host-cache-retry.md
@@ -1,0 +1,32 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260813_1636-StableArch-optimize-release-host-cache-retry
+  created: '2026-08-13T16:36:11+00:00'
+  updated: '2026-08-13T16:51:02+00:00'
+spec:
+  title: Optimize release-host caching and scoped retries
+  state: done
+  type: story
+  priority: high
+  description: Make safe content-addressed cache reuse the default, add persistent
+    isolated compilation/build caches, refine impact selection, and support authenticated
+    step-level retry without weakening fresh release evidence.
+  started_at: '2026-08-13T16:36:23+00:00'
+  completed_at: '2026-08-13T16:51:02+00:00'
+---
+
+## Transition note (2026-08-13T16:36:23+00:00)
+
+Implementation started after confirming the active macOS run consumes separate immutable prepared inputs.
+
+
+## Transition note (2026-08-13T16:51:01+00:00)
+
+Implementation complete; host-gate contracts, maintain release tests, Rust fmt/clippy/unit/E2E, docs build, and pk-doctor all pass.
+
+
+## Transition note (2026-08-13T16:51:02+00:00)
+
+Accepted cache and retry optimization implemented with candidate-bound cache scopes and fresh core/security evidence.

--- a/context/workitems/done/2026/08/BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe.md
+++ b/context/workitems/done/2026/08/BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe.md
@@ -1,0 +1,32 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260813_1728-OpenDeer-fix-axe-playwright-context-host-probe
+  created: '2026-08-13T17:28:04+00:00'
+  updated: '2026-08-13T17:28:32+00:00'
+spec:
+  title: Fix axe Playwright explicit context host probe
+  state: done
+  type: bug
+  priority: critical
+  description: The v0.32.1 macOS addon-tools host gate reaches Chromium but axe-core
+    rejects browser.newPage(); use browser.newContext() and context.newPage(), close
+    the context, validate, and release v0.32.2.
+  started_at: '2026-08-13T17:28:08+00:00'
+  completed_at: '2026-08-13T17:28:32+00:00'
+---
+
+## Transition note (2026-08-13T17:28:08+00:00)
+
+Reproduced from host evidence: axe-core requires an explicit Playwright BrowserContext.
+
+
+## Transition note (2026-08-13T17:28:32+00:00)
+
+Explicit BrowserContext implementation and regression assertions pass host-gate and release-maintenance contracts.
+
+
+## Transition note (2026-08-13T17:28:32+00:00)
+
+Fix complete and ready for v0.32.2 release integration.

--- a/docs-site/content/docs/contributing/e2e-tests.md
+++ b/docs-site/content/docs/contributing/e2e-tests.md
@@ -121,7 +121,8 @@ gate without `--dry-run`; populated `runtime/` and `evidence/` directories are
 intentionally non-resumable.
 
 The entry point accepts that one path plus optional fixed `--dry-run`,
-`--reuse-cache`, and `--ui=auto|textual|plain` flags. It canonicalizes the path,
+`--cold-cache`, `--retry-from=<failed-run-dir>`, and
+`--ui=auto|textual|plain` flags. It canonicalizes the path,
 requires one direct child of the approved root, rejects symlinks, special
 files, hardlinks, unexpected files, unsafe permissions, bad checksums, and
 tag/commit mismatches, then creates `runtime/` and `evidence/` itself.
@@ -137,10 +138,12 @@ managed-Python roots are fixed beneath
 variables cannot affect execution. The resolved uv, Python, Textual, lockfile,
 and tool paths are recorded in evidence.
 
-`--reuse-cache` is intended for repeated rehearsals. It permits
-content-addressed container layer reuse while retaining the complete command,
-runtime, scan, cleanup, and evidence surface. Without it, downstream images
-are rebuilt without cache.
+Content-addressed container layer reuse is the default. `--cold-cache` forces
+downstream image rebuilding for cache investigations. Rust downloads live in a
+dedicated credential-free cache and compiled output is scoped to the candidate
+commit. `--retry-from` accepts only a separate run with byte-identical immutable
+inputs and reuses checksummed successful conditional probes; core lifecycle,
+security scanning, cleanup, and publication evidence are always regenerated.
 
 Candidate compilation, build scripts, CLI execution, and runtime smoke run
 with a fixed sanitized environment and a macOS sandbox that denies access to

--- a/docs-site/content/docs/contributing/maintenance.md
+++ b/docs-site/content/docs/contributing/maintenance.md
@@ -169,15 +169,32 @@ log, End resumes the live tail, and `p` displays the authoritative evidence
 path. The UI is presentation rather than evidence; full output is retained in
 `evidence/command-results.log`.
 
-For a repeated candidate rehearsal, append `--reuse-cache`. This permits the
-container engine to reuse content-addressed build layers but does not skip any
-gate task, runtime probe, security scan, cleanup, or evidence validation. Fresh
-downstream image layers remain the default.
+Content-addressed container layers are reused by default. The Rust registry is
+shared in a dedicated credential-free host-gate cache, while compiled artifacts
+are isolated by candidate commit so a failed candidate can be retried without a
+full two-target rebuild. Use `--cold-cache` only when deliberately investigating
+cache behavior. Cold mode retains downloaded Rust packages but forces downstream
+container layers to rebuild.
+
+To retry after a conditional addon or lifecycle check fails, prepare a new run
+and name the failed run as its checkpoint source:
+
+```bash
+NEW_RUN="$(./scripts/maintain.sh release-host-prepare X.Y.Z)"
+./scripts/maintain.sh release-host \
+  --retry-from=tmp/host-gates/aibox-release/<failed-run-id> "${NEW_RUN}"
+```
+
+The retry source must contain byte-identical immutable candidate inputs.
+Completed conditional checks are reused only when their candidate-bound
+checkpoint checksum is valid. The candidate lifecycle, SBOM, vulnerability
+scan, cleanup, manifest assembly, and publication verification remain fresh.
 
 The reviewed entry point accepts only that run-directory path. It rejects
 traversal, symlinks, special files, hardlinks, unexpected inputs, unsafe
 permissions, checksum drift, and tag/commit mismatches. A previous partial run
-cannot be resumed: `runtime/` and `evidence/` must not exist when it starts.
+is never resumed in place: `runtime/` and `evidence/` must not exist in the new
+run when it starts. Retry imports only validated conditional checkpoints.
 The host checkout's `HEAD` must match the attested candidate commit, but
 unrelated tracked worktree edits do not invalidate the gate because all builds
 and probes use the immutable checksummed source archive rather than worktree

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -82,6 +82,7 @@ ok "Targets ready: ${TARGETS[*]}"
 
 # ── Build ────────────────────────────────────────────────────────────────────
 mkdir -p "${DIST_DIR}"
+TARGET_DIR="${CARGO_TARGET_DIR:-${CLI_DIR}/target}"
 
 build_log_dir="$(mktemp -d "${TMPDIR:-/tmp}/aibox-macos-build.XXXXXX")"
 build_pids=()
@@ -122,7 +123,7 @@ done
 for target in "${TARGETS[@]}"; do
 
   local_name="aibox-${VERSION_TAG}${target}"
-  cp "${CLI_DIR}/target/${target}/release/aibox" "${DIST_DIR}/${local_name}"
+  cp "${TARGET_DIR}/${target}/release/aibox" "${DIST_DIR}/${local_name}"
   tar -czf "${DIST_DIR}/${local_name}.tar.gz" \
     -C "${DIST_DIR}" "${local_name}" \
     -C "${PROJECT_ROOT}" LICENSE

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -144,7 +144,7 @@ ${bold}Release:${reset}
                            Print release step aliases and concrete step names
   release-host-prepare <version>
                            Prepare immutable checksummed host-gate inputs
-  release-host <run-dir> [--dry-run]
+  release-host <run-dir> [--dry-run] [--cold-cache] [--retry-from=<failed-run-dir>]
                            Run macOS validation; --dry-run stops before publication
   release-finalize-runtime <version>
                            Refresh and commit repo-owned generated runtime files
@@ -2620,10 +2620,10 @@ cmd_release_host_prepare() {
 }
 
 cmd_release_host() {
-  if [[ "$#" -ge 1 && "$#" -le 4 ]]; then
+  if [[ "$#" -ge 1 && "$#" -le 5 ]]; then
     "${SCRIPT_DIR}/release-host-gate.sh" "$@"
   else
-    die "Usage: ./scripts/maintain.sh release-host [--dry-run] [--reuse-cache] [--ui=auto|textual|plain] <run-dir>"
+    die "Usage: ./scripts/maintain.sh release-host [--dry-run] [--cold-cache] [--retry-from=<failed-run-dir>] [--ui=auto|textual|plain] <run-dir>"
   fi
 }
 

--- a/scripts/release-host-gate.sh
+++ b/scripts/release-host-gate.sh
@@ -3,14 +3,18 @@
 set -euo pipefail
 
 DRY_RUN=0
-REUSE_CACHE=0
+REUSE_CACHE=1
 UI_MODE=auto
 UI_SEEN=0
+RETRY_FROM=""
+CACHE_MODE_SEEN=0
 RUN_DIR=""
 for ARGUMENT in "$@"; do
   case "${ARGUMENT}" in
     --dry-run) [[ "${DRY_RUN}" == 0 ]] || { echo "Duplicate --dry-run" >&2; exit 2; }; DRY_RUN=1 ;;
-    --reuse-cache) [[ "${REUSE_CACHE}" == 0 ]] || { echo "Duplicate --reuse-cache" >&2; exit 2; }; REUSE_CACHE=1 ;;
+    --reuse-cache) [[ "${CACHE_MODE_SEEN}" == 0 ]] || { echo "Duplicate cache mode" >&2; exit 2; }; REUSE_CACHE=1; CACHE_MODE_SEEN=1 ;;
+    --cold-cache) [[ "${CACHE_MODE_SEEN}" == 0 ]] || { echo "Duplicate cache mode" >&2; exit 2; }; REUSE_CACHE=0; CACHE_MODE_SEEN=1 ;;
+    --retry-from=*) [[ -z "${RETRY_FROM}" ]] || { echo "Duplicate retry source" >&2; exit 2; }; RETRY_FROM="${ARGUMENT#--retry-from=}" ;;
     --ui=auto|--ui=textual|--ui=plain) [[ "${UI_SEEN}" == 0 ]] || { echo "Duplicate --ui" >&2; exit 2; }; UI_MODE="${ARGUMENT#--ui=}"; UI_SEEN=1 ;;
     --*) echo "Unknown release-host option: ${ARGUMENT}" >&2; exit 2 ;;
     *) [[ -z "${RUN_DIR}" ]] || { echo "Only one release-host run directory is accepted" >&2; exit 2; }; RUN_DIR="${ARGUMENT}" ;;
@@ -18,7 +22,7 @@ for ARGUMENT in "$@"; do
 done
 
 if [[ -z "${RUN_DIR:-}" ]]; then
-  echo "Usage: ./scripts/release-host-gate.sh [--dry-run] [--reuse-cache] [--ui=auto|textual|plain] tmp/host-gates/aibox-release/<run-id>" >&2
+  echo "Usage: ./scripts/release-host-gate.sh [--dry-run] [--cold-cache] [--retry-from=<failed-run-dir>] [--ui=auto|textual|plain] tmp/host-gates/aibox-release/<run-id>" >&2
   exit 2
 fi
 
@@ -60,6 +64,7 @@ exec /usr/bin/env -i \
   UV_NO_CONFIG=1 UV_PYTHON_DOWNLOADS=automatic AIBOX_HOST_GATE_UV_BIN="${UV_BIN}" \
   TERM="${TERM:-dumb}" COLORTERM="${COLORTERM:-}" \
   AIBOX_RELEASE_HOST_DRY_RUN="${DRY_RUN}" AIBOX_RELEASE_HOST_REUSE_CACHE="${REUSE_CACHE}" \
+  AIBOX_RELEASE_HOST_RETRY_FROM="${RETRY_FROM}" \
   AIBOX_RELEASE_HOST_UI="${UI_MODE}" \
   "${UV_BIN}" run --no-project --python 3.14.6 \
   --with-requirements "${SCRIPT_DIR}/release-host-ui.lock" -- \

--- a/scripts/release_host_gate.py
+++ b/scripts/release_host_gate.py
@@ -651,6 +651,46 @@ def sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def seal_checkpoint(path: Path) -> None:
+    """Bind a completed conditional check to its exact evidence bytes."""
+    path.with_suffix(path.suffix + ".sha256").write_text(
+        f"{sha256(path)}  {path.name}\n", encoding="utf-8"
+    )
+
+
+def reuse_checkpoint(retry_evidence: Path, evidence: Path, check: str) -> Path | None:
+    """Copy a valid completed conditional check from a candidate-identical run."""
+    marker = retry_evidence / "container-e2e" / f"{check}.json"
+    checksum = marker.with_suffix(marker.suffix + ".sha256")
+    if (not marker.is_file() or marker.is_symlink() or
+            not checksum.is_file() or checksum.is_symlink()):
+        return None
+    fields = checksum.read_text(encoding="utf-8").strip().split(maxsplit=1)
+    if len(fields) != 2 or fields[0] != sha256(marker) or fields[1].lstrip("*") != marker.name:
+        return None
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    if payload.get("status") != "passed":
+        return None
+    if check in ADDON_GROUPS:
+        expected = {"status": "passed", "addons": ADDON_GROUPS[check]}
+        if check == "addon-tools":
+            expected["browser_fixture"] = {"title": "Fixture", "violations": 0}
+        if payload != expected:
+            return None
+    elif check == "latex-lifecycle":
+        if payload.get("revisions") != 2 or not isinstance(payload.get("preview_port"), int):
+            return None
+    elif check == "rootless-podman":
+        if payload.get("rootless_readiness") is not True:
+            return None
+    else:
+        return None
+    destination = evidence / "container-e2e" / marker.name
+    shutil.copy2(marker, destination)
+    shutil.copy2(checksum, destination.with_suffix(destination.suffix + ".sha256"))
+    return destination
+
+
 def validate_regular(path: Path) -> None:
     """Require an immutable, regular, single-link input file."""
     info = path.lstat()
@@ -967,6 +1007,7 @@ def run_addon_group(runner: Runner, profile: Path, env: dict[str, str], candidat
         if browser_fixture is not None:
             payload["browser_fixture"] = browser_fixture
         marker.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        seal_checkpoint(marker)
         return marker
     finally:
         if compose_file.exists():
@@ -1068,6 +1109,7 @@ def run_latex_lifecycle(runner: Runner, profile: Path, env: dict[str, str], cand
         result = evidence / "container-e2e/latex-lifecycle.json"
         result.write_text(json.dumps({"status": "passed", "revisions": 2, "preview_port": port},
                                      indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        seal_checkpoint(result)
         return result
     finally:
         if compose_file.exists():
@@ -1119,6 +1161,7 @@ def run_rootless_podman(runner: Runner, profile: Path, env: dict[str, str], cand
             "execution_boundary": "outer runtime user-namespace privileges were not widened",
             "subuid": subuid.strip(), "subgid": subgid.strip(), "containers_conf": config.strip(),
         }, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        seal_checkpoint(result)
         return result
     finally:
         if compose_file.exists():
@@ -1164,6 +1207,23 @@ def run_gate(renderer: object | None = None) -> None:
     for name, expected in checksums.items():
         if sha256(input_dir / name) != expected:
             fail(f"checksum mismatch: {name}")
+
+    retry_evidence: Path | None = None
+    retry_argument = os.environ.get("AIBOX_RELEASE_HOST_RETRY_FROM", "")
+    if retry_argument:
+        retry_run = resolve_run_dir(retry_argument, project_root)
+        if retry_run == run_dir:
+            fail("retry source must be a different prepared run")
+        retry_input = retry_run / "input"
+        retry_evidence_candidate = retry_run / "evidence"
+        if not retry_input.is_dir() or not retry_evidence_candidate.is_dir():
+            fail("retry source has no input/evidence trees")
+        for name in ("checksums.sha256", "provenance.json", "source.tar.gz"):
+            retry_item = retry_input / name
+            if (not retry_item.is_file() or retry_item.is_symlink() or
+                    sha256(retry_item) != sha256(input_dir / name)):
+                fail(f"retry source candidate differs: {name}")
+        retry_evidence = retry_evidence_candidate
 
     # Phase 2: bind the archive and changed-path selection to real Git objects.
     provenance = json.loads((input_dir / "provenance.json").read_text(encoding="utf-8"))
@@ -1247,20 +1307,25 @@ def run_gate(renderer: object | None = None) -> None:
 
     # Phase 4: isolate mutable tool state and deny candidate access to owner
     # credentials, Keychain services, Git metadata, and immutable inputs.
+    original_home = Path.home()
     home = runtime / "home"
     docker_config = runtime / "docker-config"
-    cargo_home = runtime / "cargo-home"
+    cache_root = original_home / "Library/Caches/aibox-host-gates"
+    cargo_home = cache_root / "cargo-home"
+    cargo_target_dir = cache_root / "cargo-target" / provenance["commit"]
     home.mkdir(mode=0o700)
     docker_config.mkdir(mode=0o700)
-    cargo_home.mkdir(mode=0o700)
-    original_home = Path.home()
+    cache_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    cargo_home.mkdir(mode=0o700, exist_ok=True)
+    cargo_target_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     docker_cli_plugin_sources = stage_docker_cli_plugins(original_home, docker_config)
     fixed_env = {
         "PATH": f"{original_home}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
         "HOME": str(home), "TMPDIR": str(runtime / "tmp"),
         "DOCKER_CONFIG": str(docker_config), "GH_CONFIG_DIR": str(runtime / "gh-config"),
         "DOCKER_BUILDKIT": "1", "COMPOSE_DOCKER_CLI_BUILD": "1",
-        "CARGO_HOME": str(cargo_home), "RUSTUP_HOME": str(original_home / ".rustup"),
+        "CARGO_HOME": str(cargo_home), "CARGO_TARGET_DIR": str(cargo_target_dir),
+        "RUSTUP_HOME": str(original_home / ".rustup"),
         "CARGO_NET_OFFLINE": "true", "RUST_BACKTRACE": "1",
         "AIBOX_RELEASE_HOST_OFFLINE": "1",
         "AIBOX_RELEASE_HOST_REUSE_CACHE": "1" if reuse_cache else "0",
@@ -1320,11 +1385,15 @@ def run_gate(renderer: object | None = None) -> None:
         "ui_dependencies": locked_ui_dependencies(script_dir / "release-host-ui.lock"),
         "uv_cache_dir": os.environ["UV_CACHE_DIR"],
         "uv_python_install_dir": os.environ["UV_PYTHON_INSTALL_DIR"],
-        "cargo_home": fixed_env["CARGO_HOME"], "rustup_home": fixed_env["RUSTUP_HOME"],
+        "cargo_home": fixed_env["CARGO_HOME"],
+        "cargo_target_dir": fixed_env["CARGO_TARGET_DIR"],
+        "cargo_cache_scope": provenance["commit"],
+        "rustup_home": fixed_env["RUSTUP_HOME"],
         "home": fixed_env["HOME"], "docker_config": fixed_env["DOCKER_CONFIG"],
         "docker_buildkit": fixed_env["DOCKER_BUILDKIT"],
         "container_runtime": container_runtime,
         "container_cache_policy": "reuse content-addressed layers" if reuse_cache else "force downstream rebuilds",
+        "retry_evidence": str(retry_evidence) if retry_evidence else None,
         "docker_cli_plugin_sources": docker_cli_plugin_sources,
         "gh_config_dir": fixed_env["GH_CONFIG_DIR"],
     }, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -1350,7 +1419,7 @@ def run_gate(renderer: object | None = None) -> None:
 
     machine = subprocess.run(["/usr/bin/uname", "-m"], check=True, capture_output=True, text=True).stdout.strip()
     target = "aarch64-apple-darwin" if machine == "arm64" else "x86_64-apple-darwin"
-    candidate_bin = source_root / f"cli/target/{target}/release/aibox"
+    candidate_bin = cargo_target_dir / f"{target}/release/aibox"
     runner.run(sandboxed(profile, [str(candidate_bin), "--version"], fixed_env), cwd=source_root,
                label="Smoke native Darwin binary")
     (evidence / "darwin-smoke/complete.json").write_text(
@@ -1455,6 +1524,11 @@ def run_gate(renderer: object | None = None) -> None:
     conditional_evidence: list[Path] = []
     for group in ADDON_GROUPS:
         if group in selected_checks:
+            reused = reuse_checkpoint(retry_evidence, evidence, group) if retry_evidence else None
+            if reused:
+                conditional_evidence.append(reused)
+                runner._step("passed", f"{group} (reused candidate-bound checkpoint)", 0.0)
+                continue
             started = time.monotonic()
             runner._step("running", group, 0.0)
             runner.output_task = group
@@ -1469,34 +1543,44 @@ def run_gate(renderer: object | None = None) -> None:
                 runner.output_task = None
             runner._step("passed", group, time.monotonic() - started)
     if "latex-lifecycle" in selected_checks:
-        preview_port = 18000 + int(provenance["commit"][:8], 16) % 1000
-        started = time.monotonic()
-        runner._step("running", "latex-lifecycle", 0.0)
-        runner.output_task = "latex-lifecycle"
-        try:
-            conditional_evidence.append(run_latex_lifecycle(
-                runner, profile, fixed_env, candidate_bin, container_runtime,
-                runtime, evidence, version, preview_port))
-        except BaseException:
-            runner._step("failed", "latex-lifecycle", time.monotonic() - started)
-            raise
-        finally:
-            runner.output_task = None
-        runner._step("passed", "latex-lifecycle", time.monotonic() - started)
+        reused = reuse_checkpoint(retry_evidence, evidence, "latex-lifecycle") if retry_evidence else None
+        if reused:
+            conditional_evidence.append(reused)
+            runner._step("passed", "latex-lifecycle (reused candidate-bound checkpoint)", 0.0)
+        else:
+            preview_port = 18000 + int(provenance["commit"][:8], 16) % 1000
+            started = time.monotonic()
+            runner._step("running", "latex-lifecycle", 0.0)
+            runner.output_task = "latex-lifecycle"
+            try:
+                conditional_evidence.append(run_latex_lifecycle(
+                    runner, profile, fixed_env, candidate_bin, container_runtime,
+                    runtime, evidence, version, preview_port))
+            except BaseException:
+                runner._step("failed", "latex-lifecycle", time.monotonic() - started)
+                raise
+            finally:
+                runner.output_task = None
+            runner._step("passed", "latex-lifecycle", time.monotonic() - started)
     if "rootless-podman" in selected_checks:
-        started = time.monotonic()
-        runner._step("running", "rootless-podman", 0.0)
-        runner.output_task = "rootless-podman"
-        try:
-            conditional_evidence.append(run_rootless_podman(
-                runner, profile, fixed_env, candidate_bin, container_runtime,
-                runtime, evidence, version))
-        except BaseException:
-            runner._step("failed", "rootless-podman", time.monotonic() - started)
-            raise
-        finally:
-            runner.output_task = None
-        runner._step("passed", "rootless-podman", time.monotonic() - started)
+        reused = reuse_checkpoint(retry_evidence, evidence, "rootless-podman") if retry_evidence else None
+        if reused:
+            conditional_evidence.append(reused)
+            runner._step("passed", "rootless-podman (reused candidate-bound checkpoint)", 0.0)
+        else:
+            started = time.monotonic()
+            runner._step("running", "rootless-podman", 0.0)
+            runner.output_task = "rootless-podman"
+            try:
+                conditional_evidence.append(run_rootless_podman(
+                    runner, profile, fixed_env, candidate_bin, container_runtime,
+                    runtime, evidence, version))
+            except BaseException:
+                runner._step("failed", "rootless-podman", time.monotonic() - started)
+                raise
+            finally:
+                runner.output_task = None
+            runner._step("passed", "rootless-podman", time.monotonic() - started)
 
     # Phase 8: assemble a fixed, checksummed manifest. When publication is
     # enabled it receives no arbitrary artifact list; dry-run stops after the

--- a/scripts/release_host_gate.py
+++ b/scripts/release_host_gate.py
@@ -990,12 +990,14 @@ def run_addon_group(runner: Runner, profile: Path, env: dict[str, str], candidat
                 'const { chromium } = require("@playwright/test"); '
                 'const AxeBuilder = require("@axe-core/playwright").default; '
                 '(async () => { const browser = await chromium.launch({ headless: true, channel: "chromium" }); '
-                'const page = await browser.newPage(); '
+                'const context = await browser.newContext(); '
+                'const page = await context.newPage(); '
                 'await page.setContent("<!doctype html><html lang=\\"en\\"><head><title>Fixture</title></head>'
                 '<body><main><button type=\\"button\\">Ready</button></main></body></html>"); '
                 'const results = await new AxeBuilder({ page }).analyze(); '
                 'console.log(JSON.stringify({ title: await page.title(), violations: results.violations.length })); '
-                'await browser.close(); })().catch(error => { console.error(error); process.exit(1); });'
+                'await context.close(); await browser.close(); '
+                '})().catch(error => { console.error(error); process.exit(1); });'
             )
             output = runner.capture([container_runtime, "exec", "--user", "aibox", name,
                                      "node", "-e", fixture_script])

--- a/scripts/test-maintain-release.sh
+++ b/scripts/test-maintain-release.sh
@@ -12,7 +12,7 @@ AIBOX_MAINTAIN_SOURCE_ONLY=1 source "${SCRIPT_DIR}/maintain.sh"
   || die "v1 prereleases must resolve to v1.x-pre-release"
 [[ "$(release_branch_for_version 1.0.0)" == "v1.x-release" ]] \
   || die "v1 release versions must resolve to v1.x-release"
-declare -f cmd_release_host | grep -Fq 'release-host [--dry-run] [--reuse-cache] [--ui=auto|textual|plain] <run-dir>' \
+declare -f cmd_release_host | grep -Fq 'release-host [--dry-run] [--cold-cache] [--retry-from=<failed-run-dir>] [--ui=auto|textual|plain] <run-dir>' \
   || die "release-host must accept a prepared run directory and fixed presentation/cache options"
 grep -Fq 'X.Y.Z or X.Y.Z-prerelease' "${SCRIPT_DIR}/build-macos.sh" \
   || die "macOS artifact builds must accept prerelease SemVer"

--- a/scripts/test-release-host-gate.sh
+++ b/scripts/test-release-host-gate.sh
@@ -185,6 +185,10 @@ with tempfile.TemporaryDirectory() as temporary:
 assert "browser-testing" in gate.ADDON_GROUPS["addon-tools"]
 assert "@axe-core/playwright" in source
 assert 'chromium.launch({ headless: true, channel: "chromium" })' in source
+assert 'const context = await browser.newContext()' in source
+assert 'const page = await context.newPage()' in source
+assert 'await context.close(); await browser.close()' in source
+assert 'browser.newPage()' not in source
 assert '"browser_fixture"' in source
 assert gate.parse_ui_mode(None) == "auto"
 assert gate.parse_ui_mode("textual") == "textual"

--- a/scripts/test-release-host-gate.sh
+++ b/scripts/test-release-host-gate.sh
@@ -147,6 +147,8 @@ assert set(gate.TRUSTED_CONTROL_PATHS) == {
 }
 source = (script_dir / "release_host_gate.py").read_text()
 assert '"CARGO_HOME": str(cargo_home)' in source
+assert '"CARGO_TARGET_DIR": str(cargo_target_dir)' in source
+assert '"cargo_cache_scope": provenance["commit"]' in source
 assert '"cargo", "fetch", "--locked"' in source
 assert 'fetch_env = {**fixed_env, "CARGO_NET_OFFLINE": "false"}' in source
 assert '"DOCKER_BUILDKIT": "1"' in source
@@ -164,6 +166,22 @@ assert gate.dry_run_enabled("1") is True
 assert gate.cache_reuse_enabled(None) is False
 assert gate.cache_reuse_enabled("0") is False
 assert gate.cache_reuse_enabled("1") is True
+with tempfile.TemporaryDirectory() as temporary:
+    root = Path(temporary)
+    old_evidence = root / "old" / "container-e2e"
+    new_evidence = root / "new"
+    old_evidence.mkdir(parents=True)
+    (new_evidence / "container-e2e").mkdir(parents=True)
+    marker = old_evidence / "addon-tools.json"
+    marker.write_text(__import__("json").dumps({
+        "status": "passed", "addons": gate.ADDON_GROUPS["addon-tools"],
+        "browser_fixture": {"title": "Fixture", "violations": 0},
+    }) + "\n")
+    gate.seal_checkpoint(marker)
+    reused = gate.reuse_checkpoint(root / "old", new_evidence, "addon-tools")
+    assert reused and reused.read_text() == marker.read_text()
+    marker.write_text('{"status":"failed"}\n')
+    assert gate.reuse_checkpoint(root / "old", new_evidence, "addon-tools") is None
 assert "browser-testing" in gate.ADDON_GROUPS["addon-tools"]
 assert "@axe-core/playwright" in source
 assert 'chromium.launch({ headless: true, channel: "chromium" })' in source


### PR DESCRIPTION
## Summary
- reuse safe host build caches by default and add candidate-bound conditional retries
- persist isolated Cargo caches for macOS release builds
- create an explicit Playwright BrowserContext for axe-core host validation

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test -- --test-threads=1
- scripts/test-release-host-gate.sh
- scripts/test-maintain-release.sh
- pk-doctor: 0 errors, 0 warnings, 0 actionable