### PR TITLE
chore: prepare v0.32.2 release metadata

### DIFF
--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -693,6 +693,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.6",
         note: "Patch release: makes the browser-testing host gate launch the full Chromium channel installed by Playwright --no-shell instead of requesting the omitted headless-shell executable.",
     },
+    CompatEntry {
+        aibox_version: "0.32.2",
+        processkit_version: "v0.28.6",
+        note: "Patch release: uses an explicit Playwright BrowserContext for axe host validation and makes safe release-host caches and candidate-bound retries available by default.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/dist/RELEASE-NOTES.md
+++ b/dist/RELEASE-NOTES.md
@@ -1,10 +1,16 @@
-# aibox v0.32.1 — 2026-08-13
+# aibox v0.32.2 — 2026-08-13
 
-**Summary:** This patch completes the browser-testing release by aligning the macOS host probe with the full Chromium binary installed by the addon. Projects using the addon need no configuration change.
+**Summary:** This patch completes the browser-testing host probe and substantially shortens future macOS release retries through safe, candidate-bound caching.
 
 ## Fixed
 
-- Launch Playwright with `channel: "chromium"` in the release-host fixture so `--no-shell` installations use full Chromium rather than searching for the intentionally omitted headless-shell executable.
-- Add a contract assertion that prevents the host probe from drifting back to the default headless-shell launch mode.
+- Create an explicit Playwright `BrowserContext` before running axe-core, matching axe's supported integration contract.
+- Preserve full-Chromium channel selection for the addon installed with Playwright `--no-shell`.
 
-[v0.32.1]: https://github.com/projectious-work/aibox/compare/v0.32.0...v0.32.1
+## Changed
+
+- Reuse content-addressed container layers by default; `--cold-cache` remains available for deliberate clean rebuilds.
+- Persist credential-free Cargo downloads and scope compiled macOS targets to the immutable candidate commit.
+- Add `--retry-from=<failed-run-dir>` for checksummed reuse of successful conditional host probes from byte-identical candidate inputs, while lifecycle and security evidence remain fresh.
+
+[v0.32.2]: https://github.com/projectious-work/aibox/compare/v0.32.1...v0.32.2

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.32.2 | v0.28.6 | uses an explicit Playwright BrowserContext for axe host validation and makes safe release-host caches and candidate-bound retries available by default |
 | 0.32.1 | v0.28.6 | makes the browser-testing host gate launch the full Chromium channel installed by Playwright `--no-shell` instead of requesting the omitted headless-shell executable |
 | 0.32.0 | v0.28.6 | adds a pinned Chromium-first Playwright and axe browser-testing addon with optional Firefox/WebKit, live release-host browser evidence, and a cleaner full-width Textual release dashboard |
 | 0.31.5 | v0.28.6 | retries transient OpenCode release downloads and makes Textual yanks selection-aware while preserving actionable failed-task diagnostics |


### PR DESCRIPTION
Adds the v0.32.2 compatibility entry and release notes for the axe BrowserContext fix and release-host cache/retry improvements.