### PR TITLE
fix: make axe release-host fixture accessibility-clean

### DIFF
--- a/context/logs/2026/08/LOG-20260814_0910-SparklingVale-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260814_0910-SparklingVale-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_0910-SparklingVale-workitem-created
+  created: '2026-08-14T09:10:30+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-14T09:10:30+00:00'
+  summary: 'Created WorkItem ''BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics'':
+    ''Make release-host axe fixture accessibility-clean'''
+  subject: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+  subject_kind: WorkItem
+  actor: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+---

--- a/context/logs/2026/08/LOG-20260814_0910-SunnySun-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260814_0910-SunnySun-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_0910-SunnySun-workitem-transitioned
+  created: '2026-08-14T09:10:37+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-14T09:10:37+00:00'
+  summary: Transitioned WorkItem 'BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+  subject_kind: WorkItem
+  actor: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+---

--- a/context/logs/2026/08/LOG-20260814_1001-CordialOasis-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260814_1001-CordialOasis-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1001-CordialOasis-workitem-archive-moved
+  created: '2026-08-14T10:01:09+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-14T10:01:09+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics'
+    to /workspace/context/workitems/done/2026/08/BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics.md
+  subject: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+  subject_kind: WorkItem
+  actor: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics.md
+---

--- a/context/logs/2026/08/LOG-20260814_1001-DaringLantern-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260814_1001-DaringLantern-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1001-DaringLantern-workitem-transitioned
+  created: '2026-08-14T10:01:09+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-14T10:01:09+00:00'
+  summary: Transitioned WorkItem 'BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics'
+    from 'in-progress' to 'review'
+  subject: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+  subject_kind: WorkItem
+  actor: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+---

--- a/context/logs/2026/08/LOG-20260814_1001-MindfulTulip-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260814_1001-MindfulTulip-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1001-MindfulTulip-workitem-transitioned
+  created: '2026-08-14T10:01:09+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-14T10:01:09+00:00'
+  summary: Transitioned WorkItem 'BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics'
+    from 'review' to 'done'
+  subject: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+  subject_kind: WorkItem
+  actor: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+---

--- a/context/workitems/done/2026/08/BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics.md
+++ b/context/workitems/done/2026/08/BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics.md
@@ -1,0 +1,32 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260814_0910-FluentHeron-fix-axe-fixture-heading-diagnostics
+  created: '2026-08-14T09:10:30+00:00'
+  updated: '2026-08-14T10:01:09+00:00'
+spec:
+  title: Make release-host axe fixture accessibility-clean
+  state: done
+  type: bug
+  priority: critical
+  description: The v0.32.2 addon-tools host probe reports one axe violation because
+    its minimal page lacks an h1. Add a semantic heading and retain violation IDs/help/node
+    summaries in evidence before enforcing zero violations.
+  started_at: '2026-08-14T09:10:37+00:00'
+  completed_at: '2026-08-14T10:01:09+00:00'
+---
+
+## Transition note (2026-08-14T09:10:37+00:00)
+
+Official axe rule documentation confirms the missing level-one heading best-practice violation; implementing semantic fixture and diagnostic evidence.
+
+
+## Transition note (2026-08-14T10:01:09+00:00)
+
+Repository contracts pass and the exact corrected fixture returned [] under the macOS release-host Chromium image.
+
+
+## Transition note (2026-08-14T10:01:09+00:00)
+
+Host-confirmed zero-violation fixture and durable violation detail evidence are complete for v0.32.3.

--- a/scripts/release_host_gate.py
+++ b/scripts/release_host_gate.py
@@ -674,7 +674,9 @@ def reuse_checkpoint(retry_evidence: Path, evidence: Path, check: str) -> Path |
     if check in ADDON_GROUPS:
         expected = {"status": "passed", "addons": ADDON_GROUPS[check]}
         if check == "addon-tools":
-            expected["browser_fixture"] = {"title": "Fixture", "violations": 0}
+            expected["browser_fixture"] = {
+                "title": "Fixture", "violations": 0, "violation_details": [],
+            }
         if payload != expected:
             return None
     elif check == "latex-lifecycle":
@@ -992,17 +994,24 @@ def run_addon_group(runner: Runner, profile: Path, env: dict[str, str], candidat
                 '(async () => { const browser = await chromium.launch({ headless: true, channel: "chromium" }); '
                 'const context = await browser.newContext(); '
                 'const page = await context.newPage(); '
-                'await page.setContent("<!doctype html><html lang=\\"en\\"><head><title>Fixture</title></head>'
-                '<body><main><button type=\\"button\\">Ready</button></main></body></html>"); '
+                'await page.setContent("<!doctype html><html lang=\\"en\\"><head><meta charset=\\"utf-8\\">'
+                '<title>Fixture</title></head><body><main><h1>Fixture</h1>'
+                '<button type=\\"button\\">Ready</button></main></body></html>"); '
                 'const results = await new AxeBuilder({ page }).analyze(); '
-                'console.log(JSON.stringify({ title: await page.title(), violations: results.violations.length })); '
+                'const violation_details = results.violations.map(violation => ({ '
+                'id: violation.id, impact: violation.impact, help: violation.help, '
+                'helpUrl: violation.helpUrl, nodes: violation.nodes.map(node => ({ '
+                'target: node.target, html: node.html, failureSummary: node.failureSummary })) })); '
+                'console.log(JSON.stringify({ title: await page.title(), '
+                'violations: violation_details.length, violation_details })); '
                 'await context.close(); await browser.close(); '
                 '})().catch(error => { console.error(error); process.exit(1); });'
             )
             output = runner.capture([container_runtime, "exec", "--user", "aibox", name,
                                      "node", "-e", fixture_script])
             browser_fixture = json.loads(output.strip().splitlines()[-1])
-            if browser_fixture != {"title": "Fixture", "violations": 0}:
+            if browser_fixture != {
+                    "title": "Fixture", "violations": 0, "violation_details": []}:
                 fail(f"browser-testing fixture returned unexpected evidence: {browser_fixture}")
         marker = evidence / "container-e2e" / f"{group}.json"
         payload = {"status": "passed", "addons": ADDON_GROUPS[group]}

--- a/scripts/test-release-host-gate.sh
+++ b/scripts/test-release-host-gate.sh
@@ -175,7 +175,9 @@ with tempfile.TemporaryDirectory() as temporary:
     marker = old_evidence / "addon-tools.json"
     marker.write_text(__import__("json").dumps({
         "status": "passed", "addons": gate.ADDON_GROUPS["addon-tools"],
-        "browser_fixture": {"title": "Fixture", "violations": 0},
+        "browser_fixture": {
+            "title": "Fixture", "violations": 0, "violation_details": [],
+        },
     }) + "\n")
     gate.seal_checkpoint(marker)
     reused = gate.reuse_checkpoint(root / "old", new_evidence, "addon-tools")
@@ -189,6 +191,9 @@ assert 'const context = await browser.newContext()' in source
 assert 'const page = await context.newPage()' in source
 assert 'await context.close(); await browser.close()' in source
 assert 'browser.newPage()' not in source
+assert '<main><h1>Fixture</h1>' in source
+assert 'violation_details = results.violations.map' in source
+assert 'failureSummary: node.failureSummary' in source
 assert '"browser_fixture"' in source
 assert gate.parse_ui_mode(None) == "auto"
 assert gate.parse_ui_mode("textual") == "textual"


### PR DESCRIPTION
## Summary
- add the missing level-one heading to the axe fixture
- retain violation IDs, help URLs, affected HTML, and failure summaries
- update candidate-bound checkpoint validation

## Evidence
- exact fixture returned an empty violation array on the macOS release-host Chromium image
- release-host contract and Textual headless tests pass