### PR TITLE
chore: prepare v0.32.3 release metadata

### DIFF
--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -698,6 +698,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.6",
         note: "Patch release: uses an explicit Playwright BrowserContext for axe host validation and makes safe release-host caches and candidate-bound retries available by default.",
     },
+    CompatEntry {
+        aibox_version: "0.32.3",
+        processkit_version: "v0.28.6",
+        note: "Patch release: makes the axe host fixture accessibility-clean and records structured violation diagnostics when a future browser probe fails.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/dist/RELEASE-NOTES.md
+++ b/dist/RELEASE-NOTES.md
@@ -1,16 +1,14 @@
-# aibox v0.32.2 — 2026-08-13
+# aibox v0.32.3 — 2026-08-14
 
-**Summary:** This patch completes the browser-testing host probe and substantially shortens future macOS release retries through safe, candidate-bound caching.
+**Summary:** This patch makes the release-host browser fixture accessibility-clean, verified against the actual macOS Chromium host image.
 
 ## Fixed
 
-- Create an explicit Playwright `BrowserContext` before running axe-core, matching axe's supported integration contract.
-- Preserve full-Chromium channel selection for the addon installed with Playwright `--no-shell`.
+- Add the missing level-one heading required by axe's page-level best-practice rules; the corrected fixture returns zero violations on the macOS release host.
+- Preserve structured violation IDs, help URLs, affected HTML, and failure summaries in host evidence if the fixture regresses.
 
 ## Changed
 
-- Reuse content-addressed container layers by default; `--cold-cache` remains available for deliberate clean rebuilds.
-- Persist credential-free Cargo downloads and scope compiled macOS targets to the immutable candidate commit.
-- Add `--retry-from=<failed-run-dir>` for checksummed reuse of successful conditional host probes from byte-identical candidate inputs, while lifecycle and security evidence remain fresh.
+- Keep the explicit Playwright `BrowserContext`, full Chromium channel, default cache reuse, and candidate-bound retry support introduced in v0.32.2.
 
-[v0.32.2]: https://github.com/projectious-work/aibox/compare/v0.32.1...v0.32.2
+[v0.32.3]: https://github.com/projectious-work/aibox/compare/v0.32.2...v0.32.3

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.32.3 | v0.28.6 | makes the axe host fixture accessibility-clean and records structured violation diagnostics when a future browser probe fails |
 | 0.32.2 | v0.28.6 | uses an explicit Playwright BrowserContext for axe host validation and makes safe release-host caches and candidate-bound retries available by default |
 | 0.32.1 | v0.28.6 | makes the browser-testing host gate launch the full Chromium channel installed by Playwright `--no-shell` instead of requesting the omitted headless-shell executable |
 | 0.32.0 | v0.28.6 | adds a pinned Chromium-first Playwright and axe browser-testing addon with optional Firefox/WebKit, live release-host browser evidence, and a cleaner full-width Textual release dashboard |


### PR DESCRIPTION
Adds v0.32.3 compatibility and release notes for the host-confirmed accessibility-clean axe fixture.