### PR TITLE
fix: keep latest image within release line

### DIFF
--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -14,6 +14,7 @@
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -404,6 +405,40 @@ pub fn init_from_dir(dir: &Path) -> Result<()> {
 /// Get all loaded addons.
 pub fn all_addons() -> &'static [LoadedAddon] {
     ADDONS.get().map(|v| v.as_slice()).unwrap_or(&[])
+}
+
+/// Stable fingerprint of the loaded addon option catalog.
+///
+/// Generated `aibox.toml` files record this value so a newly shipped addon or
+/// tool causes the comment catalog to be refreshed even when the config schema
+/// itself did not change.
+pub fn catalog_fingerprint() -> String {
+    let mut addons: Vec<_> = all_addons().iter().collect();
+    addons.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut hasher = Sha256::new();
+    hasher.update(ADDON_CATALOG_SCHEMA_VERSION.as_bytes());
+    for addon in addons {
+        hasher.update([0]);
+        hasher.update(addon.name.as_bytes());
+        hasher.update([0]);
+        hasher.update(addon.addon_version.as_bytes());
+        for tool in &addon.tools {
+            hasher.update([0]);
+            hasher.update(tool.name.as_bytes());
+            hasher.update([tool.default_enabled as u8]);
+            hasher.update(tool.default_version.as_bytes());
+            for version in &tool.supported_versions {
+                hasher.update([0]);
+                hasher.update(version.as_bytes());
+            }
+        }
+    }
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
 }
 
 /// Find an addon by name.

--- a/cli/src/container.rs
+++ b/cli/src/container.rs
@@ -1545,6 +1545,10 @@ pub(crate) fn serialize_config_with_comments(config: &AiboxConfig) -> String {
     out.push_str(
         "# Addon catalog — uncomment/comment one block header to enable or remove an addon.\n",
     );
+    out.push_str(&format!(
+        "# Addon catalog fingerprint: {}\n",
+        crate::addon_loader::catalog_fingerprint()
+    ));
     out.push_str(
         "# Inside an enabled addon, omitted default-enabled tools stay enabled. Uncomment\n",
     );
@@ -4421,6 +4425,10 @@ mod tests {
         let config = crate::config::test_config();
         let body = serialize_config_with_comments(&config);
 
+        assert!(body.contains("# Addon catalog fingerprint: "));
+        assert!(body.contains("# [addons.browser-testing.tools]"));
+        assert!(body.contains("# playwright = {}"));
+        assert!(body.contains("version = \"1.62.1\" (default)"));
         assert!(body.contains("Terminal image renderer used by Yazi image and SVG previews"));
         assert!(
             body.contains("Markdown, JSON, RST, and notebook terminal rendering for Yazi previews")

--- a/cli/src/migration.rs
+++ b/cli/src/migration.rs
@@ -845,10 +845,23 @@ fn explicit_customization_theme_parts(raw: &str) -> Result<Option<ThemeParts>> {
 }
 
 fn should_refresh_generated_aibox_toml_comments(raw: &str) -> bool {
+    should_refresh_generated_aibox_toml_comments_for_catalog(
+        raw,
+        &crate::addon_loader::catalog_fingerprint(),
+    )
+}
+
+fn should_refresh_generated_aibox_toml_comments_for_catalog(
+    raw: &str,
+    expected_catalog_fingerprint: &str,
+) -> bool {
+    let expected_catalog_marker =
+        format!("# Addon catalog fingerprint: {expected_catalog_fingerprint}");
     let generated_header = raw.contains("# aibox.toml — single source of truth")
         || raw.contains("# [addons] — language runtimes and tool bundles");
     generated_header
         && (!raw.contains("# Addon catalog — uncomment/comment one block header")
+            || !raw.contains(&expected_catalog_marker)
             || !raw.contains("# Skill catalog — uncomment/comment one line")
             || !raw.contains("disable a default-on tool")
             || raw.contains("config_schema =")
@@ -2852,6 +2865,30 @@ enabled = false
             codex < claude && claude < gemini,
             "comment refresh must keep original harness order:\n{after}"
         );
+    }
+
+    #[test]
+    fn generated_comment_refresh_detects_addon_catalog_changes() {
+        let base = "# aibox.toml — single source of truth\n\
+# Addon catalog — uncomment/comment one block header\n\
+# Skill catalog — uncomment/comment one line\n\
+# Inside an enabled addon, omitted default-enabled tools stay enabled. Uncomment\n\
+# a tool line to pin a version, enable an off-by-default tool, or disable a default-on tool.\n";
+        let current = format!("{base}# Addon catalog fingerprint: new-catalog\n");
+        let stale = format!("{base}# Addon catalog fingerprint: old-catalog\n");
+
+        assert!(!should_refresh_generated_aibox_toml_comments_for_catalog(
+            &current,
+            "new-catalog"
+        ));
+        assert!(should_refresh_generated_aibox_toml_comments_for_catalog(
+            &stale,
+            "new-catalog"
+        ));
+        assert!(should_refresh_generated_aibox_toml_comments_for_catalog(
+            base,
+            "new-catalog"
+        ));
     }
 
     #[test]

--- a/cli/src/update.rs
+++ b/cli/src/update.rs
@@ -54,15 +54,31 @@ struct ImageTagCandidate {
 /// fresh `aibox apply` would keep resolving `latest` to a long-stale image
 /// (BACK-20260514_1902-ShinyLake).
 pub(crate) fn fetch_latest_image_version(flavor: &str) -> Result<semver::Version> {
+    let running_version = semver::Version::parse(env!("CARGO_PKG_VERSION"))
+        .context("running aibox CLI has an invalid package version")?;
+    fetch_latest_image_version_for_major(flavor, running_version.major)
+}
+
+/// Resolve the newest published image within one maintained major release line.
+///
+/// The registry contains independent v0.x and v1.x images. Treating all tags as
+/// one SemVer stream allowed a v0 CLI configured with `latest` to select a v1
+/// prerelease image. The running CLI's major version is the release-line
+/// boundary; prereleases remain eligible inside that boundary.
+fn fetch_latest_image_version_for_major(
+    flavor: &str,
+    release_major: u64,
+) -> Result<semver::Version> {
     let all_tags = fetch_all_ghcr_tags()?;
 
-    let mut versions: Vec<ImageTagCandidate> = all_tags
-        .iter()
-        .filter_map(|tag| parse_image_tag_version(tag, flavor))
-        .collect();
+    let mut versions = image_tag_candidates_for_major(&all_tags, flavor, release_major);
 
     if versions.is_empty() {
-        anyhow::bail!("No published tags found for flavor '{}'", flavor);
+        anyhow::bail!(
+            "No published v{}.x tags found for flavor '{}'",
+            release_major,
+            flavor
+        );
     }
 
     versions.sort_by(|a, b| {
@@ -83,9 +99,22 @@ pub(crate) fn fetch_latest_image_version(flavor: &str) -> Result<semver::Version
     }
 
     anyhow::bail!(
-        "No usable published tags found for flavor '{}' — all matching GHCR tags have incomplete manifests",
-        flavor
+        "No usable published v{}.x tags found for flavor '{}' — all matching GHCR tags have incomplete manifests",
+        release_major,
+        flavor,
     )
+}
+
+fn image_tag_candidates_for_major(
+    all_tags: &[String],
+    flavor: &str,
+    release_major: u64,
+) -> Vec<ImageTagCandidate> {
+    all_tags
+        .iter()
+        .filter_map(|tag| parse_image_tag_version(tag, flavor))
+        .filter(|candidate| candidate.version.major == release_major)
+        .collect()
 }
 
 fn parse_image_tag_version(tag: &str, flavor: &str) -> Option<ImageTagCandidate> {
@@ -648,6 +677,20 @@ mod tests {
         assert!(parse_image_tag_version("base-debian-runtime-latest", "debian").is_none());
         assert!(parse_image_tag_version("base-debian-latest", "debian").is_none());
         assert!(parse_image_tag_version("base-ubuntu-v1.2.3", "debian").is_none());
+    }
+
+    #[test]
+    fn image_latest_candidates_stay_within_running_cli_major_line() {
+        let tags = vec![
+            "base-debian-runtime-v0.32.3".to_string(),
+            "base-debian-runtime-v1.0.0-alpha.1".to_string(),
+        ];
+        let versions: Vec<_> = image_tag_candidates_for_major(&tags, "debian", 0)
+            .into_iter()
+            .map(|candidate| candidate.version)
+            .collect();
+
+        assert_eq!(versions, vec![semver::Version::parse("0.32.3").unwrap()]);
     }
 
     #[test]

--- a/context/logs/2026/08/LOG-20260814_1431-NobleIvy-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260814_1431-NobleIvy-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1431-NobleIvy-workitem-created
+  created: '2026-08-14T14:31:22+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-14T14:31:22+00:00'
+  summary: 'Created WorkItem ''BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh'':
+    ''Keep v0 latest image resolution and addon comment catalogs line-correct'''
+  subject: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+  subject_kind: WorkItem
+  actor: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+---

--- a/context/logs/2026/08/LOG-20260814_1431-SparklingMesa-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260814_1431-SparklingMesa-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1431-SparklingMesa-workitem-transitioned
+  created: '2026-08-14T14:31:30+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-14T14:31:30+00:00'
+  summary: Transitioned WorkItem 'BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+  subject_kind: WorkItem
+  actor: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+---

--- a/context/logs/2026/08/LOG-20260814_1438-EarnestComet-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260814_1438-EarnestComet-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1438-EarnestComet-workitem-transitioned
+  created: '2026-08-14T14:38:49+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-14T14:38:49+00:00'
+  summary: Transitioned WorkItem 'BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh'
+    from 'in-progress' to 'review'
+  subject: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+  subject_kind: WorkItem
+  actor: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+---

--- a/context/logs/2026/08/LOG-20260814_1438-MightyOrchard-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260814_1438-MightyOrchard-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1438-MightyOrchard-workitem-archive-moved
+  created: '2026-08-14T14:38:50+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-14T14:38:50+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh'
+    to /workspace/context/workitems/done/2026/08/BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh.md
+  subject: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+  subject_kind: WorkItem
+  actor: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh.md
+---

--- a/context/logs/2026/08/LOG-20260814_1438-PromptGlade-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260814_1438-PromptGlade-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1438-PromptGlade-workitem-transitioned
+  created: '2026-08-14T14:38:50+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-14T14:38:50+00:00'
+  summary: Transitioned WorkItem 'BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh'
+    from 'review' to 'done'
+  subject: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+  subject_kind: WorkItem
+  actor: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+---

--- a/context/workitems/done/2026/08/BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh.md
+++ b/context/workitems/done/2026/08/BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh.md
@@ -1,0 +1,32 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh
+  created: '2026-08-14T14:31:22+00:00'
+  updated: '2026-08-14T14:38:50+00:00'
+spec:
+  title: Keep v0 latest image resolution and addon comment catalogs line-correct
+  state: done
+  type: bug
+  priority: high
+  description: Fix v0.x CLI image latest resolution so it cannot select v1 prerelease
+    images. Make generated aibox.toml comment refresh detect addon catalog additions
+    such as browser-testing, with regression tests for derived-project upgrades.
+  started_at: '2026-08-14T14:31:30+00:00'
+  completed_at: '2026-08-14T14:38:50+00:00'
+---
+
+## Transition note (2026-08-14T14:31:30+00:00)
+
+Implementation and regression testing started after reproducing both causes.
+
+
+## Transition note (2026-08-14T14:38:49+00:00)
+
+Implementation complete and full verification evidence collected.
+
+
+## Transition note (2026-08-14T14:38:50+00:00)
+
+Accepted: major-line latest selection, catalog-change comment refresh, and regression coverage all pass.


### PR DESCRIPTION
## Changes
- constrain GHCR image latest resolution to the running CLI major release line
- fingerprint the addon catalog so new addons and tools refresh generated aibox.toml comments
- add regressions for v0 versus v1 alpha selection and browser-testing catalog rendering

## Verification
- 1,080 unit tests passed
- 125 E2E tests passed in the full run; three contention timeouts passed serially
- 32 integration tests passed
- cargo clippy --all-targets -- -D warnings
- cargo fmt -- --check

Refs: BACK-20260814_1431-HardyPine-fix-image-line-addon-comment-refresh