### PR TITLE
fix: refresh Yazi Markdown previews

### DIFF
--- a/cli/src/seed.rs
+++ b/cli/src/seed.rs
@@ -3576,6 +3576,12 @@ rules = [
                 && DEFAULT_YAZI_PLUGIN_RICH_PREVIEW.contains("read_window"),
             "rich-preview must cache rendered output and read windowed slices on re-peek"
         );
+        assert!(
+            DEFAULT_YAZI_PLUGIN_RICH_PREVIEW.contains("h1 = (h1 * 33 + byte)")
+                && DEFAULT_YAZI_PLUGIN_RICH_PREVIEW.contains("h2 = (h2 * 65599 + byte)")
+                && !DEFAULT_YAZI_PLUGIN_RICH_PREVIEW.contains(":sub(1, 32)"),
+            "rich-preview cache identity must hash the entire selected path instead of truncating its shared directory prefix"
+        );
     }
 
     #[test]

--- a/cli/tests/e2e/preview.rs
+++ b/cli/tests/e2e/preview.rs
@@ -153,6 +153,15 @@ fn rich_preview_plugin_seeded_with_preview_enhanced() {
         plugin_path.display()
     );
 
+    let plugin = fs::read_to_string(&plugin_path)
+        .unwrap_or_else(|e| panic!("failed to read rich-preview plugin: {e}"));
+    assert!(
+        plugin.contains("h1 = (h1 * 33 + byte)")
+            && plugin.contains("h2 = (h2 * 65599 + byte)")
+            && !plugin.contains(":sub(1, 32)"),
+        "rich-preview must distinguish files that share a long directory prefix"
+    );
+
     let yazi_toml = read_yazi_toml(dir.path());
     assert!(
         yazi_toml.contains("rich-preview"),

--- a/context/logs/2026/08/LOG-20260814_1440-FastWren-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260814_1440-FastWren-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1440-FastWren-workitem-created
+  created: '2026-08-14T14:40:04+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-14T14:40:04+00:00'
+  summary: 'Created WorkItem ''BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview'':
+    ''Refresh Yazi Markdown preview when selection changes'''
+  subject: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+  subject_kind: WorkItem
+  actor: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+---

--- a/context/logs/2026/08/LOG-20260814_1440-PatientJewel-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260814_1440-PatientJewel-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1440-PatientJewel-workitem-transitioned
+  created: '2026-08-14T14:40:09+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-14T14:40:09+00:00'
+  summary: Transitioned WorkItem 'BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+  subject_kind: WorkItem
+  actor: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+---

--- a/context/logs/2026/08/LOG-20260814_1445-ReliableLynx-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260814_1445-ReliableLynx-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1445-ReliableLynx-workitem-archive-moved
+  created: '2026-08-14T14:45:08+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-14T14:45:08+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview'
+    to /workspace/context/workitems/done/2026/08/BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview.md
+  subject: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+  subject_kind: WorkItem
+  actor: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview.md
+---

--- a/context/logs/2026/08/LOG-20260814_1445-SkilledSpruce-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260814_1445-SkilledSpruce-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1445-SkilledSpruce-workitem-transitioned
+  created: '2026-08-14T14:45:08+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-14T14:45:08+00:00'
+  summary: Transitioned WorkItem 'BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview'
+    from 'review' to 'done'
+  subject: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+  subject_kind: WorkItem
+  actor: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+---

--- a/context/logs/2026/08/LOG-20260814_1445-WiseWillow-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260814_1445-WiseWillow-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260814_1445-WiseWillow-workitem-transitioned
+  created: '2026-08-14T14:45:08+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-14T14:45:08+00:00'
+  summary: Transitioned WorkItem 'BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview'
+    from 'in-progress' to 'review'
+  subject: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+  subject_kind: WorkItem
+  actor: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+---

--- a/context/workitems/done/2026/08/BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview.md
+++ b/context/workitems/done/2026/08/BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview.md
@@ -1,0 +1,32 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview
+  created: '2026-08-14T14:40:04+00:00'
+  updated: '2026-08-14T14:45:08+00:00'
+spec:
+  title: Refresh Yazi Markdown preview when selection changes
+  state: done
+  type: bug
+  priority: high
+  description: Reproduce and fix the v0.x Yazi rich Markdown preview retaining the
+    first file in a directory when subsequent Markdown files are selected. Add regression
+    coverage for per-file preview identity and refresh behavior.
+  started_at: '2026-08-14T14:40:09+00:00'
+  completed_at: '2026-08-14T14:45:08+00:00'
+---
+
+## Transition note (2026-08-14T14:40:09+00:00)
+
+Tracing generated rich-preview plugin cache and Yazi job identity before patching.
+
+
+## Transition note (2026-08-14T14:45:08+00:00)
+
+Full-path cache identity implemented; unit/E2E regression, full suite, format, and clippy verified. Parallel tmux timeouts passed serially.
+
+
+## Transition note (2026-08-14T14:45:08+00:00)
+
+Accepted: sibling Markdown files now receive distinct bounded cache keys derived from their complete paths.

--- a/images/base-debian/config/yazi/plugins/rich-preview.yazi/main.lua
+++ b/images/base-debian/config/yazi/plugins/rich-preview.yazi/main.lua
@@ -105,15 +105,18 @@ local function cache_root()
 end
 
 local function path_key(url)
-	-- Hex-encode the path so the cache filename is filesystem-safe and bounded.
-	-- Truncate to 32 chars — collisions are vanishingly rare and the full
-	-- (mtime, width) suffix guards against semantic clashes.
+	-- Hash the entire path into a bounded, filesystem-safe key. The previous
+	-- implementation truncated a hex-encoded path to its first 32 characters,
+	-- so files sharing the same first 16 path bytes collided whenever their
+	-- mtimes and preview widths also matched.
 	local s = tostring(url)
-	local out = {}
+	local h1, h2 = 5381, 52711
 	for i = 1, #s do
-		out[i] = string.format("%02x", s:byte(i))
+		local byte = s:byte(i)
+		h1 = (h1 * 33 + byte) % 4294967296
+		h2 = (h2 * 65599 + byte) % 4294967296
 	end
-	return table.concat(out):sub(1, 32)
+	return string.format("%08x%08x", h1, h2)
 end
 
 local function cache_file(url, mtime, width)


### PR DESCRIPTION
## Changes
- derive rich-preview cache identity from the complete selected file path
- retain bounded cache filenames with a dual 32-bit hash
- cover generated runtime seeding and reject the truncated-prefix implementation

## Verification
- 1,080 unit tests passed
- 125 E2E tests passed in the full run; three contention timeouts passed serially
- targeted Markdown preview Tier 1 test passed
- cargo clippy --all-targets -- -D warnings
- cargo fmt -- --check

Refs: BACK-20260814_1440-RoyalPrairie-refresh-yazi-markdown-selection-preview