### PR TITLE
chore: release v0.32.4

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aibox"
-version = "0.32.3"
+version = "0.32.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aibox"
-version = "0.32.3"
+version = "0.32.4"
 edition = "2024"
 description = "aibox — manage AI-ready development container environments"
 license = "MIT"

--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -703,6 +703,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.6",
         note: "Patch release: makes the axe host fixture accessibility-clean and records structured violation diagnostics when a future browser probe fails.",
     },
+    CompatEntry {
+        aibox_version: "0.32.4",
+        processkit_version: "v0.28.6",
+        note: "Patch release: keeps latest image resolution on the active v0 line, refreshes generated addon comments when the catalog changes, and fixes stale or collapsed Yazi Markdown previews.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.32.4 | v0.28.6 | keeps `latest` image resolution on the active v0 line, refreshes generated addon comments when the catalog changes, and fixes stale or collapsed Yazi Markdown previews |
 | 0.32.3 | v0.28.6 | makes the axe host fixture accessibility-clean and records structured violation diagnostics when a future browser probe fails |
 | 0.32.2 | v0.28.6 | uses an explicit Playwright BrowserContext for axe host validation and makes safe release-host caches and candidate-bound retries available by default |
 | 0.32.1 | v0.28.6 | makes the browser-testing host gate launch the full Chromium channel installed by Playwright `--no-shell` instead of requesting the omitted headless-shell executable |


### PR DESCRIPTION
Promotes the validated v0.32.4 release candidate to v0.x-release.