### PR TITLE
docs: record v0.32.4 release notes

### DIFF
--- a/dist/RELEASE-NOTES.md
+++ b/dist/RELEASE-NOTES.md
@@ -1,14 +1,12 @@
-# aibox v0.32.3 — 2026-08-14
+# aibox v0.32.4
 
-**Summary:** This patch makes the release-host browser fixture accessibility-clean, verified against the actual macOS Chromium host image.
+## Changes since v0.32.3
 
-## Fixed
-
-- Add the missing level-one heading required by axe's page-level best-practice rules; the corrected fixture returns zero violations on the macOS release host.
-- Preserve structured violation IDs, help URLs, affected HTML, and failure summaries in host evidence if the fixture regresses.
-
-## Changed
-
-- Keep the explicit Playwright `BrowserContext`, full Chromium channel, default cache reuse, and candidate-bound retry support introduced in v0.32.2.
-
-[v0.32.3]: https://github.com/projectious-work/aibox/compare/v0.32.2...v0.32.3
+- 46d326c2 Merge pull request #398 from projectious-work/chore/release-v0.32.4
+- d5c74c72 chore: bump CLI version to 0.32.4
+- a6a50eaa Merge pull request #397 from projectious-work/fix/yazi-hugo-frontmatter-preview
+- a6a5ca04 fix: preserve Hugo front matter in previews
+- 276c81b3 Merge pull request #396 from projectious-work/fix/yazi-markdown-preview-cache
+- aa6060d1 fix: refresh yazi markdown previews
+- 6f7178a1 Merge pull request #395 from projectious-work/fix/v0-latest-addon-catalog-refresh
+- 90b08668 fix: keep latest image within release line


### PR DESCRIPTION
Record the generated v0.32.4 release notes left by the canonical release workflow so the release branch remains clean.