### PR TITLE
fix: improve Yazi clipboard and addon refresh

### DIFF
--- a/cli/src/seed.rs
+++ b/cli/src/seed.rs
@@ -774,11 +774,13 @@ prepend_keymap = [
     { on = [ "z", "0" ], run = "plugin toggle-pane", desc = "Reset pane layout" },
     { on = [ "w", "s" ], run = "shell 'du -sch \"$@\" | ${PAGER:-less}' --block", desc = "Size selected files" },
     { on = [ "w", "h" ], run = "shell 'bat --color=always --style=plain --paging=never \"$1\" | less -R -S' --block", desc = "Preview with horizontal scroll" },
+    { on = [ "w", "v" ], run = "shell 'vim -R \"$1\"' --block", desc = "Select preview text in read-only Vim" },
     { on = [ "w", "p" ], run = "shell 'if [ -f \"$HOME/.local/bin/pdf-watch\" ]; then bash \"$HOME/.local/bin/pdf-watch\" \"$1\"; else pdf-watch \"$1\"; fi' --block", desc = "Watch PDF preview" },
     { on = [ "c", "p" ], run = "copy path", desc = "Copy selected paths" },
     { on = [ "c", "d" ], run = "copy dirname", desc = "Copy selected directories" },
     { on = [ "c", "f" ], run = "copy filename", desc = "Copy selected filenames" },
     { on = [ "c", "n" ], run = "copy name_without_ext", desc = "Copy names without extension" },
+    { on = [ "c", "c" ], run = "shell 'aibox-copy < \"$1\"'", desc = "Copy file contents to host clipboard" },
     { on = [ "g", "s" ], run = "shell 'git -c color.status=always status --short --branch --ignored=matching --untracked-files=all | ${PAGER:-less} -R' --block", desc = "Git summary" },
     { on = [ "g", "c" ], run = "shell 'git -c color.status=always status --short --ignored=matching --untracked-files=all | ${PAGER:-less} -R' --block", desc = "Show git changes" },
     { on = [ "g", "r" ], run = "cd .", desc = "Refresh directory" },
@@ -798,8 +800,10 @@ const DEFAULT_CHEATSHEET: &str = r#"  aibox Quick Reference  (prefix = Ctrl+g)
   prefix f/z      Zoom pane   g c      Git changes
   prefix c        New window  w s      Size selection
   prefix 1-9      Jump window w h      Horizontal preview
+                              w v      Select/yank preview text
   prefix g/s      lazygit/shell win
   prefix L        Layout menu c p/d/f  Copy path/dir/name
+                              c c      Copy file contents
   prefix T        Theme menu  g r      Refresh git
   prefix [        Copy mode
   prefix o        Log viewer

--- a/cli/tests/e2e/preview.rs
+++ b/cli/tests/e2e/preview.rs
@@ -273,6 +273,37 @@ fn yazi_keymap_has_horizontal_scroll_pager() {
     );
 }
 
+/// Yazi should expose whole-file host-copy and a selectable read-only preview.
+#[test]
+fn yazi_keymap_has_content_copy_and_selectable_preview() {
+    let dir = tempfile::tempdir().unwrap();
+    init_project(dir.path(), "preview-copy-select");
+
+    let keymap_toml = read_yazi_keymap(dir.path());
+
+    assert!(
+        keymap_toml.contains(r#"{ on = [ "c", "c" ], run = "shell 'aibox-copy < \"$1\"'"#),
+        "keymap.toml should copy the hovered file contents through aibox-copy"
+    );
+    assert!(
+        keymap_toml.contains(r#"{ on = [ "w", "v" ], run = "shell 'vim -R \"$1\"' --block"#),
+        "keymap.toml should expose a read-only Vim surface for selecting preview text"
+    );
+}
+
+/// The image fallback must match the generated Yazi clipboard/selection bindings.
+#[test]
+fn image_yazi_keymap_matches_content_copy_and_selectable_preview() {
+    let image_keymap = fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../images/base-debian/config/yazi/keymap.toml"),
+    )
+    .expect("read image Yazi keymap");
+
+    assert!(image_keymap.contains(r#"aibox-copy < \"$1\""#));
+    assert!(image_keymap.contains(r#"vim -R \"$1\""#));
+}
+
 /// The Yazi keymap should expose the PDF live-watch helper for selected PDFs.
 #[test]
 fn yazi_keymap_has_pdf_watch_binding() {

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -290,6 +290,34 @@ fn install_script_lists_every_repo_addon_yaml() {
 }
 
 #[test]
+fn install_script_refreshes_addons_when_binary_version_is_unchanged() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let script = std::fs::read_to_string(
+        std::path::Path::new(manifest_dir)
+            .parent()
+            .unwrap()
+            .join("scripts/install.sh"),
+    )
+    .expect("read scripts/install.sh");
+
+    let same_version_branch = script
+        .split_once(r#"if [[ "${current}" == "${version}" ]]; then"#)
+        .expect("install script should detect an unchanged version")
+        .1
+        .split_once("fi")
+        .expect("same-version branch should be closed")
+        .0;
+    assert!(
+        !same_version_branch.contains("exit 0"),
+        "same-version installs must continue to refresh addon definitions"
+    );
+    assert!(
+        same_version_branch.contains("refreshing binary and addon catalog"),
+        "same-version refresh behavior should be visible to users"
+    );
+}
+
+#[test]
 fn apply_with_installed_catalog_installs_gh_from_git_ui() {
     let dir = tempfile::tempdir().unwrap();
     let installed_addons = install_script_addons_dir();

--- a/context/logs/2026/08/LOG-20260815_1502-FluentCedar-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260815_1502-FluentCedar-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1502-FluentCedar-workitem-created
+  created: '2026-08-15T15:02:02+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-15T15:02:02+00:00'
+  summary: 'Created WorkItem ''BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools'':
+    ''Improve Yazi clipboard and preview interaction; repair missing addon tools'''
+  subject: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+  subject_kind: WorkItem
+  actor: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+---

--- a/context/logs/2026/08/LOG-20260815_1502-PeacefulOwl-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260815_1502-PeacefulOwl-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1502-PeacefulOwl-workitem-transitioned
+  created: '2026-08-15T15:02:48+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-15T15:02:48+00:00'
+  summary: Transitioned WorkItem 'BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+  subject_kind: WorkItem
+  actor: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+---

--- a/context/logs/2026/08/LOG-20260815_1505-PatientTide-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260815_1505-PatientTide-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1505-PatientTide-workitem-transitioned
+  created: '2026-08-15T15:05:48+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-15T15:05:48+00:00'
+  summary: Transitioned WorkItem 'BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools'
+    from 'in-progress' to 'review'
+  subject: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+  subject_kind: WorkItem
+  actor: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+---

--- a/context/logs/2026/08/LOG-20260815_1506-AdeptHeron-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260815_1506-AdeptHeron-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1506-AdeptHeron-workitem-transitioned
+  created: '2026-08-15T15:06:00+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-15T15:06:00+00:00'
+  summary: Transitioned WorkItem 'BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools'
+    from 'review' to 'done'
+  subject: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+  subject_kind: WorkItem
+  actor: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+---

--- a/context/logs/2026/08/LOG-20260815_1506-ClearFlute-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260815_1506-ClearFlute-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1506-ClearFlute-workitem-archive-moved
+  created: '2026-08-15T15:06:00+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-15T15:06:00+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools'
+    to /workspace/context/workitems/done/2026/08/BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools.md
+  subject: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+  subject_kind: WorkItem
+  actor: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools.md
+---

--- a/context/workitems/done/2026/08/BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools.md
+++ b/context/workitems/done/2026/08/BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools.md
@@ -1,0 +1,34 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools
+  created: '2026-08-15T15:02:02+00:00'
+  updated: '2026-08-15T15:06:00+00:00'
+spec:
+  title: Improve Yazi clipboard and preview interaction; repair missing addon tools
+  state: done
+  type: story
+  priority: high
+  description: In the maintained v0.x line, add keyboard-driven whole-file clipboard
+    yanking from Yazi, propagate Vim visual yanks through tmux to the host clipboard,
+    support horizontal preview navigation and feasible preview text selection/yanking,
+    and diagnose/fix configured supply-chain tools that are absent after apply/runtime
+    recreation.
+  started_at: '2026-08-15T15:02:48+00:00'
+  completed_at: '2026-08-15T15:06:00+00:00'
+---
+
+## Transition note (2026-08-15T15:02:48+00:00)
+
+Diagnosis established: Vim visual yanks already route through aibox-copy; Yazi has a horizontal pager binding but lacks whole-file copy and selectable-preview guidance; derived config proves the host CLI loaded a stale addon catalog and therefore ignored supply-chain.
+
+
+## Transition note (2026-08-15T15:05:48+00:00)
+
+Implemented generated and image-fallback Yazi bindings for whole-file host copy and selectable read-only Vim preview; documented horizontal/selectable preview behavior; fixed same-version installer early exit so addon catalogs refresh; preview E2E, installer integration tests, fmt, shell syntax, diff check, and clippy pass.
+
+
+## Transition note (2026-08-15T15:06:00+00:00)
+
+Implementation and verification complete; ready for protected v0.x integration.

--- a/docs-site/content/docs/reference/cheatsheet.md
+++ b/docs-site/content/docs/reference/cheatsheet.md
@@ -126,6 +126,8 @@ Quick reference for all tools in the aibox environment. Press the tab for the to
     | `Enter` | Open file in-place (suspends Yazi, `:q` returns) |
     | `e` | Open in adjacent Vim pane (stays in Yazi) |
     | `O` | Interactive opener selection |
+    | `w` `h` | Open a no-wrap pager; use arrow keys to scroll horizontally |
+    | `w` `v` | Open the file read-only in Vim for mouse/Visual selection; `y` copies the selection to tmux and the host clipboard |
 
     ### File Operations
 
@@ -141,6 +143,7 @@ Quick reference for all tools in the aibox environment. Press the tab for the to
     | `Space` | Toggle selection on current file |
     | `v` | Visual mode (select range) |
     | `V` | Invert selection |
+    | `c` `c` | Copy the hovered file's contents to the tmux and host clipboard |
 
     ### Search & Filter
 
@@ -158,6 +161,11 @@ Quick reference for all tools in the aibox environment. Press the tab for the to
     | `t` | Create new tab |
     | `1`..`9` | Switch to tab by number |
     | `[` / `]` | Previous / next tab |
+
+    The embedded Yazi preview is a rendered widget rather than an editable text
+    buffer, so it cannot provide Vim-style character selection. Use `w v` for
+    selectable raw text, or enter tmux copy mode (`Ctrl+g` then `[`) to select
+    rendered terminal cells with the keyboard or mouse.
 
     ### Misc
 

--- a/images/base-debian/config/vimrc
+++ b/images/base-debian/config/vimrc
@@ -82,7 +82,8 @@ endif
 " without +clipboard. aibox-copy uses tmux load-buffer -w and OSC52 fallback.
 function! s:AiboxCopyRegister() abort
     if executable('aibox-copy')
-        call system('aibox-copy', getreg(v:register))
+        let l:register = empty(v:register) ? '"' : v:register
+        call system('aibox-copy', getreg(l:register))
     endif
 endfunction
 

--- a/images/base-debian/config/yazi/keymap.toml
+++ b/images/base-debian/config/yazi/keymap.toml
@@ -24,6 +24,8 @@ prepend_keymap = [
     { on = [ "w", "s" ], run = "shell 'du -sch \"$@\" | ${PAGER:-less}' --block", desc = "Size selected files" },
     # w h: open the hovered file in a horizontal-scroll pager
     { on = [ "w", "h" ], run = "shell 'bat --color=always --style=plain --paging=never \"$1\" | less -R -S' --block", desc = "Preview with horizontal scroll" },
+    # w v: use Vim as the selectable raw-text preview surface
+    { on = [ "w", "v" ], run = "shell 'vim -R \"$1\"' --block", desc = "Select preview text in read-only Vim" },
     # w p: live-watch the hovered PDF and re-render when it changes
     { on = [ "w", "p" ], run = "shell 'if [ -f \"$HOME/.local/bin/pdf-watch\" ]; then bash \"$HOME/.local/bin/pdf-watch\" \"$1\"; else pdf-watch \"$1\"; fi' --block", desc = "Watch PDF preview" },
     # c *: copy selected path components to the clipboard via Yazi's native copy action
@@ -31,6 +33,8 @@ prepend_keymap = [
     { on = [ "c", "d" ], run = "copy dirname", desc = "Copy selected directories" },
     { on = [ "c", "f" ], run = "copy filename", desc = "Copy selected filenames" },
     { on = [ "c", "n" ], run = "copy name_without_ext", desc = "Copy names without extension" },
+    # c c: copy the hovered file contents through tmux/OSC52
+    { on = [ "c", "c" ], run = "shell 'aibox-copy < \"$1\"'", desc = "Copy file contents to host clipboard" },
     # g s: repo-level git summary (branch + totals)
     { on = [ "g", "s" ], run = "shell 'git -c color.status=always status --short --branch --ignored=matching --untracked-files=all | ${PAGER:-less} -R' --block", desc = "Git summary" },
     # g c: detailed changed-files view for the current repository

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -129,8 +129,8 @@ check_existing() {
     local current
     current=$("${install_dir}/${BINARY_NAME}" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
     if [[ "${current}" == "${version}" ]]; then
-      ok "aibox v${version} is already installed at ${install_dir}/${BINARY_NAME}"
-      exit 0
+      ok "aibox v${version} is already installed at ${install_dir}/${BINARY_NAME}; refreshing binary and addon catalog"
+      return
     fi
     warn "Upgrading aibox from v${current} to v${version}"
   fi


### PR DESCRIPTION
## Changes
- add c c to copy the hovered file contents through tmux/OSC52 to the host clipboard
- add w v for mouse/Vim Visual selection in a read-only preview
- retain and document w h horizontal scrolling and tmux copy-mode selection for rendered previews
- align generated and image-fallback keymaps/Vim clipboard behavior
- refresh addon definitions even when reinstalling the same CLI version, repairing stale catalogs that skip supply-chain

## Verification
- complete preview E2E module
- installer catalog integration tests
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- bash syntax and git diff checks

Refs: BACK-20260815_1502-ProudRiver-improve-yazi-clipboard-preview-addon-tools