### PR TITLE
fix: embed canonical addon catalog

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,48 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn collect_yaml_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("read addon catalog directory") {
+        let path = entry.expect("read addon catalog entry").path();
+        if path.is_dir() {
+            collect_yaml_files(&path, files);
+        } else if matches!(
+            path.extension().and_then(|ext| ext.to_str()),
+            Some("yaml" | "yml")
+        ) {
+            files.push(path);
+        }
+    }
+}
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let addons_dir = manifest_dir.join("../addons");
+    let mut files = Vec::new();
+    collect_yaml_files(&addons_dir, &mut files);
+    files.sort();
+
+    println!("cargo:rerun-if-changed={}", addons_dir.display());
+
+    let mut generated =
+        String::from("pub const EMBEDDED_ADDON_YAMLS: &[(&str, &str, &str)] = &[\n");
+    for path in files {
+        println!("cargo:rerun-if-changed={}", path.display());
+        let category = path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .expect("addon category directory");
+        let source = path
+            .strip_prefix(&addons_dir)
+            .expect("addon path below catalog")
+            .to_string_lossy();
+        let content = fs::read_to_string(&path).expect("read addon YAML");
+        generated.push_str(&format!("    ({category:?}, {source:?}, {content:?}),\n"));
+    }
+    generated.push_str("];\n");
+
+    let out = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR")).join("embedded_addons.rs");
+    fs::write(out, generated).expect("write embedded addon catalog");
+}

--- a/cli/src/addon_loader.rs
+++ b/cli/src/addon_loader.rs
@@ -1,7 +1,8 @@
 //! Loads addon definitions from YAML files and renders Dockerfile templates.
 //!
-//! Addon YAML files are stored in `$XDG_CONFIG_HOME/aibox/addons/` with
-//! category subdirectories (languages/, tools/, docs/, ai/).
+//! Canonical addon YAML files are embedded in the executable. Optional files
+//! in `$XDG_CONFIG_HOME/aibox/addons/` (or `AIBOX_ADDONS_DIR`) override matching
+//! canonical definitions and may add custom definitions.
 //!
 //! Each YAML file defines:
 //! - Metadata (name, version, builder_weight)
@@ -17,10 +18,14 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::OnceLock;
 
 use crate::addon_registry::{ToolConfig, ToolDef};
+
+mod embedded {
+    include!(concat!(env!("OUT_DIR"), "/embedded_addons.rs"));
+}
 
 pub const ADDON_CATALOG_SCHEMA_VERSION: &str = "aibox.addon-catalog.v0";
 
@@ -252,27 +257,6 @@ static ADDONS: OnceLock<Vec<LoadedAddon>> = OnceLock::new();
 // Loading
 // ---------------------------------------------------------------------------
 
-/// Get the addons directory path.
-///
-/// Checks `AIBOX_ADDONS_DIR` first. In source checkouts, fall back to the
-/// repository's bundled `addons/` directory so `cargo run ... -- doctor` works
-/// without requiring a separate global install. Packaged binaries still use the
-/// XDG install path from `scripts/install.sh`.
-pub fn addons_dir() -> Result<PathBuf> {
-    if let Ok(dir) = std::env::var("AIBOX_ADDONS_DIR") {
-        return Ok(PathBuf::from(dir));
-    }
-
-    let repo_addons = Path::new(env!("CARGO_MANIFEST_DIR")).join("../addons");
-    if repo_addons.is_dir() {
-        return Ok(repo_addons);
-    }
-
-    crate::dirs::config_dir()
-        .map(|d| d.join("addons"))
-        .ok_or_else(|| anyhow::anyhow!("Could not determine XDG config directory"))
-}
-
 /// Load all addon YAML files from the addons directory.
 /// Walks subdirectories (languages/, tools/, docs/, ai/).
 fn load_from_dir(dir: &Path) -> Result<Vec<LoadedAddon>> {
@@ -343,9 +327,6 @@ fn category_from_dir_name(dir_name: &str) -> &'static str {
 fn load_yaml_file(path: &Path) -> Result<LoadedAddon> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("Failed to read addon file: {}", path.display()))?;
-    let yaml: AddonYaml = serde_yaml::from_str(&content)
-        .with_context(|| format!("Failed to parse addon YAML: {}", path.display()))?;
-
     let category = path
         .parent()
         .and_then(|p| p.file_name())
@@ -353,6 +334,13 @@ fn load_yaml_file(path: &Path) -> Result<LoadedAddon> {
         .map(category_from_dir_name)
         .unwrap_or("Other")
         .to_string();
+
+    load_yaml_content(&content, &category, &path.display().to_string())
+}
+
+fn load_yaml_content(content: &str, category: &str, source: &str) -> Result<LoadedAddon> {
+    let yaml: AddonYaml = serde_yaml::from_str(content)
+        .with_context(|| format!("Failed to parse addon YAML: {source}"))?;
 
     Ok(LoadedAddon {
         name: yaml.name,
@@ -362,7 +350,7 @@ fn load_yaml_file(path: &Path) -> Result<LoadedAddon> {
         usage_class: yaml.usage_class,
         profiles: yaml.profiles,
         exported_surfaces: yaml.exported_surfaces,
-        category,
+        category: category.to_string(),
         builder_weight: yaml.builder_weight,
         requires: yaml.requires,
         groups: yaml.groups,
@@ -382,18 +370,66 @@ fn load_yaml_file(path: &Path) -> Result<LoadedAddon> {
     })
 }
 
+fn load_embedded_catalog() -> Result<Vec<LoadedAddon>> {
+    let mut addons = embedded::EMBEDDED_ADDON_YAMLS
+        .iter()
+        .map(|(category, source, content)| {
+            load_yaml_content(content, category_from_dir_name(category), source)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    addons.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(addons)
+}
+
+fn merge_catalogs(embedded: Vec<LoadedAddon>, overrides: Vec<LoadedAddon>) -> Vec<LoadedAddon> {
+    let mut by_name: HashMap<String, LoadedAddon> = embedded
+        .into_iter()
+        .map(|addon| (addon.name.clone(), addon))
+        .collect();
+    for addon in overrides {
+        by_name.insert(addon.name.clone(), addon);
+    }
+    let mut addons: Vec<_> = by_name.into_values().collect();
+    addons.sort_by(|a, b| a.name.cmp(&b.name));
+    addons
+}
+
 // ---------------------------------------------------------------------------
 // Global access
 // ---------------------------------------------------------------------------
 
-/// Initialize the addon store from the default XDG path. Call once at startup.
+/// Initialize the embedded addon store plus optional filesystem overrides.
 pub fn init() -> Result<()> {
-    let dir = addons_dir()?;
-    init_from_dir(&dir)
+    if let Ok(dir) = std::env::var("AIBOX_ADDONS_DIR") {
+        let addons = merge_catalogs(load_embedded_catalog()?, load_from_dir(Path::new(&dir))?);
+        ADDONS
+            .set(addons)
+            .map_err(|_| anyhow::anyhow!("Addon store already initialized"))?;
+        return Ok(());
+    }
+
+    let repo_addons = Path::new(env!("CARGO_MANIFEST_DIR")).join("../addons");
+    let addons = if repo_addons.is_dir() {
+        load_from_dir(&repo_addons)?
+    } else {
+        let embedded = load_embedded_catalog()?;
+        let installed = crate::dirs::config_dir()
+            .map(|dir| dir.join("addons"))
+            .filter(|dir| dir.is_dir())
+            .map(|dir| load_from_dir(&dir))
+            .transpose()?
+            .unwrap_or_default();
+        merge_catalogs(embedded, installed)
+    };
+    ADDONS
+        .set(addons)
+        .map_err(|_| anyhow::anyhow!("Addon store already initialized"))?;
+    Ok(())
 }
 
 /// Initialize the addon store from a specific directory.
 /// Used by tests to point at the repo's addons/ directory.
+#[cfg(test)]
 pub fn init_from_dir(dir: &Path) -> Result<()> {
     let addons = load_from_dir(dir)?;
     ADDONS
@@ -709,19 +745,6 @@ mod tests {
     }
 
     #[test]
-    fn addons_dir_defaults_to_repo_addons_in_source_checkout() {
-        unsafe {
-            std::env::remove_var("AIBOX_ADDONS_DIR");
-        }
-        let dir = addons_dir().unwrap();
-        assert!(
-            dir.ends_with("addons") && dir.is_dir(),
-            "source checkout should resolve bundled addons dir, got {}",
-            dir.display()
-        );
-    }
-
-    #[test]
     fn load_from_dir_finds_yaml_files() {
         let dir = tempfile::tempdir().unwrap();
         write_test_yaml(
@@ -748,6 +771,59 @@ runtime: |
         assert_eq!(addons[0].tools[0].name, "test-tool");
         assert_eq!(addons[0].tools[0].default_version, "1.0");
         assert!(addons[0].requires.is_empty());
+    }
+
+    #[test]
+    fn embedded_catalog_contains_release_addons() {
+        let addons = load_embedded_catalog().unwrap();
+        for name in [
+            "browser-testing",
+            "cloudflare",
+            "go-quality",
+            "release",
+            "supply-chain",
+        ] {
+            assert!(
+                addons.iter().any(|addon| addon.name == name),
+                "embedded catalog should contain {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn incomplete_installed_catalog_overrides_without_hiding_embedded_addons() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_yaml(
+            dir.path(),
+            "tools",
+            "git-ui",
+            r#"
+name: git-ui
+version: "override"
+tools:
+  - name: gh
+    default_enabled: true
+runtime: |
+  RUN echo override
+"#,
+        );
+
+        let merged = merge_catalogs(
+            load_embedded_catalog().unwrap(),
+            load_from_dir(dir.path()).unwrap(),
+        );
+        assert_eq!(
+            merged
+                .iter()
+                .find(|addon| addon.name == "git-ui")
+                .unwrap()
+                .addon_version,
+            "override"
+        );
+        assert!(
+            merged.iter().any(|addon| addon.name == "supply-chain"),
+            "a stale installed catalog must not hide embedded canonical addons"
+        );
     }
 
     #[test]

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -370,6 +370,58 @@ lazygit = { enabled = false }
 }
 
 #[test]
+fn apply_with_stale_installed_catalog_uses_embedded_supply_chain_addon() {
+    let dir = tempfile::tempdir().unwrap();
+    let stale_catalog = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(stale_catalog.path().join("tools")).unwrap();
+    std::fs::write(
+        stale_catalog.path().join("tools/git-ui.yaml"),
+        std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../addons/tools/git-ui.yaml"),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("aibox.toml"),
+        r#"[aibox]
+version = "0.32.4"
+base = "debian"
+
+[container]
+name = "embedded-supply-chain"
+
+[processkit]
+version = "unset"
+
+[addons.supply-chain.tools]
+syft = { version = "1.50.0" }
+grype = { version = "0.116.1" }
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(aibox_bin())
+        .args(["apply", "--no-container"])
+        .current_dir(dir.path())
+        .env("AIBOX_ADDONS_DIR", stale_catalog.path())
+        .output()
+        .expect("failed to execute aibox apply");
+    assert!(
+        output.status.success(),
+        "embedded catalog apply should succeed\nstderr:\n{}\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let dockerfile = std::fs::read_to_string(dir.path().join(".devcontainer/Dockerfile")).unwrap();
+    assert!(dockerfile.contains("Addon: supply-chain"));
+    assert!(!dockerfile.contains("unknown addon 'supply-chain'"));
+    assert!(dockerfile.contains("syft_1.50.0_linux_${ARCH}.tar.gz"));
+    assert!(dockerfile.contains("grype_0.116.1_linux_${ARCH}.tar.gz"));
+}
+
+#[test]
 fn nested_go_groups_expand_render_and_honor_tool_disablement() {
     let dir = tempfile::tempdir().unwrap();
     let installed_addons = install_script_addons_dir();

--- a/context/logs/2026/08/LOG-20260815_1553-CordialSail-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260815_1553-CordialSail-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1553-CordialSail-workitem-created
+  created: '2026-08-15T15:53:43+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-15T15:53:43+00:00'
+  summary: 'Created WorkItem ''BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli'':
+    ''Embed canonical addon catalog in CLI'''
+  subject: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+  subject_kind: WorkItem
+  actor: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+---

--- a/context/logs/2026/08/LOG-20260815_1553-IdealEagle-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260815_1553-IdealEagle-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1553-IdealEagle-workitem-transitioned
+  created: '2026-08-15T15:53:47+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-15T15:53:47+00:00'
+  summary: Transitioned WorkItem 'BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli'
+    from 'backlog' to 'in-progress'
+  subject: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+  subject_kind: WorkItem
+  actor: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+---

--- a/context/logs/2026/08/LOG-20260815_1601-RapidHill-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260815_1601-RapidHill-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1601-RapidHill-workitem-transitioned
+  created: '2026-08-15T16:01:59+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-15T16:01:59+00:00'
+  summary: Transitioned WorkItem 'BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli'
+    from 'in-progress' to 'review'
+  subject: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+  subject_kind: WorkItem
+  actor: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+---

--- a/context/logs/2026/08/LOG-20260815_1602-ResoluteRobin-workitem-transitioned.md
+++ b/context/logs/2026/08/LOG-20260815_1602-ResoluteRobin-workitem-transitioned.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1602-ResoluteRobin-workitem-transitioned
+  created: '2026-08-15T16:02:03+00:00'
+spec:
+  event_type: workitem.transitioned
+  timestamp: '2026-08-15T16:02:03+00:00'
+  summary: Transitioned WorkItem 'BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli'
+    from 'review' to 'done'
+  subject: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+  subject_kind: WorkItem
+  actor: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+---

--- a/context/logs/2026/08/LOG-20260815_1602-TenderFjord-workitem-archive-moved.md
+++ b/context/logs/2026/08/LOG-20260815_1602-TenderFjord-workitem-archive-moved.md
@@ -1,0 +1,17 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1602-TenderFjord-workitem-archive-moved
+  created: '2026-08-15T16:02:03+00:00'
+spec:
+  event_type: workitem.archive-moved
+  timestamp: '2026-08-15T16:02:03+00:00'
+  summary: Archived terminal WorkItem 'BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli'
+    to /workspace/context/workitems/done/2026/08/BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli.md
+  subject: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+  subject_kind: WorkItem
+  actor: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+  details:
+    path: /workspace/context/workitems/done/2026/08/BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli.md
+---

--- a/context/workitems/done/2026/08/BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli.md
+++ b/context/workitems/done/2026/08/BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli.md
@@ -1,0 +1,33 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260815_1553-PluckyFinch-embed-canonical-addon-catalog-in-cli
+  created: '2026-08-15T15:53:43+00:00'
+  updated: '2026-08-15T16:02:03+00:00'
+spec:
+  title: Embed canonical addon catalog in CLI
+  state: done
+  type: bug
+  priority: high
+  description: 'Make the shipped v0.x CLI self-contained for addon discovery: load
+    every canonical addon definition embedded in the binary, preserve supported filesystem
+    overrides, cover stale/incomplete installed catalogs (including supply-chain),
+    and publish the fix in v0.32.5.'
+  started_at: '2026-08-15T15:53:47+00:00'
+  completed_at: '2026-08-15T16:02:03+00:00'
+---
+
+## Transition note (2026-08-15T15:53:47+00:00)
+
+Implementing embedded canonical addon catalog and release coverage.
+
+
+## Transition note (2026-08-15T16:01:59+00:00)
+
+Embedded catalog implementation and stale-catalog regression verified; full suite contention failures passed sequential reruns; clippy, audit, and aarch64 release build pass.
+
+
+## Transition note (2026-08-15T16:02:03+00:00)
+
+Accepted for v0.32.5 integration.


### PR DESCRIPTION
## What changed

- embed every canonical addon YAML in the aibox executable at build time
- merge optional installed catalog files as name-based overrides
- retain source-checkout and explicit addon-directory workflows
- add regression coverage for stale catalogs omitting supply-chain

## Why

Packaged binaries could load an incomplete host-side addon catalog, causing valid configured addons such as supply-chain to be skipped during Dockerfile generation. The binary is now self-contained, while custom definitions remain supported.

## Validation

- cargo fmt -- --check
- cargo test (all non-contention tests passed; four parallel tmux timeouts passed individually)
- cargo clippy --all-targets -- -D warnings
- cargo audit
- cargo build --release --target aarch64-unknown-linux-gnu