### PR TITLE
docs: prepare v0.32.5 release metadata

### DIFF
--- a/cli/src/compat.rs
+++ b/cli/src/compat.rs
@@ -708,6 +708,11 @@ pub static COMPAT_TABLE: &[CompatEntry] = &[
         processkit_version: "v0.28.6",
         note: "Patch release: keeps latest image resolution on the active v0 line, refreshes generated addon comments when the catalog changes, and fixes stale or collapsed Yazi Markdown previews.",
     },
+    CompatEntry {
+        aibox_version: "0.32.5",
+        processkit_version: "v0.28.6",
+        note: "Patch release: embeds the canonical addon catalog so stale host installs cannot hide shipped tools, refreshes same-version installs, and adds Yazi/Vim clipboard and selectable-preview workflows.",
+    },
 ];
 
 /// Find the minimum compatible processkit version for the given aibox version.

--- a/dist/RELEASE-NOTES.md
+++ b/dist/RELEASE-NOTES.md
@@ -1,12 +1,25 @@
-# aibox v0.32.4
+# aibox v0.32.5 — 2026-08-15
 
-## Changes since v0.32.3
+**Summary:** This patch makes addon discovery reliable for derived projects and improves text-copy workflows in Yazi and Vim. Users upgrading from an older or partially refreshed catalog no longer need to repair addon YAML files manually.
 
-- 46d326c2 Merge pull request #398 from projectious-work/chore/release-v0.32.4
-- d5c74c72 chore: bump CLI version to 0.32.4
-- a6a50eaa Merge pull request #397 from projectious-work/fix/yazi-hugo-frontmatter-preview
-- a6a5ca04 fix: preserve Hugo front matter in previews
-- 276c81b3 Merge pull request #396 from projectious-work/fix/yazi-markdown-preview-cache
-- aa6060d1 fix: refresh yazi markdown previews
-- 6f7178a1 Merge pull request #395 from projectious-work/fix/v0-latest-addon-catalog-refresh
-- 90b08668 fix: keep latest image within release line
+## Added
+
+- Added `c c` in Yazi to copy the hovered file's contents to the tmux/host clipboard.
+- Added `w v` in Yazi to open a selectable, read-only Vim view of the hovered file.
+
+## Changed
+
+- The CLI now embeds the complete canonical addon catalog and treats installed catalog files as optional name-based overrides.
+- Reinstalling the same aibox version refreshes both the executable and addon catalog instead of exiting early.
+- The Yazi cheatsheet documents horizontal preview scrolling and selectable preview alternatives.
+
+## Fixed
+
+- Fixed valid configured addons such as `supply-chain`, `browser-testing`, `go-quality`, and `release` being skipped when a host had a stale or incomplete addon catalog.
+- Fixed Vim visual yanks so the selected text is forwarded to the tmux/host clipboard.
+
+## Upgrade notes
+
+Upgrade the host CLI to v0.32.5 and run `aibox apply`. No manual addon-catalog repair is required.
+
+[v0.32.5]: https://github.com/projectious-work/aibox/compare/v0.32.4...v0.32.5

--- a/docs-site/content/docs/reference/compatibility.md
+++ b/docs-site/content/docs/reference/compatibility.md
@@ -12,6 +12,7 @@ below shows the minimum compatible processkit version for each aibox release.
 
 | aibox version | Min. processkit | Notes |
 |--------------|-----------------|-------|
+| 0.32.5 | v0.28.6 | embeds the canonical addon catalog so stale host installs cannot hide shipped tools, refreshes same-version installs, and adds Yazi/Vim clipboard and selectable-preview workflows |
 | 0.32.4 | v0.28.6 | keeps `latest` image resolution on the active v0 line, refreshes generated addon comments when the catalog changes, and fixes stale or collapsed Yazi Markdown previews |
 | 0.32.3 | v0.28.6 | makes the axe host fixture accessibility-clean and records structured violation diagnostics when a future browser probe fails |
 | 0.32.2 | v0.28.6 | uses an explicit Playwright BrowserContext for axe host validation and makes safe release-host caches and candidate-bound retries available by default |


### PR DESCRIPTION
Prepare the v0.32.5 compatibility entries and curated release notes before the canonical release workflow bumps and tags the CLI version.

Validation: cargo fmt -- --check; cargo test compat::tests::cargo_pkg_version_has_compat_entry; git diff --check.