### PR TITLE
chore: track post-v0.32.5 dependency updates

### DIFF
--- a/context/logs/2026/08/LOG-20260815_1605-GoldenCharm-workitem-created.md
+++ b/context/logs/2026/08/LOG-20260815_1605-GoldenCharm-workitem-created.md
@@ -1,0 +1,15 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: LogEntry
+metadata:
+  id: LOG-20260815_1605-GoldenCharm-workitem-created
+  created: '2026-08-15T16:05:04+00:00'
+spec:
+  event_type: workitem.created
+  timestamp: '2026-08-15T16:05:04+00:00'
+  summary: 'Created WorkItem ''BACK-20260815_1605-AlertArch-review-post-release-dependency-update-set'':
+    ''Review post-v0.32.5 dependency updates'''
+  subject: BACK-20260815_1605-AlertArch-review-post-release-dependency-update-set
+  subject_kind: WorkItem
+  actor: BACK-20260815_1605-AlertArch-review-post-release-dependency-update-set
+---

--- a/context/workitems/2026/08/BACK-20260815_1605-AlertArch-review-post-release-dependency-update-set.md
+++ b/context/workitems/2026/08/BACK-20260815_1605-AlertArch-review-post-release-dependency-update-set.md
@@ -1,0 +1,18 @@
+---
+apiVersion: processkit.projectious.work/v2
+kind: WorkItem
+metadata:
+  id: BACK-20260815_1605-AlertArch-review-post-release-dependency-update-set
+  created: '2026-08-15T16:05:04+00:00'
+spec:
+  title: Review post-v0.32.5 dependency updates
+  state: backlog
+  type: task
+  priority: medium
+  description: 'Review and update the routine drift reported by the v0.32.5 Phase
+    0 release-state report after the focused patch ships: Yazi 26.8.15, uv image 0.12.5,
+    Hugo 0.165.0, Zensical 0.0.54, Go 1.26.6, PDM 2.28.1, Ansible 14.3.1, Helm 4.2.4,
+    Tau 0.3.10, and the nine Cargo.lock-compatible crate updates. Review upstream
+    changes, update pins deliberately, rebuild affected images, and rerun release-grade
+    validation.'
+---


### PR DESCRIPTION
Records the routine upstream dependency and tool-pin updates found by the v0.32.5 Phase 0 release-state review. This keeps the current patch focused while preserving a concrete follow-up for deliberate upgrades and image validation.